### PR TITLE
Remove HTML 5 Javadoc generation

### DIFF
--- a/deployment.gradle
+++ b/deployment.gradle
@@ -24,7 +24,6 @@ javadoc {
         windowTitle = "${project.artifactName} (v${project.version})"
         encoding = "UTF-8"
     }
-	options.addBooleanOption('html5', true)
 }
 
 /**


### PR DESCRIPTION
Builds will fail since HTML 5 use is not supported in jdk8
