### PR TITLE
Allow queueing synchronous work - queue .execute() instead of exceptions

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/builder/TwitchAPIBuilder.java
+++ b/common/src/main/java/com/github/twitch4j/common/builder/TwitchAPIBuilder.java
@@ -1,9 +1,11 @@
 package com.github.twitch4j.common.builder;
 
 import com.github.philippheuer.events4j.EventManager;
+import com.netflix.config.ConfigurationManager;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Wither;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -31,6 +33,11 @@ public class TwitchAPIBuilder<T> {
      * User Agent
      */
     private String userAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36";
+
+    /**
+     * HTTP Request Queue Size
+     */
+    private Integer requestQueueSize = -1;
 
     /**
      * With EventManager
@@ -77,14 +84,13 @@ public class TwitchAPIBuilder<T> {
     }
 
     /**
-     * With Max Queue Size
+     * Set the size of the http request queue
      *
-     * @param maxQueueSize maxQueueSize
+     * @param requestQueueSize requestQueueSize
      * @return T
      */
-    public T withMaxQueueSize(Integer maxQueueSize) {
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", maxQueueSize);
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", maxQueueSize);
+    public T withRequestQueueSize(Integer requestQueueSize) {
+        this.requestQueueSize = requestQueueSize;
         return (T) this;
     }
 

--- a/common/src/main/java/com/github/twitch4j/common/builder/TwitchAPIBuilder.java
+++ b/common/src/main/java/com/github/twitch4j/common/builder/TwitchAPIBuilder.java
@@ -76,4 +76,16 @@ public class TwitchAPIBuilder<T> {
         return (T) this;
     }
 
+    /**
+     * With Max Queue Size
+     *
+     * @param maxQueueSize maxQueueSize
+     * @return T
+     */
+    public T withMaxQueueSize(Integer maxQueueSize) {
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", maxQueueSize);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", maxQueueSize);
+        return (T) this;
+    }
+
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -58,6 +58,8 @@ public class TwitchHelixBuilder extends TwitchAPIBuilder<TwitchHelixBuilder> {
         // Hystrix
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", timeout);
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.requestCache.enabled", false);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
         // Jackson ObjectMapper
         ObjectMapper mapper = new ObjectMapper();

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -54,6 +54,8 @@ public class TwitchKrakenBuilder extends TwitchAPIBuilder<TwitchKrakenBuilder> {
         // Hystrix
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", timeout);
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.requestCache.enabled", false);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
         // Build
         TwitchKraken client = HystrixFeign.builder()

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Wither;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,6 +32,12 @@ public class TwitchMessagingInterfaceBuilder extends TwitchAPIBuilder<TwitchMess
     private String baseUrl = "https://tmi.twitch.tv";
 
     /**
+     * Default Timeout
+     */
+    @Wither
+    private Integer timeout = 5000;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Helix Builder
@@ -46,7 +53,14 @@ public class TwitchMessagingInterfaceBuilder extends TwitchAPIBuilder<TwitchMess
      */
     public TwitchMessagingInterface build() {
         log.debug("TMI: Initializing Module ...");
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", 2500);
+
+        // Hystrix
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", timeout);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.requestCache.enabled", false);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
+
+        // Build
         TwitchMessagingInterface client = HystrixFeign.builder()
             .client(new OkHttpClient())
             .encoder(new JacksonEncoder())

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -125,7 +125,13 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
      * User Agent
      */
     @Wither
-    private String userAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36";;
+    private String userAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36";
+
+    /**
+     * Max Queue Size
+     */
+    @Wither
+    private Integer maxQueueSize = -1;
 
     /**
      * CredentialManager
@@ -179,6 +185,7 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
                 .withClientSecret(getClientSecret())
                 .withEventManager(eventManager)
                 .withUserAgent(userAgent)
+                .withMaxQueueSize(maxQueueSize)
                 .withTimeout(timeout)
                 .build();
         }
@@ -191,6 +198,7 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
                 .withClientSecret(getClientSecret())
                 .withEventManager(eventManager)
                 .withUserAgent(userAgent)
+                .withMaxQueueSize(maxQueueSize)
                 .withTimeout(timeout)
                 .build();
         }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -128,12 +128,6 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
     private String userAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36";
 
     /**
-     * Max Queue Size
-     */
-    @Wither
-    private Integer maxQueueSize = -1;
-
-    /**
      * CredentialManager
      */
     @Wither
@@ -185,7 +179,7 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
                 .withClientSecret(getClientSecret())
                 .withEventManager(eventManager)
                 .withUserAgent(userAgent)
-                .withMaxQueueSize(maxQueueSize)
+                .withRequestQueueSize(getRequestQueueSize())
                 .withTimeout(timeout)
                 .build();
         }
@@ -198,7 +192,7 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
                 .withClientSecret(getClientSecret())
                 .withEventManager(eventManager)
                 .withUserAgent(userAgent)
-                .withMaxQueueSize(maxQueueSize)
+                .withRequestQueueSize(getRequestQueueSize())
                 .withTimeout(timeout)
                 .build();
         }
@@ -211,6 +205,8 @@ public class TwitchClientBuilder extends TwitchAPIBuilder<TwitchClientBuilder> {
                 .withClientSecret(getClientSecret())
                 .withEventManager(eventManager)
                 .withUserAgent(userAgent)
+                .withRequestQueueSize(getRequestQueueSize())
+                .withTimeout(timeout)
                 .build();
         }
 


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [ ] This pull request follows the code style of the project
* [x] I have tested this feature

Not sure about the code style of the project, it works and looks similar, never did any thing builder-related. Not sure if this is the best way to let t4j know about Hystrix config that we want to use.

### Changes Proposed

* Allow users to queue requests instead of throwing exception.

### Additional Information 
Currently you are able to run 10 requests at the same time; trying to run more throws exception. This is default config of Hystrix. With the changes you are able to queue requests and execute them as soon as the threadpool is freed. You are still limited to 10 requests at the same time.

Example of usage:

`TwitchClientBuilder.builder().withEnableHelix(true).withClientId(SettingsUtil.clientID).withClientSecret(SettingsUtil.clientSecret).withMaxQueueSize(Integer.MAX_VALUE).build();`


```
myList = Collections.synchronizedList(new ArrayList<>());
ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
for (int i = 0; i < steps; i++) {
    Thread t = new Thread(() -> {
        //data = method with API request
        //myList.addAll(data); 
    });
    executorService.submit(t);
}
```
followed by 

```executorService.shutdown();
try {
    if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
        executorService.shutdownNow();
    }
} catch (InterruptedException ex) {
    executorService.shutdownNow();
    Thread.currentThread().interrupt();
}
return myList;
```

If we don't have 10+ threads, we should put any value higher than 10 in fixed thread pool argument to check the behavior.