### PR TITLE
Fix NullPointerException caused by some HTTP 401 responses

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -49,7 +49,7 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
         Exception ex = null;
 
         try {
-            String responseBody = IOUtils.toString(response.body().asInputStream(), StandardCharsets.UTF_8.name());
+            String responseBody = response.body() == null ? "" : IOUtils.toString(response.body().asInputStream(), StandardCharsets.UTF_8.name());
 
             if (response.status() == 401) {
                 ex = new UnauthorizedException()

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
@@ -49,7 +49,7 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
         Exception ex = null;
 
         try {
-            String responseBody = IOUtils.toString(response.body().asInputStream(), StandardCharsets.UTF_8.name());
+            String responseBody = response.body() == null ? "" : IOUtils.toString(response.body().asInputStream(), StandardCharsets.UTF_8.name());
 
             if (response.status() == 401) {
                 ex = new UnauthorizedException()


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* [Issue #82]

### Changes Proposed

* Check for null value before querying instance method.

### Additional Information 
The bug is very weird. When I do the same thing with `curl`, I get a response body. Also a lot of helix methods are not affected by this. It seems to affect methods that require `user:edit:broadcast` scope, as I discovered it implementing Create Stream Marker and tested that it also occurs with Replace Stream Tags. It's possible the library (maybe Feign?) gets a 401 and stops parsing the body, but with other methods incorrect authentication returned a 401 and the body was parsed correctly. No idea really.