### PR TITLE
Added updateTitle method to TwitchKraken

### DIFF
--- a/docs/content/rest-kraken/channel-update-title.md
+++ b/docs/content/rest-kraken/channel-update-title.md
@@ -1,0 +1,41 @@
++++
+title="Channel - Update Title"
+weight = 90
++++
+
+# Update the title of a channel
+
+## Description
+
+Updates the channel / stream title
+
+## Method Definition
+
+```java
+@RequestLine("PUT /channels/{channelId}?channel[status]={title}")
+HystrixCommand<Object> updateTitle(
+    @Param("token") String authToken,
+    @Param("channelId") String channelId,
+    @Param("title") String title
+);
+```
+
+*Required Parameters (one of)*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| token | string | auth token |
+| channelId | string | channel id |
+| title | string | new channel title |
+
+*Optional Parameters*
+
+None
+
+## Code-Snippets
+
+### get team by name
+
+```java
+twitchClient.getKraken().updateTitle("authToken", "44322889", "Hello World!").execute();
+```

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -119,4 +119,32 @@ public interface TwitchKraken {
     	@Param("logins") List<String> logins
     );
 
+    /**
+     * Update title
+     * <p>
+     * Updates the title of a specified channel.
+     *
+     * @param authToken    Auth Token
+     * @param channelId    Channel Id
+     * @param title        New stream title
+     *
+     * @return Object
+     */
+
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json",
+
+    })@RequestLine("PUT /channels/{channelId}?channel[status]={title}")
+
+
+    HystrixCommand<Object> updateTitle(
+
+        @Param("token") String authToken,
+        @Param("channelId") String channelId,
+        @Param("title") String title
+
+    );
+
 }
+

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -130,21 +130,15 @@ public interface TwitchKraken {
      *
      * @return Object
      */
-
     @Headers({
         "Authorization: OAuth {token}",
         "Accept: application/vnd.twitchtv.v5+json",
-
-    })@RequestLine("PUT /channels/{channelId}?channel[status]={title}")
-
-
+    })
+    @RequestLine("PUT /channels/{channelId}?channel[status]={title}")
     HystrixCommand<Object> updateTitle(
-
         @Param("token") String authToken,
         @Param("channelId") String channelId,
         @Param("title") String title
-
     );
 
 }
-


### PR DESCRIPTION
Added method to update stream titles in TwitchKraken. While Kraken is deprecated according to Twitch, this is still the only way to update stream titles via the API, and the Trello road map they provide mentions nothing about finishing the Helix API to include things like this. 

This method is tested and working :) 

