### PR TITLE
Fix boolean field names for Pubsub ChannelPointsReward

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -16,14 +16,14 @@ public class ChannelPointsReward {
 	private String title;
 	private String prompt;
 	private long cost;
-	private boolean userInputRequired;
-	private boolean subOnly;
+	private boolean isUserInputRequired;
+	private boolean isSubOnly;
 	private Image image;
 	private Image defaultImage;
 	private String backgroundColor;
-	private boolean enabled;
-	private boolean paused;
-	private boolean inStock;
+	private boolean isEnabled;
+	private boolean isPaused;
+	private boolean isInStock;
 	private MaxPerStream maxPerStream;
 	private boolean shouldRedemptionsSkipRequestQueue;
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Fixes #123 

Note: this does *not* change the method names for the auto-generated lombok getters/setters of these fields (so I didn't bother with the annotation approach to fixing this problem... especially as other classes with similar fields did not either)