### PR TITLE
Jackson POJOs: boolean primitive -> object for best compatibility

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -16,16 +16,16 @@ public class ChannelPointsReward {
 	private String title;
 	private String prompt;
 	private long cost;
-	private boolean isUserInputRequired;
-	private boolean isSubOnly;
+	private Boolean isUserInputRequired;
+	private Boolean isSubOnly;
 	private Image image;
 	private Image defaultImage;
 	private String backgroundColor;
-	private boolean isEnabled;
-	private boolean isPaused;
-	private boolean isInStock;
+	private Boolean isEnabled;
+	private Boolean isPaused;
+	private Boolean isInStock;
 	private MaxPerStream maxPerStream;
-	private boolean shouldRedemptionsSkipRequestQueue;
+	private Boolean shouldRedemptionsSkipRequestQueue;
 
 	@Data
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -42,7 +42,7 @@ public class ChannelPointsReward {
 	@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class MaxPerStream {
-		private boolean isEnabled;
+		private Boolean isEnabled;
 		private long maxPerStream;
 	}
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
@@ -30,7 +30,7 @@ public class Extension {
     private String version;
 
     /** Indicates whether the extension is configured such that it can be activated. */
-    private String canActivate;
+    private Boolean canActivate;
 
     /** Types for which the extension can be activated. Valid values: "component", "mobile", "panel", "overlay". */
     private List<String> type;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* #123 

### Changes Proposed
* PubSub > ChannelPointsReward: boolean -> Boolean
* TwitchHelix > Extension: canActivate - String -> Boolean

### Additional Information 
When the field name for a boolean primitive starts with "is" there can be (de)serialization problems with Jackson. Converting to a Boolean object appears to alleviate this
