### PR TITLE
TwitchClientHelper: Allow for more than 100 channels

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/CollectionUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/CollectionUtils.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.common.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class CollectionUtils {
+
+    public static <T> List<List<T>> chunked(Iterable<T> iterable, int size) {
+        List<List<T>> chunks = new ArrayList<>();
+        List<T> chunk = null;
+        Iterator<T> it = iterable.iterator();
+        for (int i = 0; it.hasNext(); i++) {
+            if (i % size == 0) {
+                chunk = new ArrayList<>();
+                chunks.add(chunk);
+            }
+
+            chunk.add(it.next());
+        }
+        return chunks;
+    }
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/CollectionUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/CollectionUtils.java
@@ -1,19 +1,26 @@
 package com.github.twitch4j.common.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 public class CollectionUtils {
 
+    /**
+     * Assigns elements of the given iterable to chunks not exceeding the desired size
+     *
+     * @param iterable the source of elements to be assigned to a chunk
+     * @param size the maximum size of each chunk
+     * @return a list of the chunks, or an empty list if the iterable yielded no elements
+     * @throws NullPointerException if the passed iterable is null
+     */
     public static <T> List<List<T>> chunked(Iterable<T> iterable, int size) {
         List<List<T>> chunks = new ArrayList<>();
         List<T> chunk = null;
         Iterator<T> it = iterable.iterator();
         for (int i = 0; it.hasNext(); i++) {
             if (i % size == 0) {
-                chunk = new ArrayList<>();
+                chunk = new ArrayList<>(size);
                 chunks.add(chunk);
             }
 

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -8,7 +8,7 @@ import java.util.*;
 public class TwitchUtils {
 
     public static Set<CommandPermission> getPermissionsFromTags(Map<String, Object> tags) {
-        Set<CommandPermission> permissionSet = new HashSet<>();
+        Set<CommandPermission> permissionSet = EnumSet.of(CommandPermission.EVERYONE);
 
         // Check for Permissions
         if (tags.containsKey("badges")) {
@@ -78,9 +78,6 @@ public class TwitchUtils {
                 */
             }
         }
-
-        // Everyone
-        permissionSet.add(CommandPermission.EVERYONE);
 
         return permissionSet;
     }


### PR DESCRIPTION
### Changes Proposed
* Create CollectionUtils class to create chunked versions of collections
* Chunk getStream calls to allow for more than 100 channels to be tracked
* Set higher `limit` for follow listener
* Allow for bulk enable/disable stream/follow listener
* Allow for enable/disable stream/follow listener without a helix call when the channel id/name is already known
* Unrelated micro-optimization while I was poking around the util package: Use an EnumSet in TwitichUtils#getPermissionsFromTags instead of a HashSet

### Issues Fixed 
* #121 

### Additional Information
If `threadRate` is too low, 429 errors will occur. In the future, we can make the delay between requests more dynamic
