### PR TITLE
Fixing client-builder.md docs page to correctly point to logging.md page

### DIFF
--- a/docs/content/getting-started/client-builder.md
+++ b/docs/content/getting-started/client-builder.md
@@ -26,4 +26,4 @@ TwitchClient twitchClient = TwitchClientBuilder.builder()
 
 ## Logging
 
-Please check out [Logging](./logging) on how to set up logging.
+Please check out [Logging](../logging) on how to set up logging.


### PR DESCRIPTION
The "Logging" link here is broken: https://twitch4j.gitlab.io/twitch4j/getting-started/client-builder/

Not anymore!