### PR TITLE
Implement sub streaks

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -131,9 +131,13 @@ public class IRCEventHandler {
 				if(cumulativeMonths == 0) {
 					cumulativeMonths = 1;
 				}
+                                
+                                // check user's sub streak
+                                // Twitch API specifies that 0 is returned if the user chooses not to share their streak
+                                Integer streak = event.getTags().containsKey("msg-param-streak-months") ? Integer.parseInt(event.getTags().get("msg-param-streak-months")) : 0;
 
 				// Dispatch Event
-                eventManager.dispatchEvent(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null));
+                eventManager.dispatchEvent(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak));
 			}
 			// Receive Gifted Sub
 			else if(event.getTags().get("msg-id").equalsIgnoreCase("subgift")) {
@@ -150,7 +154,7 @@ public class IRCEventHandler {
 				}
 
 				// Dispatch Event
-                eventManager.dispatchEvent(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy));
+                eventManager.dispatchEvent(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy, 0));
 			}
 			// Gift X Subs
 			else if(event.getTags().get("msg-id").equalsIgnoreCase("submysterygift")) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -37,7 +37,7 @@ public class SubscriptionEvent extends AbstractChannelEvent {
 	private Optional<String> message;
 
 	/**
-	 * X Months subscription streak
+	 * Cumulative months subscribed
 	 */
 	private Integer months;
 
@@ -50,6 +50,12 @@ public class SubscriptionEvent extends AbstractChannelEvent {
 	 * User that gifted the sub
 	 */
 	private EventUser giftedBy;
+        
+        
+        /**
+         * Consecutive months subscribed
+         */
+        private Integer subStreak;
 
     /**
      * Event Constructor
@@ -58,11 +64,12 @@ public class SubscriptionEvent extends AbstractChannelEvent {
      * @param user User that subscribed
      * @param subPlan Sub Plan
      * @param message Sub Message
-     * @param months Number of months user has been subscribed (cumulative, not consecutive)
+     * @param months Cumulative number of months user has been subscribed (not consecutive)
      * @param gifted Is gifted?
      * @param giftedBy User that gifted the sub
+     * @param subStreak Consecutive number of months user has been subscribed (not cumulative); 0 if no streak or user chooses not to share their streak
      */
-	public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy) {
+	public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak) {
 		super(channel);
 		this.user = user;
 		this.subscriptionPlan = subPlan;
@@ -70,6 +77,7 @@ public class SubscriptionEvent extends AbstractChannelEvent {
 		this.months = months;
 		this.gifted = gifted;
 		this.giftedBy = giftedBy;
+                this.subStreak = subStreak;
 	}
 
     /**


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

<!-- Uncommend and remove this message, if there is relation to any issues.
### Issues Fixed 
* [Issue #1]

...
 -->

### Changes Proposed

* Add method to query consecutive months subscribed.

### Additional Information 
The Twitch documentation is ambiguous about what value is given for 1st sub in a streak: ["[`msg-param-streak-months`] is 0 if `msg-param-should-share-streak` is 0."](https://dev.twitch.tv/docs/irc/tags/#usernotice-twitch-tags). Since only streaks >= 2 get the option in Twitch chat to "share their streak", the `USERNOTICE` should give 0 for 1st-in-streak subs. This makes sense inside the Twitch API but may confuse some users who would expect a value of 1 in this case. This PR passes the value of `msg-param-streak-months` unchanged to the `SubscriptionEvent`.