### PR TITLE
Number of months for resub events is inaccurate #77

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -124,15 +124,16 @@ public class IRCEventHandler {
                 EventUser user = event.getUser();
 				String subPlan = event.getTagValue("msg-param-sub-plan").get();
 				boolean isResub = event.getTags().get("msg-id").equalsIgnoreCase("resub");
-				Integer subStreak = (event.getTags().containsKey("msg-param-months")) ? Integer.parseInt(event.getTags().get("msg-param-months")) : 1;
+				Integer cumulativeMonths = (event.getTags().containsKey("msg-param-cumulative-months")) ? Integer.parseInt(event.getTags().get("msg-param-cumulative-months")) : 0;
+                                //according to the Twitch docs, msg-param-months is used only for giftsubs, which are handled below
 
 				// twitch sometimes returns 0 months for new subs
-				if(subStreak == 0) {
-					subStreak = 1;
+				if(cumulativeMonths == 0) {
+					cumulativeMonths = 1;
 				}
 
 				// Dispatch Event
-                eventManager.dispatchEvent(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, false, null));
+                eventManager.dispatchEvent(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null));
 			}
 			// Receive Gifted Sub
 			else if(event.getTags().get("msg-id").equalsIgnoreCase("subgift")) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -58,7 +58,7 @@ public class SubscriptionEvent extends AbstractChannelEvent {
      * @param user User that subscribed
      * @param subPlan Sub Plan
      * @param message Sub Message
-     * @param months Months
+     * @param months number of months user has been subscribed (cumulative, not consecutive)
      * @param gifted Is gifted?
      * @param giftedBy User that gifted the sub
      */

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -58,7 +58,7 @@ public class SubscriptionEvent extends AbstractChannelEvent {
      * @param user User that subscribed
      * @param subPlan Sub Plan
      * @param message Sub Message
-     * @param months number of months user has been subscribed (cumulative, not consecutive)
+     * @param months Number of months user has been subscribed (cumulative, not consecutive)
      * @param gifted Is gifted?
      * @param giftedBy User that gifted the sub
      */


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* [Issue #77 ]

### Additional Information 
Tested in a 71k viewer chat by printing `SubscriberEvent`'s fields to console (notably `getMonths()`) and comparing to the notification in chat.

I was unable to test if the current behavior for cumulative months of giftsubs is accurate, but since this PR only changes the code specifically in the `if` conditional for regular (non-gifted) subs, it does not introduce any bugs with giftsubs.