### PR TITLE
Fix logic in stream listener to fire events when stream is offline

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -121,7 +121,7 @@ public class TwitchClientHelper implements AutoCloseable {
                         if (!listenForGoLive.contains(userId))
                             return;
 
-                        ChannelCache currentChannelCache = channelInformation.get(userId, s -> new ChannelCache(null,null, null, null, null));
+                        ChannelCache currentChannelCache = channelInformation.get(userId, s -> new ChannelCache(null, null, null, null, null));
                         if (stream != null)
                             currentChannelCache.setUserName(stream.getUserName());
                         final EventChannel channel = new EventChannel(userId, currentChannelCache.getUserName());
@@ -258,7 +258,7 @@ public class TwitchClientHelper implements AutoCloseable {
                     log.info("Channel {} already added for Stream Events", channelName);
                 } else {
                     // initialize cache
-                    channelInformation.get(user.getId(), s -> new ChannelCache(user.getLogin(),null, null, null, null));
+                    channelInformation.get(user.getId(), s -> new ChannelCache(user.getLogin(), null, null, null, null));
                 }
             });
             startOrStopEventGenerationThread();

--- a/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
@@ -17,6 +17,11 @@ import java.time.LocalDateTime;
 public class ChannelCache {
 
     /**
+     * User Name
+     */
+    private String userName;
+
+    /**
      * IsLive
      */
     private Boolean isLive;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Fixes #126 (actually)

### Changes Proposed

* Account for streams that would not be returned by the Get Streams endpoint due to offline status. This was done in a way to maintain O(n) complexity
* Add latest user name to channel cache for the sake of firing events with the most updated EventChannel object
