### PR TITLE
Add user_name to Helix Stream and optimize TwitchClientHelper's StreamEventListener

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -30,6 +30,10 @@ public class Stream {
     @NonNull
     private String userId;
 
+    /** Display name of the user who is streaming */
+    @NonNull
+    private String userName;
+
     /** ID of the game being played on the stream. */
     private String gameId;
 

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
@@ -42,6 +42,7 @@ public class StreamsServiceTest extends AbstractEndpointTest {
         resultList.getStreams().forEach(stream -> {
             assertNotNull(stream.getId(), "Id should not be null!");
             assertNotNull(stream.getUserId(), "UserId should not be null!");
+            assertNotNull(stream.getUserName(), "UserName should not be null!");
             // assertNotNull(stream.getGameId(), "GameId should not be null!");
         });
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add user_name field to Helix Stream object
* Optimize TwitchClientHelper's StreamEventListener from O(m*n) to O(n) when handling TwitchHelix#getStreams calls
