### PR TITLE
Replaced Comments with Doc Strings

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AnaylticsDateRange.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AnaylticsDateRange.java
@@ -20,9 +20,9 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AnaylticsDateRange {
 
-    // Starting date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z.
+    /** Starting date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z. */
     private Date startedAt;
 
-    // Ending date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z.
+    /** Ending date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z. */
     private Date endedAt;
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboardEntry.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboardEntry.java
@@ -15,14 +15,14 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitsLeaderboardEntry {
 
-    // ID of the user (viewer) in the leaderboard entry.
+    /** ID of the user (viewer) in the leaderboard entry. */
     @NonNull
     private String userId;
 
-    // Leaderboard rank of the user.
+    /** Leaderboard rank of the user. */
     private Integer rank;
 
-    // Leaderboard score (number of Bits) of the user.
+    /** Leaderboard score (number of Bits) of the user. */
     private Integer score;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
@@ -20,40 +20,39 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Clip {
 
-    // ID of the clip being queried.
+    /** ID of the clip being queried. */
     private String id;
 
-    // URL where the clip can be viewed.
+    /** URL where the clip can be viewed. */
     private String url;
 
-    // URL to embed the clip.
+    /** URL to embed the clip. */
     private String embedUrl;
 
-    // User ID of the stream from which the clip was created.
+    /** User ID of the stream from which the clip was created. */
     private String broadcasterId;
 
-    // ID of the user who created the clip.
+    /** ID of the user who created the clip. */
     private String creatorId;
 
-    // ID of the video from which the clip was created.
+    /** ID of the video from which the clip was created. */
     private String videoId;
 
-    // ID of the game assigned to the stream when the clip was created.
+    /** ID of the game assigned to the stream when the clip was created. */
     private String gameId;
 
-    // Language of the stream from which the clip was created.
+    /** Language of the stream from which the clip was created. */
     private String language;
 
-    // Title of the clip.
+    /** Title of the clip. */
     private String title;
 
-    // Number of times the clip has been viewed.
+    /** Number of times the clip has been viewed. */
     private Integer viewCount;
 
-    // Date when the clip was created.
+    /** Date when the clip was created. */
     private Date createdAt;
 
-    // URL of the clip thumbnail.
+    /** URL of the clip thumbnail. */
     private String thumbnailUrl;
-
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
@@ -20,19 +20,19 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Extension {
 
-    // ID of the extension.
+    /** ID of the extension. */
     private String id;
 
-    // Name of the extension.
+    /** Name of the extension. */
     private String name;
 
-    // Version of the extension.
+    /** Version of the extension. */
     private String version;
 
-    // Indicates whether the extension is configured such that it can be activated.
+    /** Indicates whether the extension is configured such that it can be activated. */
     private String canActivate;
 
-    // Types for which the extension can be activated. Valid values: "component", "mobile", "panel", "overlay".
+    /** Types for which the extension can be activated. Valid values: "component", "mobile", "panel", "overlay". */
     private List<String> type;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalytics.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalytics.java
@@ -15,16 +15,16 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionAnalytics {
 
-    // ID of the extension whose analytics data is being provided.
+    /** ID of the extension whose analytics data is being provided. */
     @NonNull
     private String extensionId;
 
-    // URL to the downloadable CSV file containing analytics data. Valid for 5 minutes.
+    /** URL to the downloadable CSV file containing analytics data. Valid for 5 minutes. */
     private String URL;
 
-    // Type of report.
+    /** Type of report. */
     private String type;
 
-    // Report contains data of this time range.
+    /** Report contains data of this time range. */
     private AnaylticsDateRange dateRange;
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Follow.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Follow.java
@@ -3,13 +3,9 @@ package com.github.twitch4j.helix.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 
 /**
  * Follow
@@ -21,19 +17,19 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Follow {
 
-    // ID of the user following the to_id user.
+    /** ID of the user following the to_id user. */
     private String fromId;
 
-    // Login name corresponding to from_id.
+    /** Login name corresponding to from_id. */
     private String fromName;
 
-    // ID of the user being followed by the from_id user.
+    /** ID of the user being followed by the from_id user. */
     private String toId;
 
-    // Login name corresponding to to_id.
+    /** Login name corresponding to to_id. */
     private String toName;
 
-    // Date and time when the from_id user followed the to_id user.
+    /** Date and time when the from_id user followed the to_id user. */
     private LocalDateTime followedAt;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Game.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Game.java
@@ -3,12 +3,7 @@ package com.github.twitch4j.helix.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-import java.util.Date;
+import lombok.*;
 
 /**
  * Game
@@ -20,13 +15,13 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Game {
 
-    // Game ID.
+    /** Game ID. */
     private String id;
 
-    // Game name.
+    /** Game name. */
     private String name;
 
-    // Template URL for the game’s box art.
+    /** Template URL for the game’s box art. */
     private String boxArtUrl;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalytics.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalytics.java
@@ -15,16 +15,16 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GameAnalytics {
 
-    // ID of the extension whose analytics data is being provided.
+    /** ID of the extension whose analytics data is being provided. */
     @NonNull
     private String gameId;
 
-    // URL to the downloadable CSV file containing analytics data. Valid for 5 minutes.
+    /** URL to the downloadable CSV file containing analytics data. Valid for 5 minutes. */
     private String URL;
 
-    // Type of report.
+    /** Type of report. */
     private String type;
 
-    // Report contains data of this time range.
+    /** Report contains data of this time range. */
     private AnaylticsDateRange dateRange;
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HearthstoneMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HearthstoneMetadata.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 /**
- * Heartstone Metadata
+ * Hearthstone Metadata
  */
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -16,16 +16,16 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HearthstoneMetadata {
 
-    // The Broadcaster
+    /** The Broadcaster */
     @NonNull
     private HearthstonePlayer broadcaster;
 
-    // The Opponent
+    /** The Opponent */
     @NonNull
     private HearthstonePlayer opponent;
 
     /**
-     * Heartstone Player
+     * Hearthstone Player
      */
     @Data
     @Setter(AccessLevel.PRIVATE)
@@ -34,13 +34,13 @@ public class HearthstoneMetadata {
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class HearthstonePlayer {
 
-        // Hero Type
+        /** Hero Type */
         private HearthstoneHero hero;
 
     }
 
     /**
-     * Heartstone Hero
+     * Hearthstone Hero
      */
     @Data
     @Setter(AccessLevel.PRIVATE)
@@ -49,16 +49,16 @@ public class HearthstoneMetadata {
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class HearthstoneHero {
 
-        // Name of the Hearthstone hero.
+        /** Name of the Hearthstone hero. */
         @NonNull
         private String name;
 
-        // Class of the Hearthstone hero.
+        /** Class of the Hearthstone hero. */
         @NonNull
         @JsonProperty("class")
         private String className;
 
-        // Type of Hearthstone hero.
+        /** Type of Hearthstone hero. */
         @NonNull
         private String type;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Moderator.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Moderator.java
@@ -12,11 +12,11 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Moderator {
 
-    // ID of the subscribed user.
+    /** ID of the subscribed user. */
     @NonNull
     private String userId;
 
-    // Login name of the subscribed user.
+    /** Login name of the subscribed user. */
     @NonNull
     private String userName;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OverwatchMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OverwatchMetadata.java
@@ -15,7 +15,7 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OverwatchMetadata {
 
-    // The Broadcaster
+    /** The Broadcaster */
     @NonNull
     private OverwatchPlayer broadcaster;
 
@@ -29,7 +29,7 @@ public class OverwatchMetadata {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OverwatchPlayer {
 
-        // Hero Type
+        /** Hero Type */
         private OverwatchHero hero;
 
     }
@@ -44,15 +44,15 @@ public class OverwatchMetadata {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OverwatchHero {
 
-        // Name of the Overwatch hero.
+        /** Name of the Overwatch hero. */
         @NonNull
         private String name;
 
-        // Role of the Overwatch hero.
+        /** Role of the Overwatch hero. */
         @NonNull
         private String role;
 
-        // Ability being used by the broadcaster.
+        /** Ability being used by the broadcaster. */
         @NonNull
         private String ability;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -22,45 +22,45 @@ import java.util.regex.Pattern;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Stream {
 
-    // Stream ID.
+    /** Stream ID. */
     @NonNull
     private String id;
 
-    // ID of the user who is streaming.
+    /** ID of the user who is streaming. */
     @NonNull
     private String userId;
 
-    // ID of the game being played on the stream.
+    /** ID of the game being played on the stream. */
     private String gameId;
 
-    // Array of community IDs.
+    /** Array of community IDs. */
     @NonNull
     private List<UUID> communityIds;
 
-    // Stream type: "live" or "" (in case of error).
+    /** Stream type: "live" or "" (in case of error). */
     @NonNull
     private String type;
 
-    // Stream title.
+    /** Stream title. */
     @NonNull
     private String title;
 
-    // Number of viewers watching the stream at the time of the query.
+    /** Number of viewers watching the stream at the time of the query. */
     @NonNull
     private Integer viewerCount;
 
-    // UTC timestamp on when the stream started
+    /** UTC timestamp on when the stream started */
     @NonNull
     private Calendar startedAt;
 
-    // Ids of active tags on the stream
+    /** Ids of active tags on the stream */
     private List<UUID> tagIds = new ArrayList<>();
 
-    // Stream language.
+    /** Stream language. */
     @NonNull
     private String language;
 
-    // Thumbnail URL of the stream. All image URLs have variable width and height. You can replace {width} and {height} with any values to get that size image
+    /** Thumbnail URL of the stream. All image URLs have variable width and height. You can replace {width} and {height} with any values to get that size image */
     @NonNull
     private String thumbnailUrl;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkers.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkers.java
@@ -19,11 +19,11 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamMarkers {
 
-    // Stream ID.
+    /** Stream ID. */
     @NonNull
     private String userId;
 
-    // Markers
+    /** Markers */
     @NonNull
     private List<VideoMarkers> videos;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMetadata.java
@@ -17,16 +17,16 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamMetadata {
 
-    // ID of the user who is streaming.
+    /** ID of the user who is streaming. */
     @NonNull
     private String userId;
 
-    // ID of the game being played on the stream.
+    /** ID of the game being played on the stream. */
     private String gameId;
 
-    // Object containing the Hearthstone metadata, if available; otherwise, null.
+    /** Object containing the Hearthstone metadata, if available; otherwise, null. */
     private HearthstoneMetadata hearthstone;
 
-    // Object containing the Overwatch metadata, if available; otherwise, null.
+    /** Object containing the Overwatch metadata, if available; otherwise, null. */
     private OverwatchMetadata overwatch;
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTag.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTag.java
@@ -1,17 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
-import java.util.Map;
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
+import java.util.*;
 
 /**
  * Stream Tags (LiveStream)
@@ -22,18 +16,18 @@ import lombok.Setter;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamTag {
-    // Tag ID.
+    /** Tag ID. */
     @NonNull
     private UUID tagId;
 
-    // Whether the tag is automatically set by Twitch (meaning that it cannot be set manually)
+    /** Whether the tag is automatically set by Twitch (meaning that it cannot be set manually) */
     private Boolean isAuto;
-    
-    // Map with key/value pairs for the localized name of tags. Key is the locale ("en-us", "da-dk", etc.)
+
+    /** Map with key/value pairs for the localized name of tags. Key is the locale ("en-us", "da-dk", etc.) */
     @NonNull
     private Map<String, String> localizationNames;
 
-    // Map with key/value pairs for the localized description/purpose of tags. Key is the locale ("en-us", "da-dk", etc.)
+    /** Map with key/value pairs for the localized description/purpose of tags. Key is the locale ("en-us", "da-dk", etc.) */
     @NonNull
     private Map<String, String> localizationDescriptions;
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
@@ -12,30 +12,30 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Subscription {
 
-    // User ID of the broadcaster.
+    /** User ID of the broadcaster. */
     @NonNull
     private String broadcasterId;
 
-    // Username of the broadcaster.
+    /** Username of the broadcaster. */
     @NonNull
     private String broadcasterName;
 
-    // Determines if the subscription is a gift subscription.
+    /** Determines if the subscription is a gift subscription. */
     private Boolean isGift;
 
-    // Type of subscription (Tier 1, Tier 2, Tier 3). 1000 = Tier 1, 2000 = Tier 2, 3000 = Tier 3 subscriptions.
+    /** Type of subscription (Tier 1, Tier 2, Tier 3). 1000 = Tier 1, 2000 = Tier 2, 3000 = Tier 3 subscriptions. */
     @NonNull
     private String tier;
 
-    // Name of the subscription.
+    /** Name of the subscription. */
     @NonNull
     private String plan_name;
 
-    // ID of the subscribed user.
+    /** ID of the subscribed user. */
     @NonNull
     private String userId;
 
-    // Login name of the subscribed user.
+    /** Login name of the subscribed user. */
     @NonNull
     private String userName;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/User.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/User.java
@@ -18,34 +18,34 @@ import lombok.Setter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class User {
 
-    // User’s ID.
+    /** User’s ID. */
     private String id;
 
-    // User’s login name.
+    /** User’s login name. */
     private String login;
 
-    // User’s display name.
+    /** User’s display name. */
     private String displayName;
 
-    // User’s type: "staff", "admin", "global_mod", or "".
+    /** User’s type: "staff", "admin", "global_mod", or "". */
     private String type;
 
-    // User’s broadcaster type: "partner", "affiliate", or "".
+    /** User’s broadcaster type: "partner", "affiliate", or "". */
     private String broadcasterType;
 
-    // User’s channel description.
+    /** User’s channel description. */
     private String description;
 
-    // URL of the user’s profile image.
+    /** URL of the user’s profile image. */
     private String profileImageUrl;
 
-    // URL of the user’s offline image.
+    /** URL of the user’s offline image. */
     private String offlineImageUrl;
 
-    // Total number of views of the user’s channel.
+    /** Total number of views of the user’s channel. */
     private Integer viewCount;
 
-    // User’s email address. Returned if the request includes the user:read:email scope.
+    /** User’s email address. Returned if the request includes the user:read:email scope. */
     private String email;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
@@ -20,46 +20,46 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Video {
 
-    // ID of the video.
+    /** ID of the video. */
     private String id;
 
-    // ID of the user who owns the video.
+    /** ID of the user who owns the video. */
     private String userId;
 
-    // Login name corresponding to user_id.
+    /** Login name corresponding to user_id. */
     private String userName;
 
-    // Title of the video.
+    /** Title of the video. */
     private String title;
 
-    // Description of the video.
+    /** Description of the video. */
     private String description;
 
-    // Date when the video was created.
+    /** Date when the video was created. */
     private Date createdAt;
 
-    // Date when the video was published.
+    /** Date when the video was published. */
     private Date publishedAt;
 
-    // URL of the video.
+    /** URL of the video. */
     private String url;
 
-    // Template URL for the thumbnail of the video.
+    /** Template URL for the thumbnail of the video. */
     private String thumbnailUrl;
 
-    // Indicates whether the video is publicly viewable. Valid values: "public", "private".
+    /** Indicates whether the video is publicly viewable. Valid values: "public", "private". */
     private String viewable;
 
-    // Number of times the video has been viewed.
+    /** Number of times the video has been viewed. */
     private Integer viewCount;
 
-    // Language of the video.
+    /** Language of the video. */
     private String language;
 
-    // Type of video. Valid values: "upload", "archive", "highlight".
+    /** Type of video. Valid values: "upload", "archive", "highlight". */
     private String type;
 
-    // Length of the video.
+    /** Length of the video. */
     private String duration;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarker.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarker.java
@@ -19,23 +19,23 @@ import java.util.Calendar;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoMarker {
 
-    // Stream ID.
+    /** Stream ID. */
     @NonNull
     private String id;
 
-    // RFC3339 timestamp of the marker.
+    /** RFC3339 timestamp of the marker. */
     @NonNull
     private Calendar createdAt;
 
-    // Description of the marker.
+    /** Description of the marker. */
     @NonNull
     private String description;
 
-    // Relative offset (in seconds) of the marker, from the beginning of the stream.
+    /** Relative offset (in seconds) of the marker, from the beginning of the stream. */
     @NonNull
     private String position_seconds;
 
-    // A link to the stream with a query parameter that is a timestamp of the marker’s location.
+    /** A link to the stream with a query parameter that is a timestamp of the marker’s location. */
     private String url;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarkers.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarkers.java
@@ -19,11 +19,11 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoMarkers {
 
-    // Stream ID.
+    /** Stream ID. */
     @NonNull
     private String videoId;
 
-    // Markers
+    /** Markers */
     @NonNull
     private List<VideoMarker> markers;
 

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/GamesServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/GamesServiceTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("integration")
 public class GamesServiceTest extends AbtractEndpointTest {
 
-    // Overwatch GameId
+    /** Overwatch GameId */
     private static String overwatchGameId = "488552";
 
     @Test

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
@@ -19,13 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("integration")
 public class StreamsServiceTest extends AbtractEndpointTest {
 
-    // UserId
+    /** UserId */
     private static String twitchUserId = "149223493";
 
-    // Hearthstone GameId
+    /** Hearthstone GameId */
     private static String hearthstoneGameId = "138585";
 
-    // Overwatch GameId
+     /** Overwatch GameId */
     private static String overwatchGameId = "488552";
 
     /**

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("integration")
 public class UsersServiceTest extends AbtractEndpointTest {
 
-    // UserId
+    /** UserId */
     private static String twitchUserId = "149223493l";
 
     /**

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("integration")
 public class VideoServiceTest extends AbtractEndpointTest {
 
-    // Overwatch GameId
+    /** Overwatch GameId */
     private static String overwatchGameId = "488552l";
 
     /**

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Chatters.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Chatters.java
@@ -18,28 +18,28 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Chatters {
 
-    // Viewer Count
+    /** Viewer Count */
     @NonNull
     @JsonProperty("chatter_count")
     private Integer viewerCount;
 
-    // VIPS
+    /** VIPS */
     @JsonIgnore
     private List<String> vips;
 
-    // Staff
+    /** Staff */
     @JsonIgnore
     private List<String> staff;
 
-    // Admins
+    /** Admins */
     @JsonIgnore
     private List<String> admins;
 
-    // Moderators
+    /** Moderators */
     @JsonIgnore
     private List<String> moderators;
 
-    // Viewers
+    /** Viewers */
     @JsonIgnore
     private List<String> viewers;
 


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] This pull request follows the code style of the project
* [ ] ~~I have tested this feature~~ Not a code change.

...

### Changes Proposed

* Replaced a bunch of `// comments` with a `/** doc strings */` instead.
* Fixed typo (Heartstone vs Hearthstone)

Just thought this would be a bit cleaner for JavaDocs, not sure how lombok handles docs for generated setters though should be nicer regardless.