### PR TITLE
Add feature from issue #66 - Add auth-endpoints to TwitchHelix to all…

### DIFF
--- a/docs/content/rest-helix/clips-get.md
+++ b/docs/content/rest-helix/clips-get.md
@@ -15,7 +15,9 @@ The response has a JSON payload with a `data` field containing an array of clip 
 
 ```java
 @RequestLine("GET /clips?broadcaster_id={broadcaster_id}&game_id={game_id}&id={id}&after={after}&before={before}&first={first}&started_at={started_at}&ended_at={ended_at}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<ClipList> getClips(
+    @Param("token") String authToken,
 	@Param("broadcaster_id") Long broadcasterId,
 	@Param("game_id") String gameId,
 	@Param("id") String id,
@@ -39,6 +41,7 @@ HystrixCommand<ClipList> getClips(
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries specifying broadcaster_id or game_id. The cursor value specified here is from the pagination response field of a prior query. |
 | before  | string | Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries specifying broadcaster_id or game_id. The cursor value specified here is from the pagination response field of a prior query. |
 | first | string | Ending date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.) If this is specified, started_at also must be specified; otherwise, the time period is ignored. |

--- a/docs/content/rest-helix/games-get.md
+++ b/docs/content/rest-helix/games-get.md
@@ -15,7 +15,9 @@ The response has a JSON payload with a data field containing an array of games e
 
 ```java
 @RequestLine("GET /games?id={id}&name={name}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<GameList> getGames(
+    @Param("token") String authToken,
 	@Param("id") List<Long> id,
 	@Param("name") List<String> name
 );
@@ -30,7 +32,9 @@ HystrixCommand<GameList> getGames(
 
 *Optional Parameters*
 
-None
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 
 ## Code-Snippets
 

--- a/docs/content/rest-helix/games-top.md
+++ b/docs/content/rest-helix/games-top.md
@@ -14,7 +14,9 @@ The response has a JSON payload with a data field containing an array of games i
 
 ```java
 @RequestLine("GET /games/top?after={after}&before={before}&first={first}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<GameTopList> getTopGames(
+    @Param("token") String authToken,
 	@Param("after") String after,
 	@Param("before") String before,
 	@Param("first") String first
@@ -29,6 +31,7 @@ None
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | before | string | Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | first | string | Maximum number of objects to return. Maximum: 100. Default: 20. |

--- a/docs/content/rest-helix/streams-get.md
+++ b/docs/content/rest-helix/streams-get.md
@@ -15,7 +15,9 @@ The response has a JSON payload with a data field containing an array of stream 
 
 ```java
 @RequestLine("GET /streams?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<StreamList> getStreams(
+    @Param("token") String authToken,
 	@Param("after") String after,
 	@Param("before") String before,
 	@Param("first") Integer limit,
@@ -35,6 +37,7 @@ None
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | before | string | Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | limit | string | Maximum number of objects to return. Maximum: 100. Default: 20. |

--- a/docs/content/rest-helix/streams-getMetadata.md
+++ b/docs/content/rest-helix/streams-getMetadata.md
@@ -15,7 +15,9 @@ The response has a JSON payload with a data field containing an array of stream 
 
 ```java
 @RequestLine("GET /streams/metadata?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<StreamMetadataList> getStreamsMetadata(
+    @Param("token") String authToken,
 	@Param("after") String after,
 	@Param("before") String before,
 	@Param("first") Integer limit,
@@ -35,6 +37,7 @@ None
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | before | string | Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | limit | string | Maximum number of objects to return. Maximum: 100. Default: 20. |

--- a/docs/content/rest-helix/users-followers.md
+++ b/docs/content/rest-helix/users-followers.md
@@ -15,7 +15,9 @@ The response has a JSON payload with a data field containing an array of follow 
 
 ```java
 @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<FollowList> getFollowers(
+    @Param("token") String authToken,
 	@Param("from_id") String fromId,
 	@Param("to_id") String toId,
 	@Param("after") String after,
@@ -31,6 +33,7 @@ None
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | first | string | Maximum number of objects to return. Maximum: 100. Default: 20. |
 | from_id | string | User ID. The request returns information about users who are being followed by the from_id user. |

--- a/docs/content/rest-helix/videos-get.md
+++ b/docs/content/rest-helix/videos-get.md
@@ -15,7 +15,9 @@ The response has a JSON payload with a data field containing an array of video e
 
 ```java
 @RequestLine("GET /videos?id={id}&user_id={user_id}&game_id={game_id}&language={language}&period={period}&sort={sort}&type={type}&after={after}&before={before}&first={first}")
+@Headers("Authorization: Bearer {token}")
 HystrixCommand<VideoList> getVideos(
+    @Param("token") String authToken,
 	@Param("id") String id,
 	@Param("user_id") Long userId,
 	@Param("game_id") Long gameId,
@@ -41,6 +43,7 @@ HystrixCommand<VideoList> getVideos(
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
+| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | before | string | Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | limit | string | Maximum number of objects to return. Maximum: 100. Default: 20. |

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -117,6 +117,7 @@ public interface TwitchHelix {
      * @return ClipList Clip List
      */
     @RequestLine("GET /clips?broadcaster_id={broadcaster_id}&game_id={game_id}&id={id}&after={after}&before={before}&first={first}&started_at={started_at}&ended_at={ended_at}")
+    @Deprecated
     HystrixCommand<ClipList> getClips(
         @Param("broadcaster_id") String broadcasterId,
         @Param("game_id") String gameId,
@@ -145,7 +146,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /clips?broadcaster_id={broadcaster_id}&game_id={game_id}&id={id}&after={after}&before={before}&first={first}&started_at={started_at}&ended_at={ended_at}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<ClipList> getClipsUsingAuth(
+    HystrixCommand<ClipList> getClips(
         @Param("token") String authToken,
         @Param("broadcaster_id") String broadcasterId,
         @Param("game_id") String gameId,
@@ -169,6 +170,7 @@ public interface TwitchHelix {
      * @return GameList
      */
     @RequestLine("GET /games?id={id}&name={name}")
+    @Deprecated
     HystrixCommand<GameList> getGames(
         @Param("id") List<String> id,
         @Param("name") List<String> name
@@ -185,7 +187,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /games?id={id}&name={name}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<GameList> getGamesUsingAuth(
+    HystrixCommand<GameList> getGames(
         @Param("token") String authToken,
         @Param("id") List<String> id,
         @Param("name") List<String> name
@@ -200,6 +202,7 @@ public interface TwitchHelix {
      * @return GameList
      */
     @RequestLine("GET /games/top?after={after}&before={before}&first={first}")
+    @Deprecated
     HystrixCommand<GameTopList> getTopGames(
         @Param("after") String after,
         @Param("before") String before,
@@ -218,7 +221,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /games/top?after={after}&before={before}&first={first}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<GameTopList> getTopGamesUsingAuth(
+    HystrixCommand<GameTopList> getTopGames(
         @Param("token") String authToken,
         @Param("after") String after,
         @Param("before") String before,
@@ -239,6 +242,7 @@ public interface TwitchHelix {
      * @return StreamList
      */
     @RequestLine("GET /streams?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+    @Deprecated
     HystrixCommand<StreamList> getStreams(
         @Param("after") String after,
         @Param("before") String before,
@@ -267,7 +271,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /streams?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<StreamList> getStreamsUsingAuth(
+    HystrixCommand<StreamList> getStreams(
         @Param("token") String authToken,
         @Param("after") String after,
         @Param("before") String before,
@@ -293,6 +297,7 @@ public interface TwitchHelix {
      * @return StreamMetadataList
      */
     @RequestLine("GET /streams/metadata?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+    @Deprecated
     HystrixCommand<StreamMetadataList> getStreamsMetadata(
         @Param("after") String after,
         @Param("before") String before,
@@ -321,7 +326,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /streams/metadata?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<StreamMetadataList> getStreamsMetadataUsingAuth(
+    HystrixCommand<StreamMetadataList> getStreamsMetadata(
         @Param("token") String authToken,
         @Param("after") String after,
         @Param("before") String before,
@@ -425,6 +430,7 @@ public interface TwitchHelix {
      * @return FollowList
      */
     @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")
+    @Deprecated
     HystrixCommand<FollowList> getFollowers(
         @Param("from_id") Long fromId,
         @Param("to_id") Long toId,
@@ -447,7 +453,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<FollowList> getFollowersUsingAuth(
+    HystrixCommand<FollowList> getFollowers(
         @Param("token") String authToken,
         @Param("from_id") Long fromId,
         @Param("to_id") Long toId,
@@ -527,6 +533,7 @@ public interface TwitchHelix {
      * @return VideoList
      */
     @RequestLine("GET /videos?id={id}&user_id={user_id}&game_id={game_id}&language={language}&period={period}&sort={sort}&type={type}&after={after}&before={before}&first={first}")
+    @Deprecated
     HystrixCommand<VideoList> getVideos(
         @Param("id") String id,
         @Param("user_id") Long userId,
@@ -562,7 +569,7 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /videos?id={id}&user_id={user_id}&game_id={game_id}&language={language}&period={period}&sort={sort}&type={type}&after={after}&before={before}&first={first}")
     @Headers("Authorization: Bearer {token}")
-    HystrixCommand<VideoList> getVideosUsingAuth(
+    HystrixCommand<VideoList> getVideos(
         @Param("token") String authToken,
         @Param("id") String id,
         @Param("user_id") Long userId,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -129,6 +129,35 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets clip information by clip ID (one or more), broadcaster ID (one only), or game ID (one only). 
+     * Using user-token or app-token to increase rate limits.
+     *
+     * @param authToken User or App auth Token, for increased rate-limits  
+     * @param broadcasterId ID of the broadcaster for whom clips are returned. The number of clips returned is determined by the first query-string parameter (default: 20). Results are ordered by view count.
+     * @param gameId        ID of the game for which clips are returned. The number of clips returned is determined by the first query-string parameter (default: 20). Results are ordered by view count.
+     * @param id            ID of the clip being queried. Limit: 100.
+     * @param after         Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
+     * @param before        Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
+     * @param limit         Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @param startedAt     Starting date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.)
+     * @param endedAt       Ending date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.)
+     * @return ClipList Clip List
+     */
+    @RequestLine("GET /clips?broadcaster_id={broadcaster_id}&game_id={game_id}&id={id}&after={after}&before={before}&first={first}&started_at={started_at}&ended_at={ended_at}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ClipList> getClipsUsingAuth(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("game_id") String gameId,
+        @Param("id") String id,
+        @Param("after") String after,
+        @Param("before") String before,
+        @Param("first") Integer limit,
+        @Param("started_at") Date startedAt,
+        @Param("ended_at") Date endedAt
+    );
+
+    /**
      * TODO: Create Entitlement Grants Upload URL
      */
 
@@ -146,6 +175,23 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets game information by game ID or name. 
+     * Using user-token or app-token to increase rate limits.
+     *
+     * @param authToken User or App auth Token, for increased rate-limits
+     * @param id Game ID. At most 100 id values can be specified.
+     * @param name Game name. The name must be an exact match. For instance, â€œPokemonâ€� will not return a list of Pokemon games; instead, query the specific Pokemon game(s) in which you are interested. At most 100 name values can be specified.
+     * @return GameList
+     */
+    @RequestLine("GET /games?id={id}&name={name}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<GameList> getGamesUsingAuth(
+        @Param("token") String authToken,
+        @Param("id") List<String> id,
+        @Param("name") List<String> name
+    );
+
+    /**
      * Gets games sorted by number of current viewers on Twitch, most popular first.
      *
      * @param after Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
@@ -155,6 +201,25 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /games/top?after={after}&before={before}&first={first}")
     HystrixCommand<GameTopList> getTopGames(
+        @Param("after") String after,
+        @Param("before") String before,
+        @Param("first") String first
+    );
+
+    /**
+     * Gets games sorted by number of current viewers on Twitch, most popular first. 
+     * Using user-token or app-token to increase rate limits.
+     *
+     * @param authToken User or App auth Token, for increased rate-limits
+     * @param after Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param before Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param first Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @return GameList
+     */
+    @RequestLine("GET /games/top?after={after}&before={before}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<GameTopList> getTopGamesUsingAuth(
+        @Param("token") String authToken,
         @Param("after") String after,
         @Param("before") String before,
         @Param("first") String first
@@ -186,6 +251,35 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets information about active streams. Streams are returned sorted by number of current viewers, in descending order. Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams. 
+     * Using user-token or app-token to increase rate limits.
+     *
+     * @param authToken User or App auth Token, for increased rate-limits
+     * @param after       Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param before      Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit       Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @param communityId Returns streams in a specified community ID. You can specify up to 100 IDs.
+     * @param gameIds     Returns streams broadcasting a specified game ID. You can specify up to 100 IDs.
+     * @param language    Stream language. You can specify up to 100 languages.
+     * @param userIds     Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
+     * @param userLogins  Returns streams broadcast by one or more specified user login names. You can specify up to 100 names.
+     * @return StreamList
+     */
+    @RequestLine("GET /streams?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<StreamList> getStreamsUsingAuth(
+        @Param("token") String authToken,
+        @Param("after") String after,
+        @Param("before") String before,
+        @Param("first") Integer limit,
+        @Param("community_id") List<UUID> communityId,
+        @Param("game_id") List<String> gameIds,
+        @Param("language") String language,
+        @Param("user_id") List<Long> userIds,
+        @Param("user_login") List<String> userLogins
+    );
+
+    /**
      * Gets metadata information about active streams playing Overwatch or Hearthstone. Streams are sorted by number of current viewers, in descending order. Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams.
      *
      * @param after       Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
@@ -200,6 +294,35 @@ public interface TwitchHelix {
      */
     @RequestLine("GET /streams/metadata?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
     HystrixCommand<StreamMetadataList> getStreamsMetadata(
+        @Param("after") String after,
+        @Param("before") String before,
+        @Param("first") Integer limit,
+        @Param("community_id") List<UUID> communityId,
+        @Param("game_id") List<String> gameIds,
+        @Param("language") String language,
+        @Param("user_id") List<Long> userIds,
+        @Param("user_login") List<String> userLogins
+    );
+
+    /**
+     * Gets metadata information about active streams playing Overwatch or Hearthstone. Streams are sorted by number of current viewers, in descending order. Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams. 
+     * Using user-token or app-token to increase rate limits.
+     *
+     * @param authToken   User or App auth Token, for increased rate-limits
+     * @param after       Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param before      Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit       Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @param communityId Returns streams in a specified community ID. You can specify up to 100 IDs.
+     * @param gameIds     Returns streams broadcasting a specified game ID. You can specify up to 100 IDs.
+     * @param language    Stream language. You can specify up to 100 languages.
+     * @param userIds     Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
+     * @param userLogins  Returns streams broadcast by one or more specified user login names. You can specify up to 100 names.
+     * @return StreamMetadataList
+     */
+    @RequestLine("GET /streams/metadata?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<StreamMetadataList> getStreamsMetadataUsingAuth(
+        @Param("token") String authToken,
         @Param("after") String after,
         @Param("before") String before,
         @Param("first") Integer limit,
@@ -310,6 +433,29 @@ public interface TwitchHelix {
     );
 
     /**
+     * Get Followers
+     * <p>
+     * Gets information on follow relationships between two Twitch users. Information returned is sorted in order, most recent follow first. This can return information like “who is lirik following,” “who is following lirik,” or “is user X following user Y.”
+     * Using user-token or app-token to increase rate limits.
+     *
+     * @param authToken User or App auth Token, for increased rate-limits
+     * @param fromId User ID. The request returns information about users who are being followed by the from_id user.
+     * @param toId   User ID. The request returns information about users who are following the to_id user.
+     * @param after  Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
+     * @param limit  Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @return FollowList
+     */
+    @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<FollowList> getFollowersUsingAuth(
+        @Param("token") String authToken,
+        @Param("from_id") Long fromId,
+        @Param("to_id") Long toId,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    );
+
+    /**
      * Update User
      * <p>
      * Updates the description of a user specified by a Bearer token.
@@ -394,6 +540,43 @@ public interface TwitchHelix {
         @Param("first") Integer limit
     );
 
+    /**
+     * Get Videos
+     * <p>
+     * Gets video information by video ID (one or more), user ID (one only), or game ID (one only).
+     * The response has a JSON payload with a data field containing an array of video elements. For lookup by user or game, pagination is available, along with several filters that can be specified as query string parameters.
+     * Using user-token or app-token to increase rate limits.
+     * 
+     * @param authToken User or App auth Token, for increased rate-limits
+     * @param id       ID of the video being queried. Limit: 100. If this is specified, you cannot use any of the optional query string parameters below.
+     * @param userId   ID of the user who owns the video. Limit 1.
+     * @param gameId   ID of the game the video is of. Limit 1.
+     * @param language Language of the video being queried. Limit: 1.
+     * @param period   Period during which the video was created. Valid values: "all", "day", "week", "month". Default: "all".
+     * @param sort     Sort order of the videos. Valid values: "time", "trending", "views". Default: "time".
+     * @param type     Type of video. Valid values: "all", "upload", "archive", "highlight". Default: "all".
+     * @param after    Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
+     * @param before   Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
+     * @param limit    Number of values to be returned when getting videos by user or game ID. Limit: 100. Default: 20.
+     * @return VideoList
+     */
+    @RequestLine("GET /videos?id={id}&user_id={user_id}&game_id={game_id}&language={language}&period={period}&sort={sort}&type={type}&after={after}&before={before}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<VideoList> getVideosUsingAuth(
+        @Param("token") String authToken,
+        @Param("id") String id,
+        @Param("user_id") Long userId,
+        @Param("game_id") Long gameId,
+        @Param("language") String language,
+        @Param("period") String period,
+        @Param("sort") String sort,
+        @Param("type") String type,
+        @Param("after") String after,
+        @Param("before") String before,
+        @Param("first") Integer limit
+    );
+
+    
     /**
      * TODO: Get Webhook Subscriptions
      */

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/ClipsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/ClipsServiceTest.java
@@ -37,7 +37,7 @@ public class ClipsServiceTest extends AbtractEndpointTest {
     @DisplayName("Get Clips")
     public void getClips() {
         // TestCase
-        ClipList clipList = testUtils.getTwitchHelixClient().getClips(null, "488552", null, null, null, null, null, null).execute();
+        ClipList clipList = testUtils.getTwitchHelixClient().getClips(null, null, "488552", null, null, null, null, null, null).execute();
 
         // Validate
         clipList.getData().forEach(clip -> {

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/GamesServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/GamesServiceTest.java
@@ -23,7 +23,7 @@ public class GamesServiceTest extends AbtractEndpointTest {
     @DisplayName("Get Games")
     public void getGames() {
         // TestCase
-        GameList resultList = testUtils.getTwitchHelixClient().getGames(Arrays.asList(overwatchGameId), null).execute();
+        GameList resultList = testUtils.getTwitchHelixClient().getGames(null, Arrays.asList(overwatchGameId), null).execute();
 
         // Test
         assertTrue(resultList.getGames().size() > 0, "Should at least find one result from the streams method!");
@@ -37,7 +37,7 @@ public class GamesServiceTest extends AbtractEndpointTest {
     @DisplayName("Get Top Games")
     public void getTopGames() {
         // TestCase
-        GameTopList resultList = testUtils.getTwitchHelixClient().getTopGames(null, null, null).execute();
+        GameTopList resultList = testUtils.getTwitchHelixClient().getTopGames(null, null, null, null).execute();
 
         // Test
         assertTrue(resultList.getGames().size() > 0, "Should at least find one result from the getTopGames method!");

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
@@ -32,7 +32,7 @@ public class StreamsServiceTest extends AbtractEndpointTest {
     @DisplayName("Fetch information about current live streams")
     public void getStreams() {
         // TestCase
-        StreamList resultList = testUtils.getTwitchHelixClient().getStreams("", "", 5, null, null, null, null, null).execute();
+        StreamList resultList = testUtils.getTwitchHelixClient().getStreams(null, "", "", 5, null, null, null, null, null).execute();
 
         // Test
         assertTrue(resultList.getStreams().size() > 0, "Should at least find one result from the streams method!");
@@ -50,7 +50,7 @@ public class StreamsServiceTest extends AbtractEndpointTest {
     @DisplayName("Fetch meta-information (hearthstone) about live streams")
     public void getStreamMetadataForHearthstone() {
         // TestCase
-        StreamMetadataList resultList = testUtils.getTwitchHelixClient().getStreamsMetadata("", "", 5, null, Arrays.asList(hearthstoneGameId), null, null, null).execute();
+        StreamMetadataList resultList = testUtils.getTwitchHelixClient().getStreamsMetadata(null, "", "", 5, null, Arrays.asList(hearthstoneGameId), null, null, null).execute();
 
         // Test
         assertTrue(resultList.getStreams().size() > 0, "Should at least find one result from the streams metadata method!");
@@ -70,7 +70,7 @@ public class StreamsServiceTest extends AbtractEndpointTest {
     @DisplayName("Fetch meta-information (overwatch) about live streams")
     public void getStreamMetadataForOverwatch() {
         // TestCase
-        StreamMetadataList resultList = testUtils.getTwitchHelixClient().getStreamsMetadata("", "", 5, null, Arrays.asList(overwatchGameId), null, null, null).execute();
+        StreamMetadataList resultList = testUtils.getTwitchHelixClient().getStreamsMetadata(null, "", "", 5, null, Arrays.asList(overwatchGameId), null, null, null).execute();
 
         // Test
         assertTrue(resultList.getStreams().size() > 0, "Should at least find one result from the streams metadata method!");

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
@@ -23,7 +23,7 @@ public class VideoServiceTest extends AbtractEndpointTest {
     @DisplayName("Fetch videos")
     public void getVideos() {
         // TestCase
-        VideoList resultList = testUtils.getTwitchHelixClient().getVideos(null, null, overwatchGameId, null, null, null, null, null, null, 100).execute();
+        VideoList resultList = testUtils.getTwitchHelixClient().getVideos(null, null, null, overwatchGameId, null, null, null, null, null, null, 100).execute();
 
         // Test
         assertTrue(resultList.getVideos().size() > 0, "Should at least find one result from the videos method!");


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [X] This pull request follows the code style of the project
* [X] I have tested this feature

...
### Issues Fixed 
* [Issue #67 ]

...

### Changes Proposed

* Expand current unauthenticated Helix methods, in order to give the caller the option of providing a bearer token (user- or app-token). This allows for a more lenient rate limit.
* Added the following new methods with UsingAuth postfix, rather than altering the existing methods. This is to preserve backwards compatibility with existing callers:
* getClipsUsingAuth
* getGamesUsingAuth
* getStreamsUsingAuth
* getStreamsMetadataUsingAuth
* getFollowersUsingAuth
* getVideosUsingAuth
* I have not altered the existing automated test, since auth-tokens expire.
* I have tested each of the above methods in a separate application, using a valid app-token to call the above methods through the expanded api.
...

### Additional Information 
<!-- Any other information that may be able to help me with the problem. Remove them it is not necercarly. -->
API limits as described here:
https://dev.twitch.tv/docs/api/guide/#rate-limits