### PR TITLE
Feature: Channel Points redemption PubSub events

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
@@ -1,12 +1,15 @@
 package com.github.twitch4j.common.util;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
 
 public class TypeConvert {
 
     /**
      * ObjectMapper
      */
+    @Getter
     private static ObjectMapper objectMapper = new ObjectMapper();
 
     public static String objectToJson(Object object) {
@@ -25,4 +28,19 @@ public class TypeConvert {
         }
     }
 
+    public static <T> T convertValue(Object fromValue, TypeReference<T> toValueTypeRef) {
+        try {
+            return objectMapper.convertValue(fromValue, toValueTypeRef);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static <T> T convertValue(Object fromValue, Class<T> toValueType) {
+        try {
+            return objectMapper.convertValue(fromValue, toValueType);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/PubSubSubscription.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/PubSubSubscription.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.pubsub;
+
+import com.github.twitch4j.pubsub.domain.PubSubRequest;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * PubSub subscription.
+ * Can be used to unsubscribe from a topic
+ *
+ * @see TwitchPubSub#unsubscribeFromTopic(PubSubSubscription)
+ */
+@RequiredArgsConstructor
+public class PubSubSubscription {
+    @Getter(AccessLevel.PACKAGE)
+    private final PubSubRequest request;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChannelPointsRedemption {
+
+	/**
+	 * Unique ID for this redemption event
+	 */
+	private String id;
+
+	/**
+	 * User that requested this redemption.
+	 */
+	private ChannelPointsUser user;
+
+	/**
+	 * 	ID of the channel in which the reward was redeemed.
+	 */
+	private String channelId;
+
+	/**
+	 * Timestamp in which a reward was redeemed
+	 */
+	private String redeemedAt;
+
+	/**
+	 * Data about the reward that was redeemed
+	 */
+	private ChannelPointsReward reward;
+
+	/**
+	 * (Optional) A string that the user entered if the reward requires input
+	 */
+	private String userInput;
+
+	/**
+	 * reward redemption status, will be FULFULLED if a user skips the reward queue, UNFULFILLED otherwise
+	 */
+	private String status;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChannelPointsReward {
+
+	private String id;
+	private String channelId;
+	private String title;
+	private String prompt;
+	private long cost;
+	private boolean userInputRequired;
+	private boolean subOnly;
+	private Image image;
+	private Image defaultImage;
+	private String backgroundColor;
+	private boolean enabled;
+	private boolean paused;
+	private boolean inStock;
+	private MaxPerStream maxPerStream;
+	private boolean shouldRedemptionsSkipRequestQueue;
+
+	@Data
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Image {
+		@JsonProperty("url_1x")
+		private String url1x;
+		@JsonProperty("url_2x")
+		private String url2x;
+		@JsonProperty("url_4x")
+		private String url4x;
+	}
+
+	@Data
+	@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class MaxPerStream {
+		private boolean isEnabled;
+		private long maxPerStream;
+	}
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsUser.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsUser.java
@@ -1,8 +1,6 @@
-package com.github.twitch4j.pubsub;
+package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
@@ -10,11 +8,10 @@ import lombok.Data;
 @Data
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PubSubResponsePayloadMessage {
+public class ChannelPointsUser {
 
-    private String type;
-
-    @JsonProperty("data")
-    private JsonNode messageData;
+	private String id;
+	private String login;
+	private String displayName;
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubResponsePayload.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubResponsePayload.java
@@ -24,7 +24,4 @@ public class PubSubResponsePayload {
     private void unpackMessage(String message) {
         this.message = TypeConvert.jsonToObject(message, PubSubResponsePayloadMessage.class);
     }
-
-
-
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelPointsRedemptionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelPointsRedemptionEvent.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Calendar;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPointsRedemptionEvent extends TwitchEvent {
+
+    /**
+     * The time the pubsub message was sent
+     */
+    private final Calendar timestamp;
+
+    /**
+     * Data about the redemption, includes unique id and user that redeemed it
+     */
+    private final ChannelPointsRedemption redemption;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RedemptionStatusUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RedemptionStatusUpdateEvent.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Calendar;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class RedemptionStatusUpdateEvent extends ChannelPointsRedemptionEvent {
+
+	public RedemptionStatusUpdateEvent(Calendar timestamp, ChannelPointsRedemption redemption) {
+		super(timestamp, redemption);
+	}
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RewardRedeemedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RewardRedeemedEvent.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Calendar;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class RewardRedeemedEvent extends ChannelPointsRedemptionEvent {
+
+	public RewardRedeemedEvent(Calendar timestamp, ChannelPointsRedemption redemption) {
+		super(timestamp, redemption);
+	}
+
+}

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/TwitchPubSubTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/TwitchPubSubTest.java
@@ -30,10 +30,10 @@ public class TwitchPubSubTest {
     @Disabled
     public void localTestRun() {
         // listen for events in channel
-        twitchPubSub.listenForCheerEvents(TestUtils.getCredential(), 149223493l);
-        twitchPubSub.listenForCommerceEvents(TestUtils.getCredential(), 149223493l);
-        twitchPubSub.listenForSubscriptionEvents(TestUtils.getCredential(), 149223493l);
-        twitchPubSub.listenForWhisperEvents(TestUtils.getCredential(), 149223493l);
+        twitchPubSub.listenForCheerEvents(TestUtils.getCredential(), "149223493");
+        twitchPubSub.listenForCommerceEvents(TestUtils.getCredential(), "149223493");
+        twitchPubSub.listenForSubscriptionEvents(TestUtils.getCredential(), "149223493");
+        twitchPubSub.listenForWhisperEvents(TestUtils.getCredential(), "149223493");
 
         // sleep a second and look of the message was sended
         TestUtils.sleepFor(60000);


### PR DESCRIPTION
### Prerequisites
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* https://github.com/twitch4j/twitch4j/issues/80


### Changes Proposed

* Change `messageData` in `PubSubResponsePayloadMessage` to a `JsonNode` and move work of unpacking actual data to the `PubSub#onTextMessage` switch, since some PubSub response messageData fields are escaped JSON in a string, and others are objects. Expose more ObjectMapper methods in `TypeConvert` to make the conversion cleaner.
* Add supporting ChannelPoints domain objects and Helix methods.

### Additional Information 
Additional valuable improvements to PubSub were made by @turikhay in 
https://github.com/turikhay/twitch4j/tree/feature/channel_points_redemption that should probably be cherrypicked, but I feel like changing messageData to a JsonNode will make PubSub cleaner and easier to work with overall. 