### PR TITLE
TwitchClientBuilder: Use the same event manager for TwitchChat

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -249,6 +249,7 @@ public class TwitchClientBuilder {
         TwitchChat chat = null;
         if (this.enableChat) {
             chat = TwitchChatBuilder.builder()
+                .withEventManager(eventManager)
                 .withCredentialManager(credentialManager)
                 .withChatAccount(chatAccount)
                 .withChatQueueSize(chatQueueSize)


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Events from the TwitchChat module would not be dispatched to the general EventManager

### Changes Proposed
* TwitchClientBuilder: Use the same event manager for TwitchChat
