### PR TITLE
Implement raid events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -52,6 +52,7 @@ public class IRCEventHandler {
         eventManager.onEvent(IRCMessageEvent.class).subscribe(event -> onHostOnEvent(event));
         eventManager.onEvent(IRCMessageEvent.class).subscribe(event -> onHostOffEvent(event));
         eventManager.onEvent(IRCMessageEvent.class).subscribe(event -> onChannelState(event));
+        eventManager.onEvent(IRCMessageEvent.class).subscribe(event -> onRaid(event));
 	}
 
 	/**
@@ -164,6 +165,25 @@ public class IRCEventHandler {
 			}
 		}
 	}
+        
+        /**
+         * ChatChannel Raid Event (receiving)
+         * @param event IRCMessageEvent
+         */
+        public void onRaid(IRCMessageEvent event) {
+                if (event.getCommandType().equals("USERNOTICE") && event.getTags().containsKey("msg-id") && event.getTags().get("msg-id").equalsIgnoreCase("raid")) {
+                        EventChannel channel = event.getChannel();
+                        EventUser raider = event.getUser();
+                        Integer viewers;
+                        try {
+                                viewers = Integer.parseInt(event.getTags().get("msg-param-viewerCount"));
+                        }
+                        catch(NumberFormatException ex) {
+                                viewers = 0;
+                        }
+                        eventManager.dispatchEvent(new RaidEvent(channel, raider, viewers));
+                }
+        }
 
 	/**
 	 * ChatChannel clearing chat, timeouting or banning user Event

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/RaidEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/RaidEvent.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.events.domain.EventUser;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Value;
+
+/**
+ * This event gets called when a user receives a raid.
+ * <p>
+ * This event is <i>not</i> called when a user receives a host that is not part of a raid.
+ */
+@Value
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class RaidEvent extends AbstractChannelEvent {
+    
+        /**
+	 * Event User who initiated the raid
+	 */
+	private EventUser raider;
+        
+        /**
+         * Number of viewers in the raid
+         */
+        private Integer viewers;
+
+        /**
+         * 
+         * @param channel ChatChannel receiving the raid
+         * @param raider User who is sending the raid
+         * @param viewers number of viewers from the raid
+         */
+        public RaidEvent(EventChannel channel, EventUser raider, Integer viewers) {
+            super(channel);
+            this.raider = raider;
+            this.viewers = viewers;
+        }
+}


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

<!-- Uncommend and remove this message, if there is relation to any issues.
### Issues Fixed 
* [Issue #1]

 -->

### Changes Proposed

* Implement a `RaidEvent` for incoming raids that includes the numbers of viewers joining from the raid.

### Additional Information 
<!-- Any other information that may be able to help me with the problem. Remove them it is not necercarly. -->
This implementation parses the [IRC raid USERNOTICE as documented here](https://dev.twitch.tv/docs/irc/tags#usernotice-twitch-tags). Tested in my chat when receiving a raid and event was properly fired with the accurate raid-viewer count.