### PR TITLE
Add PubSub support for moderation actions

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -64,7 +64,7 @@ public class IRCMessageEvent extends TwitchEvent {
 	/**
 	 * Client Permissions
 	 */
-	private final Set<CommandPermission> clientPermissions = new HashSet<>();
+	private final Set<CommandPermission> clientPermissions = EnumSet.noneOf(CommandPermission.class);
 
 	/**
 	 * RAW Message

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -303,7 +303,9 @@ public class TwitchPubSub implements AutoCloseable {
                                 }
 
                             } else if (topic.startsWith("chat_moderator_actions")) {
-                                eventManager.publish(new ChatModerationEvent(TypeConvert.convertValue(msgData, ChatModerationAction.class)));
+                                String channelId = topic.substring(topic.lastIndexOf('.') + 1);
+                                ChatModerationAction data = TypeConvert.convertValue(msgData, ChatModerationAction.class);
+                                eventManager.publish(new ChatModerationEvent(channelId, data));
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -11,11 +11,13 @@ import com.github.twitch4j.common.util.TimeUtils;
 import com.github.twitch4j.common.util.TwitchUtils;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
+import com.github.twitch4j.pubsub.domain.ChatModerationAction;
 import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import com.github.twitch4j.pubsub.domain.PubSubResponse;
 import com.github.twitch4j.pubsub.enums.PubSubType;
 import com.github.twitch4j.pubsub.enums.TMIConnectionState;
 import com.github.twitch4j.pubsub.events.ChannelPointsRedemptionEvent;
+import com.github.twitch4j.pubsub.events.ChatModerationEvent;
 import com.github.twitch4j.pubsub.events.RedemptionStatusUpdateEvent;
 import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
 import com.neovisionaries.ws.client.WebSocket;
@@ -300,6 +302,8 @@ public class TwitchPubSub implements AutoCloseable {
                                     default: eventManager.publish(new ChannelPointsRedemptionEvent(timestamp, redemption));
                                 }
 
+                            } else if (topic.startsWith("chat_moderator_actions")) {
+                                eventManager.publish(new ChatModerationEvent(TypeConvert.convertValue(msgData, ChatModerationAction.class)));
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }
@@ -480,6 +484,23 @@ public class TwitchPubSub implements AutoCloseable {
         request.setNonce(UUID.randomUUID().toString());
         request.getData().put("auth_token", credential.getAccessToken());
         request.getData().put("topics", Collections.singletonList("whispers." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    /**
+     * Event Listener: A moderator performs an action in the channel
+     *
+     * @param credential Credential (for channelId, scope: channel:moderate)
+     * @param channelId Target Channel Id
+     * @return PubSubSubscription
+     */
+    public PubSubSubscription listenForModerationEvents(OAuth2Credential credential, String channelId) {
+        final PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("chat_moderator_actions." + channelId));
 
         return listenOnTopic(request);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -508,6 +508,18 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     /**
+     * Event Listener: A moderator performs an action in the channel
+     *
+     * @param credential Credential (for userId, scope: channel:moderate)
+     * @param userId The user id associated with the credential
+     * @param roomId The user id associated with the target channel
+     * @return PubSubSubscription
+     */
+    public PubSubSubscription listenForModerationEvents(OAuth2Credential credential, String userId, String roomId) {
+        return listenForModerationEvents(credential, userId + "." + roomId);
+    }
+
+    /**
      * Event Listener: Anyone makes a channel points redemption on a channel.
      *
      * @param credential Credential (any)

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -19,14 +19,64 @@ import java.util.stream.Collectors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChatModerationAction {
 
+    /**
+     * The raw string for the class of moderation action. Can be "chat_channel_moderation" or "chat_login_moderation"
+     *
+     * @see ChatModerationAction#getModType()
+     */
     private String type;
+
+    /**
+     * The raw string for the specific moderation action. Examples include "timeout" or "slow"
+     *
+     * @see ChatModerationAction#getModerationAction()
+     */
     private String moderationAction;
+
+    /**
+     * The arguments passed to the moderation action command. Can be null.
+     *
+     * @see ChatModerationAction#getTargetedUserName()
+     * @see ChatModerationAction#getReason()
+     * @see ChatModerationAction#getDeletedMessage()
+     * @see ChatModerationAction#getTimeoutDuration()
+     * @see ChatModerationAction#getSlowDuration()
+     * @see ChatModerationAction#getFollowersDuration()
+     */
     private List<String> args;
+
+    /**
+     * The login for the account that triggered the moderation action
+     */
     private String createdBy;
+
+    /**
+     * The user id for the account that triggered the moderation action
+     */
     private String createdByUserId;
+
+    /**
+     * The relevant message id, if the action was a message deletion
+     */
     private String msgId;
+
+    /**
+     * The user id for the targeted account by the moderation action (e.g. the user id that was banned)
+     */
     private String targetUserId;
+
+    /**
+     * The user name for the targeted account by the moderation action (e.g. the user login that was banned)
+     * <p>
+     * Note: While this field is included in the pubsub response, the API appears to never populate it with a non-empty string
+     */
     private String targetUserLogin;
+
+    /**
+     * Whether the moderation action was triggered by AutoMod
+     *
+     * @see <a href="https://help.twitch.tv/s/article/setting-up-moderation-for-your-twitch-channel?language=en_US#automod">Twitch Docs</a>
+     */
     private Boolean fromAutomod;
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -40,7 +40,7 @@ public class ChatModerationAction {
      * @return the specific moderation action that took place, in a convenient enum form
      */
     public ModerationAction getModAction() {
-        return ModerationAction.mappings.get(moderationAction);
+        return ModerationAction.MAPPINGS.get(moderationAction);
     }
 
     /**
@@ -137,36 +137,99 @@ public class ChatModerationAction {
     }
 
     public enum ModerationAction {
+        /**
+         * User was banned
+         */
         BAN,
+        /**
+         * User was unbanned
+         */
         UNBAN,
+        /**
+         * User was timed out
+         */
         TIMEOUT,
+        /**
+         * User time out was removed
+         */
         UNTIMEOUT,
+        /**
+         * Chat message was deleted
+         */
         DELETE,
+        /**
+         * Chat slow mode was enabled
+         */
         SLOW,
+        /**
+         * Chat slow mode was disabled
+         */
         SLOW_OFF,
+        /**
+         * Chat followers only mode was enabled
+         */
         FOLLOWERS,
+        /**
+         * Chat followers only mode was disabled
+         */
         FOLLOWERS_OFF,
+        /**
+         * Unique chat mode was enabled
+         */
         R9K_BETA,
+        /**
+         * Unique chat mode was disabled
+         */
         R9K_BETA_OFF,
+        /**
+         * Emote only chat was enabled
+         */
         EMOTE_ONLY,
+        /**
+         * Emote only chat was disabled
+         */
         EMOTE_ONLY_OFF,
+        /**
+         * Subscribers-only chat was enabled
+         */
         SUBSCRIBERS,
+        /**
+         * Subscribers-only chat was disabled
+         */
         SUBSCRIBERS_OFF,
+        /**
+         * User was given VIP status
+         */
         VIP,
+        /**
+         * User VIP status was removed
+         */
         UNVIP,
+        /**
+         * User was modded
+         */
         MOD,
+        /**
+         * User was unmodded
+         */
         UNMOD,
+        /**
+         * Another channel was hosted
+         */
         HOST,
+        /**
+         * Channel exited host mode
+         */
         UNHOST;
 
         @Getter
         private final String twitchString;
 
         ModerationAction() {
-            this.twitchString = this.name().toLowerCase().replace('_', ' ');
+            this.twitchString = this.name().toLowerCase().replace("_", "");
         }
 
-        private static final Map<String, ModerationAction> mappings = Arrays.stream(ModerationAction.values())
+        private static final Map<String, ModerationAction> MAPPINGS = Arrays.stream(ModerationAction.values())
             .collect(Collectors.toMap(ModerationAction::getTwitchString, Function.identity()));
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -79,19 +79,21 @@ public class ChatModerationAction {
      */
     private Boolean fromAutomod;
 
-    /**
-     * @return the specific moderation type that took place, in a convenient enum form
+    /*
+     * Library-generated helper fields/methods
      */
-    public ModerationType getModType() {
-        return ModerationType.parse(type);
-    }
 
     /**
-     * @return the specific moderation action that took place, in a convenient enum form
+     * The specific moderation type that took place, in a convenient enum form
      */
-    public ModerationAction getModAction() {
-        return ModerationAction.MAPPINGS.get(moderationAction);
-    }
+    @Getter(lazy = true)
+    private final ModerationType modType = ModerationType.parse(type);
+
+    /**
+     * The specific moderation action that took place, in a convenient enum form
+     */
+    @Getter(lazy = true)
+    private final ModerationAction modAction = ModerationAction.MAPPINGS.get(moderationAction);
 
     /**
      * @return optional wrapper around the username that was specified in a ban, unban, timeout, untimeout, vip,
@@ -110,7 +112,7 @@ public class ChatModerationAction {
     }
 
     /**
-     * @return the reason associated with the ban or timeout (or an empty string if none was specified)
+     * @return optional wrapper around the reason associated with the ban or timeout (or an empty string if none was specified)
      */
     public Optional<String> getReason() {
         switch (getModAction()) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -1,0 +1,172 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChatModerationAction {
+
+    private String type;
+    private String moderationAction;
+    private List<String> args;
+    private String createdBy;
+    private String createdByUserId;
+    private String msgId;
+    private String targetUserId;
+    private String targetUserLogin;
+    private Boolean fromAutomod;
+
+    /**
+     * @return the specific moderation type that took place, in a convenient enum form
+     */
+    public ModerationType getModType() {
+        return ModerationType.parse(type);
+    }
+
+    /**
+     * @return the specific moderation action that took place, in a convenient enum form
+     */
+    public ModerationAction getModAction() {
+        return ModerationAction.mappings.get(moderationAction);
+    }
+
+    /**
+     * @return optional wrapper around the username that was specified in a ban, unban, timeout, untimeout, vip,
+     * unvip, mod, unmod, host, or delete message command
+     */
+    public Optional<String> getTargetedUserName() {
+        final ModerationAction action = getModAction();
+        if (args != null && args.size() > 0 && (action == ModerationAction.BAN || action == ModerationAction.UNBAN
+            || action == ModerationAction.TIMEOUT || action == ModerationAction.UNTIMEOUT
+            || action == ModerationAction.DELETE || action == ModerationAction.HOST
+            || action == ModerationAction.VIP || action == ModerationAction.UNVIP
+            || action == ModerationAction.MOD || action == ModerationAction.UNMOD))
+            return Optional.of(args.get(0));
+
+        return Optional.ofNullable(this.targetUserLogin).filter(s -> !s.isEmpty());
+    }
+
+    /**
+     * @return the reason associated with the ban or timeout (or an empty string if none was specified)
+     */
+    public Optional<String> getReason() {
+        switch (getModAction()) {
+            case BAN:
+                if (args != null && args.size() > 1)
+                    return Optional.of(args.get(1));
+
+            case TIMEOUT:
+                if (args != null && args.size() > 2)
+                    return Optional.of(args.get(2));
+
+            default:
+                return Optional.empty();
+        }
+    }
+
+    /**
+     * @return optional wrapper around the message that was deleted
+     */
+    public Optional<String> getDeletedMessage() {
+        if (getModAction() == ModerationAction.DELETE && args != null && args.size() > 1)
+            return Optional.of(args.get(1));
+
+        return Optional.empty();
+    }
+
+    /**
+     * @return optional wrapper around the duration the user was timed out for, in seconds
+     */
+    public OptionalInt getTimeoutDuration() {
+        if (getModAction() == ModerationAction.TIMEOUT && args != null && args.size() > 1)
+            return OptionalInt.of(Integer.parseInt(args.get(1)));
+
+        return OptionalInt.empty();
+    }
+
+    /**
+     * @return optional wrapper around the slow mode delay, in seconds
+     */
+    public OptionalInt getSlowDuration() {
+        if (getModAction() == ModerationAction.SLOW && args != null && args.size() > 0)
+            return OptionalInt.of(Integer.parseInt(args.get(0)));
+
+        return OptionalInt.empty();
+    }
+
+    /**
+     * @return optional wrapper around the duration followers only mode was set to, in minutes
+     */
+    public OptionalInt getFollowersDuration() {
+        if (getModAction() == ModerationAction.FOLLOWERS && args != null && args.size() > 0)
+            return OptionalInt.of(Integer.parseInt(args.get(0)));
+
+        return OptionalInt.empty();
+    }
+
+    /*
+     * Convenience Enums
+     */
+
+    public enum ModerationType {
+        CHANNEL,
+        LOGIN;
+
+        private static ModerationType parse(String twitchString) {
+            if ("chat_channel_moderation".equals(twitchString))
+                return CHANNEL;
+
+            if ("chat_login_moderation".equals(twitchString))
+                return LOGIN;
+
+            return null; // should not occur
+        }
+    }
+
+    public enum ModerationAction {
+        BAN,
+        UNBAN,
+        TIMEOUT,
+        UNTIMEOUT,
+        DELETE,
+        SLOW,
+        SLOW_OFF,
+        FOLLOWERS,
+        FOLLOWERS_OFF,
+        R9K_BETA,
+        R9K_BETA_OFF,
+        EMOTE_ONLY,
+        EMOTE_ONLY_OFF,
+        SUBSCRIBERS,
+        SUBSCRIBERS_OFF,
+        VIP,
+        UNVIP,
+        MOD,
+        UNMOD,
+        HOST,
+        UNHOST;
+
+        @Getter
+        private final String twitchString;
+
+        ModerationAction() {
+            this.twitchString = this.name().toLowerCase().replace('_', ' ');
+        }
+
+        private static final Map<String, ModerationAction> mappings = Arrays.stream(ModerationAction.values())
+            .collect(Collectors.toMap(ModerationAction::getTwitchString, Function.identity()));
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -272,13 +272,49 @@ public class ChatModerationAction {
         /**
          * Channel exited host mode
          */
-        UNHOST;
+        UNHOST,
+        /**
+         * The message was flagged by AutoMod for manual review
+         */
+        AUTOMOD_REJECTED("automod_rejected"),
+        /**
+         * Moderator added a permitted term to AutoMod
+         */
+        ADD_PERMITTED_TERM("add_permitted_term"),
+        /**
+         * Moderator added a blocked term to AutoMod
+         */
+        ADD_BLOCKED_TERM("add_blocked_term"),
+        /**
+         * Moderator deleted a permitted term from AutoMod
+         */
+        DELETE_PERMITTED_TERM("delete_permitted_term"),
+        /**
+         * Moderator deleted a blocked term from AutoMod
+         */
+        DELETE_BLOCKED_TERM("delete_blocked_term"),
+        /**
+         * Moderator approved a message that was flagged by AutoMod
+         */
+        APPROVED_AUTOMOD_MESSAGE("approved_automod_message"),
+        /**
+         * Moderator denied a message that was flagged by AutoMod
+         */
+        DENIED_AUTOMOD_MESSAGE("denied_automod_message"),
+        /**
+         * AutoMod settings were modified
+         */
+        MODIFIED_AUTOMOD_PROPERTIES("modified_automod_properties");
 
         @Getter
         private final String twitchString;
 
         ModerationAction() {
             this.twitchString = this.name().toLowerCase().replace("_", "");
+        }
+
+        ModerationAction(String twitchString) {
+            this.twitchString = twitchString;
         }
 
         private static final Map<String, ModerationAction> MAPPINGS = Arrays.stream(ModerationAction.values())

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -84,16 +84,16 @@ public class ChatModerationAction {
      */
 
     /**
-     * The specific moderation type that took place, in a convenient enum form
-     */
-    @Getter(lazy = true)
-    private final ModerationType modType = ModerationType.parse(type);
-
-    /**
      * The specific moderation action that took place, in a convenient enum form
      */
     @Getter(lazy = true)
     private final ModerationAction modAction = ModerationAction.MAPPINGS.get(moderationAction);
+
+    /**
+     * The specific moderation type that took place, in a convenient enum form
+     */
+    @Getter(lazy = true)
+    private final ModerationType modType = ModerationType.parse(type, modAction);
 
     /**
      * @return optional wrapper around the username that was specified in a ban, unban, timeout, untimeout, vip,
@@ -178,11 +178,16 @@ public class ChatModerationAction {
         CHANNEL,
         LOGIN;
 
-        private static ModerationType parse(String twitchString) {
+        private static ModerationType parse(String twitchString, ModerationAction modAction) {
             if ("chat_channel_moderation".equals(twitchString))
                 return CHANNEL;
 
             if ("chat_login_moderation".equals(twitchString))
+                return LOGIN;
+
+            // API inconsistency documented here https://github.com/twitchdev/issues/issues/99
+            if (modAction == ModerationAction.MOD || modAction == ModerationAction.UNMOD
+                || modAction == ModerationAction.VIP || modAction == ModerationAction.UNVIP)
                 return LOGIN;
 
             return null; // should not occur

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -97,7 +97,7 @@ public class ChatModerationAction {
 
     /**
      * @return optional wrapper around the username that was specified in a ban, unban, timeout, untimeout, vip,
-     * unvip, mod, unmod, host, or delete message command
+     * unvip, mod, unmod, host, raid, or delete message command
      */
     public Optional<String> getTargetedUserName() {
         final ModerationAction action = getModAction();
@@ -105,7 +105,8 @@ public class ChatModerationAction {
             || action == ModerationAction.TIMEOUT || action == ModerationAction.UNTIMEOUT
             || action == ModerationAction.DELETE || action == ModerationAction.HOST
             || action == ModerationAction.VIP || action == ModerationAction.UNVIP
-            || action == ModerationAction.MOD || action == ModerationAction.UNMOD))
+            || action == ModerationAction.MOD || action == ModerationAction.UNMOD
+            || action == ModerationAction.RAID))
             return Optional.of(args.get(0));
 
         return Optional.ofNullable(this.targetUserLogin).filter(s -> !s.isEmpty());

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -274,6 +274,14 @@ public class ChatModerationAction {
          */
         UNHOST,
         /**
+         * A raid on another channel was initiated
+         */
+        RAID,
+        /**
+         * Channel exited raid mode
+         */
+        UNRAID,
+        /**
          * The message was flagged by AutoMod for manual review
          */
         AUTOMOD_REJECTED("automod_rejected"),

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChatModerationEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChatModerationEvent.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ChatModerationAction;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ChatModerationEvent extends TwitchEvent {
+
+    /**
+     * Data regarding the moderation action that took place
+     */
+    private final ChatModerationAction data;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChatModerationEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChatModerationEvent.java
@@ -10,6 +10,11 @@ import lombok.EqualsAndHashCode;
 public class ChatModerationEvent extends TwitchEvent {
 
     /**
+     * The ID for the channel where the moderation action took place
+     */
+    private final String channelId;
+
+    /**
      * Data regarding the moderation action that took place
      */
     private final ChatModerationAction data;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Fixes #68 

### Changes Proposed
* Create `ChatModerationAction` object
* Create `ChatModerationEvent`
* Create `TwitchPubSub#listenForModerationEvents(OAuth2Credential, String)`
* Create websocket message handler for the event
