### PR TITLE
TwitchClientHelper: Further username robustness

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -112,13 +112,13 @@ public class TwitchClientHelper implements AutoCloseable {
                 try {
                     List<Stream> streams = hystrixGetAllStreams.execute().getStreams();
                     streams.forEach(stream -> {
-                        final EventChannel channel = new EventChannel(stream.getId(), stream.getUserName());
+                        final EventChannel channel = new EventChannel(stream.getUserId(), stream.getUserName());
 
                         // Check if the channel's live status is still desired to be tracked
                         if (!listenForGoLive.contains(stream.getUserId()))
                             return;
 
-                        ChannelCache currentChannelCache = channelInformation.get(stream.getId(), s -> new ChannelCache(null, null, null, null));
+                        ChannelCache currentChannelCache = channelInformation.get(stream.getUserId(), s -> new ChannelCache(null, null, null, null));
 
                         boolean dispatchGoLiveEvent = false;
                         boolean dispatchGoOfflineEvent = false;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* Fixes #126

### Changes Proposed
* Change `listenForGoLive` and `listenForFollow` to track the channel id instead of the `EventChannel` object. This improves robustness of the code for situations where (a) the login does not match the display name or (b) the user has a name change
* Channel cache: when invalidating entries, don't bother checking `Cache#getIfPresent(Object)`
* Channel cache: replace manual put-if-absent pattern with atomic mapping handled by caffeine
