### PR TITLE
Implement support for Twitch Founders badge

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
@@ -22,6 +22,11 @@ public enum CommandPermission {
 	SUBSCRIBER,
 
 	/**
+	 * Founder (first 10 subscribers of an Affiliate, or first 25 subscribers of a Partner)
+	 */
+	FOUNDER,
+
+	/**
 	 * Gifted a sub
 	 */
 	SUBGIFTER,

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -45,6 +45,11 @@ public class TwitchUtils {
             if (badges.containsKey("staff")) {
                 permissionSet.add(CommandPermission.TWITCHSTAFF);
             }
+            // Founder
+            if(badges.containsKey("founder")) {
+                permissionSet.add(CommandPermission.FOUNDER);
+                permissionSet.add(CommandPermission.SUBSCRIBER);
+            }
         }
         // Moderator
         if (tags.containsKey("mod") && tags.get("mod").equals("1")) {


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Issue #97

### Changes Proposed

* Add a `ChannelPermission` for [Founders](https://help.twitch.tv/s/article/founders-badge)
* Give Founders `ChannelPermission.FOUNDER` and `ChannelPermission.SUBSCRIBER`.

### Additional Information 
*Founders* is a new chatter type in Twitch chat. Founders are the first 10 subscribers to an affiliate or the first 25 subscribers to a partner. They receive a special badge in chat that replaces their subscriber badge.

If a Founder unsubscribes, they will no longer have the badge on their messages when their subscription expires; however, if they resubscribe, they will regain the badge. Therefore, the presence of the badge on their messages *always* indicates that they are also a subscriber. This implementation assigns messages marked with a Founders badge as having both `ChannelPermission.FOUNDER` and `ChannelPermission.SUBSCRIBER`.