### PR TITLE
Fixed problem with authorization

### DIFF
--- a/src/main/java/me/philippheuer/twitch4j/enums/TwitchScopes.java
+++ b/src/main/java/me/philippheuer/twitch4j/enums/TwitchScopes.java
@@ -102,6 +102,9 @@ public enum TwitchScopes {
 		for (TwitchScopes scope : scopes) {
 			sb.append(scope.getKey()).append("+");
 		}
+		if (sb.length() > 0 && sb.charAt(sb.length() - 1) == '+') {
+			sb.setLength(sb.length() - 1);
+		}
 		return sb.toString();
 	}
 


### PR DESCRIPTION
I fixed a bug with authorization. It was an issue with one extra "+" char at the end of the "scope" line. 
For example `https://localhost:7090/...&scope=chat_login+"`
After my change it will be: `https://localhost:7090/...&scope=chat_login"`

...
