### PR TITLE
Add feature from issue #66 - Add users endpoint to TwitchKraken

### DIFF
--- a/docs/content/rest-kraken/_index.md
+++ b/docs/content/rest-kraken/_index.md
@@ -58,6 +58,7 @@ Channel
 - [Channel - Get Subscriptions](./channel-get-subscribers)
 
 Users:
+- [User -> Get](./user-get)
 - [User -> Add Follow](./user-add-follow)
 
 Ingests:

--- a/docs/content/rest-kraken/user-get.md
+++ b/docs/content/rest-kraken/user-get.md
@@ -1,0 +1,44 @@
++++
+title="Users - Get"
+weight = 49
++++
+
+#  Get Users
+
+## Description
+
+Gets a list of specified user objects.
+
+*This is a legacy method which is still included, because helix does not provide the user creation date yet.*
+
+## Method Definition
+
+```java
+@RequestLine("GET /users?login={logins}")
+@Headers({
+	"Accept: application/vnd.twitchtv.v5+json"
+})
+HystrixCommand<KrakenUserList> getUsersByLogin(
+	@Param("logins") List<String> logins	
+);
+```
+
+*Required Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| logins | text | User login name (lower case channelname/username). Multiple login names can be specified. Limit: 100. |
+
+None
+
+*Optional Parameters*
+
+None
+
+## Code-Snippets
+
+### get information about a single user
+
+```java
+KrakenUserList resultList = getTwitchKrakenClient().getUsersByLogin(Arrays.asList("twitch4j")).execute();
+```

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -1,9 +1,13 @@
 package com.github.twitch4j.kraken;
 
+import java.util.List;
+
 import com.github.twitch4j.kraken.domain.KrakenIngestList;
 import com.github.twitch4j.kraken.domain.KrakenSubscriptionList;
 import com.github.twitch4j.kraken.domain.KrakenTeam;
 import com.github.twitch4j.kraken.domain.KrakenTeamList;
+import com.github.twitch4j.kraken.domain.KrakenUser;
+import com.github.twitch4j.kraken.domain.KrakenUserList;
 import com.netflix.hystrix.HystrixCommand;
 import feign.Headers;
 import feign.Param;
@@ -101,5 +105,21 @@ public interface TwitchKraken {
     @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenTeam> getTeamByName(
         @Param("name") String name
+    );
+    
+    /**
+     * Get Users
+     * <p>
+     * Gets a list of specified user objects.
+     * 
+     * @param logins User login name (lower case channelname/username). Multiple login names can be specified. Limit: 100.
+     * @return KrakenUser
+     */
+    @RequestLine("GET /users?login={logins}")
+    @Headers({
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenUserList> getUsersByLogin(
+    	@Param("logins") List<String> logins	
     );
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -122,4 +122,5 @@ public interface TwitchKraken {
     HystrixCommand<KrakenUserList> getUsersByLogin(
     	@Param("logins") List<String> logins	
     );
+
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUserList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUserList.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.kraken.domain;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class KrakenUserList {
+	/**
+	 * Data
+	 */
+	private List<KrakenUser> users;
+}

--- a/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
@@ -1,0 +1,36 @@
+package kraken.endpoints;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.github.twitch4j.kraken.domain.KrakenUser;
+import com.github.twitch4j.kraken.domain.KrakenUserList;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag("integration")
+public class UsersServiceTest extends AbstractKrakenServiceTest {
+
+    @Test
+    @DisplayName("getUsers")
+    @Disabled
+    public void getUsers() {
+    	KrakenUserList resultList = getTwitchKrakenClient().getUsersByLogin(Arrays.asList("twitch4j")).execute(); 
+        assertTrue(resultList.getUsers().size() != 1, "Number of found users was not 1!");
+        KrakenUser user = resultList.getUsers().get(0);
+        assertTrue(user.getId().equals(149223493l), "Twitch4J user id should be 149223493!");
+        assertTrue(user.getBio().equals("Twitch4J IntegrationTest User"), "Twitch4J user bio should be \"Twitch4J IntegrationTest User\"!");
+        assertEquals(user.getName(), "twitch4j", "Twitch4J user name should be twitch4j!");
+        assertEquals(user.getDisplayName(), "twitch4j", "Twitch4J user display name should be twitch4j!");
+        assertEquals(user.getType(), "user", "Twitch4J user type should be user!");
+        assertEquals(user.getCreatedAt().getTime(), 1488456578184L, "Twitch4J user creation date is invalid!");
+    }
+}

--- a/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
@@ -23,8 +23,8 @@ public class UsersServiceTest extends AbstractKrakenServiceTest {
     @DisplayName("getUsers")
     @Disabled
     public void getUsers() {
-    	KrakenUserList resultList = getTwitchKrakenClient().getUsersByLogin(Arrays.asList("twitch4j")).execute(); 
-        assertTrue(resultList.getUsers().size() != 1, "Number of found users was not 1!");
+    	KrakenUserList resultList = getTwitchKrakenClient().getUsersByLogin(Arrays.asList("twitch4j")).execute();
+        assertTrue(resultList.getUsers().size() == 1, "Number of found users was not 1!");
         KrakenUser user = resultList.getUsers().get(0);
         assertTrue(user.getId().equals(149223493l), "Twitch4J user id should be 149223493!");
         assertTrue(user.getBio().equals("Twitch4J IntegrationTest User"), "Twitch4J user bio should be \"Twitch4J IntegrationTest User\"!");


### PR DESCRIPTION
Added "getUsersByLogin" to TwitchKraken, since the the Helix Users endpoint does not support retrieving the "createdAt" property of a user yet.

<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [X] This pull request follows the code style of the project
* [X] I have tested this feature

...
### Issues Fixed 
* [Issue #66 ]

...

### Changes Proposed

* Added getUsersByLogin method to TwitchKraken. This method retrieves User-objects through the Kraken endpoint. This is in order to support retrieving the CreatedAt property of a user, which is not supported by Helix yet. This property is useful for keeping an eye on potential spam accounts.
* Added UserServiceTest integration-test for the above method.
* Added KrakenUserList object, for encapsulating the resulting list from the endpoint.

...

### Additional Information 
<!-- Any other information that may be able to help me with the problem. Remove them it is not necercarly. -->
