### PR TITLE
Establish whisper-specific rate limiting

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -81,6 +81,12 @@ public class TwitchChatBuilder {
     protected Bandwidth chatRateLimit = Bandwidth.simple(20, Duration.ofSeconds(30));
 
     /**
+     * Custom RateLimit for Whispers
+     */
+    @With
+    protected Bandwidth[] whisperRateLimit = { Bandwidth.simple(100, Duration.ofSeconds(60)), Bandwidth.simple(3, Duration.ofSeconds(1)) };
+
+    /**
      * Scheduler Thread Pool Executor
      */
     @With
@@ -116,7 +122,7 @@ public class TwitchChatBuilder {
         }
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout);
     }
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Created separate command queue and rate limit bucket for whispers
* Allowed users to configure their bandwidth settings for the whisper-specific rate-limit bucket

### Additional Information 
https://dev.twitch.tv/docs/irc/guide/ - Whispers have more stringent limits (3 per second, up to 100 per minute is the default) than general IRC commands
