### PR TITLE
Fix for KrakenTeam not having JSON property annotations.

### DIFF
--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeam.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeam.java
@@ -16,6 +16,7 @@ public class KrakenTeam {
 
 	private String name;
 
+	@JsonProperty("display_name")
 	private String displayName;
 
 	private String info;
@@ -26,7 +27,9 @@ public class KrakenTeam {
 
 	private String banner;
 
-	private Date createdAt;
+    @JsonProperty("created_at")
+    private Date createdAt;
 
-	private Date updatedAt;
+    @JsonProperty("updated_at")
+    private Date updatedAt;
 }

--- a/rest-kraken/src/test/java/kraken/endpoints/TeamServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/TeamServiceTest.java
@@ -28,9 +28,12 @@ public class TeamServiceTest extends AbstractKrakenServiceTest {
     @DisplayName("getTeamByName")
     @Disabled
     public void getTeamByName() {
-        KrakenTeam result = getTwitchKrakenClient().getTeamByName("staff").execute();
+        KrakenTeam team = getTwitchKrakenClient().getTeamByName("staff").execute();
 
-        assertNotNull(result, "Didn't find the specified team!");
+        assertNotNull(team, "Didn't find the specified team!");
+        assertNotNull(team.getDisplayName(), "Team did not have a Display Name");
+        assertNotNull(team.getCreatedAt(), "Team did not have a 'Created At' date");
+        assertNotNull(team.getUpdatedAt(), "Team did not have a 'Updated At' date");
     }
 
 }


### PR DESCRIPTION
This caused the displayName, createdAt, and updatedAt properties to not be set from the incoming JSON.

Modified the TeamServiceTest to assert that these properties are being set.
This worked locally, but kept the test with @Disabled annotation.

### Prerequisites
* [X] This pull request follows the code style of the project
* [X] I have tested this feature

### Changes Proposed

* Added `@JsonProperty` annotations to `displayName`, `createdAt`, and `updatedAt` to match the snake case of the incoming JSON properties.
