### PR TITLE
Moved all threading to ScheduledThreadPoolExecutor

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
@@ -26,16 +26,16 @@ public class TwitchAuth {
      */
     public TwitchAuth(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl) {
         this.credentialManager = credentialManager;
-
-        // register the twitch identityProvider
-        Optional<OAuth2IdentityProvider> ip = this.credentialManager.getOAuth2IdentityProviderByName("twitch");
-        if (ip.isPresent()) {
-            // already registered
-        } else {
-            // register
-            IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl);
-            this.credentialManager.registerIdentityProvider(identityProvider);
-        }
+        registerIdentityProvider(credentialManager, clientId, clientSecret, redirectUrl);
     }
 
+    public static void registerIdentityProvider(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl) {
+        // register the twitch identityProvider
+        Optional<OAuth2IdentityProvider> ip = credentialManager.getOAuth2IdentityProviderByName("twitch");
+        if (!ip.isPresent()) {
+            // register
+            IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl);
+            credentialManager.registerIdentityProvider(identityProvider);
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ subprojects {
             // Apache Commons
             dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
             dependency group: 'commons-io', name: 'commons-io', version: '2.6'
-			dependency group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 			dependency group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
 
 			// Event Dispatcher

--- a/common/src/main/java/com/github/twitch4j/common/util/ThreadUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/ThreadUtils.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.common.util;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class ThreadUtils {
+    private static ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
+
+    /**
+     * A singular thread pool executor for all submodules
+     * @return ScheduledThreadPoolExecutor
+     */
+    public static ScheduledThreadPoolExecutor getDefaultScheduledThreadPoolExecutor() {
+        if(scheduledThreadPoolExecutor == null) {
+            scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+            scheduledThreadPoolExecutor.setRemoveOnCancelPolicy(true);
+            scheduledThreadPoolExecutor.setMaximumPoolSize(Runtime.getRuntime().availableProcessors() * 8);
+        }
+        return scheduledThreadPoolExecutor;
+    }
+}

--- a/pubsub/build.gradle
+++ b/pubsub/build.gradle
@@ -3,9 +3,6 @@ dependencies {
 	// WebSocket
 	compile group: 'com.neovisionaries', name: 'nv-websocket-client'
 
-	// FIFO Queue
-	compile group: 'org.apache.commons', name: 'commons-collections4'
-
 	// Twitch4J Modules
 	compile project(':' + rootProject.name + '-common')
 	compile project(':' + rootProject.name + '-auth')

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -1,8 +1,11 @@
 package com.github.twitch4j.pubsub;
 
 import com.github.philippheuer.events4j.core.EventManager;
+import com.github.twitch4j.common.util.ThreadUtils;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 /**
  * Twitch PubSub Builder
@@ -17,7 +20,13 @@ public class TwitchPubSubBuilder {
      * Event Manager
      */
     @With
-    private EventManager eventManager = new EventManager();
+    private EventManager eventManager = null;
+
+    /**
+     * Scheduler Thread Pool Executor
+     */
+    @With
+    private ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = null;
 
     /**
      * Initialize the builder
@@ -33,9 +42,15 @@ public class TwitchPubSubBuilder {
      */
     public TwitchPubSub build() {
         log.debug("PubSub: Initializing Module ...");
-        TwitchPubSub twitchPubSub = new TwitchPubSub(this.eventManager);
+        if(scheduledThreadPoolExecutor == null)
+            scheduledThreadPoolExecutor = ThreadUtils.getDefaultScheduledThreadPoolExecutor();
 
-        return twitchPubSub;
+        if(eventManager == null) {
+            eventManager = new EventManager();
+            eventManager.autoDiscovery();
+        }
+
+        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor);
     }
 
 }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
@@ -11,6 +11,8 @@ import com.github.twitch4j.pubsub.TwitchPubSub;
 import com.github.twitch4j.tmi.TwitchMessagingInterface;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
 @Slf4j
 public class TwitchClient implements AutoCloseable {
 
@@ -55,6 +57,11 @@ public class TwitchClient implements AutoCloseable {
     private final ModuleLoader moduleLoader;
 
     /**
+     * Scheduled Thread Pool Executor
+     */
+    private final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
+
+    /**
      * TwitchClientHelper
      * <p>
      * A helper method that contains some common use-cases, like follow events / go live event listeners / ...
@@ -71,8 +78,9 @@ public class TwitchClient implements AutoCloseable {
      * @param chat TwitchChat
      * @param pubsub TwitchPubSub
      * @param graphql TwitchGraphQL
+     * @param threadPoolExecutor ScheduledThreadPoolExecutor
      */
-    public TwitchClient(EventManager eventManager, TwitchHelix helix, TwitchKraken kraken, TwitchMessagingInterface messagingInterface, TwitchChat chat, TwitchPubSub pubsub, TwitchGraphQL graphql) {
+    public TwitchClient(EventManager eventManager, TwitchHelix helix, TwitchKraken kraken, TwitchMessagingInterface messagingInterface, TwitchChat chat, TwitchPubSub pubsub, TwitchGraphQL graphql, ScheduledThreadPoolExecutor threadPoolExecutor) {
         this.eventManager = eventManager;
         this.helix = helix;
         this.kraken = kraken;
@@ -80,7 +88,8 @@ public class TwitchClient implements AutoCloseable {
         this.chat = chat;
         this.pubsub = pubsub;
         this.graphql = graphql;
-        this.twitchClientHelper = new TwitchClientHelper(this);
+        this.twitchClientHelper = new TwitchClientHelper(this, threadPoolExecutor);
+        this.scheduledThreadPoolExecutor = threadPoolExecutor;
 
         // module loader
         this.moduleLoader = new ModuleLoader(this);
@@ -213,5 +222,6 @@ public class TwitchClient implements AutoCloseable {
         if (this.twitchClientHelper != null) {
             twitchClientHelper.close();
         }
+        scheduledThreadPoolExecutor.shutdownNow();
     }
 }


### PR DESCRIPTION


<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature


### Issues Fixed 
* https://github.com/twitch4j/twitch4j/issues/111

### Changes Proposed

* Moved all threading to ScheduledThreadPoolExecutor (PubSub, Chat, ClientHelper)
* Added ScheduledThreadPoolExecutor clean up code
* Modified TwitchClientBuilder to be parent for ScheduledThreadPoolExecutor
* Added singleton ThreadPoolExecutor for all sub-modules and a class to retrieve it (only used when one not provided). See ThreadUtils
* Cleaned up some useless fields in Builder APIs
* Modified TwitchClientBuilder to work better with Chat module
* Removed requirement for instantiated TwitchAuth to register an identity provider. This prevents making unnecessary classes be garbage collected
*Fixed bug: listenForFollow not working due to a bad boolean case
* Moved TwitchPubSub to ArrayBlockingQueue from CircularFifoQueue (same as chat)
* Moved TwitchPubSub heartbeat sending to its own thread.  Checking still happens in main thread.
* Removed unneeded deps from gradle (commons-collections4)
*Added config for chatQueue wait time. This is how much time to wait for an object on the chatQueue before looping again


