### PR TITLE
feat: Add unofficial topics to PubSub and improve thread-safety

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -146,7 +146,8 @@ public class TwitchChat implements AutoCloseable {
      * @param chatCredential Chat Credential
      * @param commandPrefixes Command Prefixes
      * @param chatQueueSize Chat Queue Size
-     * @param chatRateLimit Bandwidth / Bucket
+     * @param chatRateLimit Bandwidth / Bucket for chat
+     * @param whisperRateLimit Bandwidth / Buckets for whispers
      * @param taskExecutor ScheduledThreadPoolExecutor
      * @param chatQueueTimeout Timeout to wait for events in Chat Queue
      */

--- a/common/src/main/java/com/github/twitch4j/common/util/CollectionUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/CollectionUtils.java
@@ -9,6 +9,7 @@ public class CollectionUtils {
     /**
      * Assigns elements of the given iterable to chunks not exceeding the desired size
      *
+     * @param <T> type of the iterable
      * @param iterable the source of elements to be assigned to a chunk
      * @param size the maximum size of each chunk
      * @return a list of the chunks, or an empty list if the iterable yielded no elements

--- a/common/src/main/java/com/github/twitch4j/common/util/CryptoUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/CryptoUtils.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.common.util;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+public class CryptoUtils {
+    private static final ThreadLocal<Random> RANDOM;
+    private static final char[] CHARSET;
+
+    public static String generateNonce(final int length) {
+        final Random rand = RANDOM.get();
+        final StringBuilder sb = new StringBuilder(length);
+
+        while (sb.length() < length) {
+            sb.append(CHARSET[rand.nextInt(CHARSET.length)]);
+        }
+
+        return sb.toString();
+    }
+
+    static {
+        RANDOM = ThreadLocal.withInitial(SecureRandom::new);
+        CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+    }
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
@@ -10,7 +10,7 @@ public class TypeConvert {
      * ObjectMapper
      */
     @Getter
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     public static String objectToJson(Object object) {
         try {

--- a/pubsub/build.gradle
+++ b/pubsub/build.gradle
@@ -3,6 +3,9 @@ dependencies {
 	// WebSocket
 	api group: 'com.neovisionaries', name: 'nv-websocket-client'
 
+	// Jackson (JSON)
+	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+
 	// Twitch4J Modules
 	api project(':' + rootProject.name + '-common')
 	api project(':' + rootProject.name + '-auth')

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -569,6 +569,116 @@ public class TwitchPubSub implements AutoCloseable {
         return listenOnTopic(request);
     }
 
+    @Deprecated
+    public PubSubSubscription listenForBroadcastSettingUpdateEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("broadcast-settings-update." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForStreamChatRoomEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("stream-chat-room-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForChannelChatroomEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("chatrooms-channel-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForUserChatroomEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("chatrooms-user-v1." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForUserBitsUpdateEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("user-bits-updates-v1." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForUserImageUpdateEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("user-image-update." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForFollowingEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("following." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForFriendshipEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("friendship." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForPresenceEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("presence." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForVideoPlaybackEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("video-playback." + userId));
+
+        return listenOnTopic(request);
+    }
+
     /**
      * Close
      */

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -361,6 +361,8 @@ public class TwitchPubSub implements AutoCloseable {
                                 final String channelId = topic.substring(topic.lastIndexOf('.') + 1);
                                 final FollowingData data = TypeConvert.jsonToObject(rawMessage, FollowingData.class);
                                 eventManager.publish(new FollowingEvent(channelId, data));
+                            } else if (topic.startsWith("hype-train-events-v1.rewards")) {
+                                eventManager.publish(new HypeTrainRewardsEvent(TypeConvert.convertValue(msgData, HypeTrainRewardsData.class)));
                             } else if (topic.startsWith("hype-train-events-v1")) {
                                 final String channelId = topic.substring(topic.lastIndexOf('.') + 1);
                                 switch (type) {
@@ -789,7 +791,6 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
-    @Deprecated
     public PubSubSubscription listenForHypeTrainRewardEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "hype-train-events-v1.rewards." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -310,6 +310,12 @@ public class TwitchPubSub implements AutoCloseable {
                                 switch(type) {
                                     case "reward-redeemed": eventManager.publish(new RewardRedeemedEvent(timestamp, redemption)); break;
                                     case "redemption-status-update": eventManager.publish(new RedemptionStatusUpdateEvent(timestamp, redemption)); break;
+                                    case "custom-reward-created":
+                                        // todo
+                                    case "custom-reward-updated":
+                                        // todo
+                                    case "custom-reward-deleted":
+                                        // todo
                                     default: eventManager.publish(new ChannelPointsRedemptionEvent(timestamp, redemption));
                                 }
 
@@ -565,6 +571,98 @@ public class TwitchPubSub implements AutoCloseable {
         request.setNonce(UUID.randomUUID().toString());
         request.getData().put("auth_token", credential.getAccessToken());
         request.getData().put("topics", Collections.singletonList("community-points-channel-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    /*
+     * Undocumented topics - Use at your own risk
+     */
+
+    @Deprecated
+    public PubSubSubscription listenForAdsEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("ads." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForDashboardActivityFeedEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("dashboard-activity-feed." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForUserChannelPointsEvents(OAuth2Credential credential, String userId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("community-points-user-v1." + userId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForChannelDropEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("channel-drop-events." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForChannelBitsLeaderboardEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-WEEK"));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForChannelSubLeaderboardEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("leaderboard-events-v1.sub-gift-sent-" + channelId + "-WEEK"));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForChannelSubGiftsEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("channel-sub-gifts-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForRaidEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("raid." + channelId));
 
         return listenOnTopic(request);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -440,6 +440,16 @@ public class TwitchPubSub implements AutoCloseable {
                                 eventManager.publish(new PollsEvent(type, pollData));
                             } else if (topic.startsWith("friendship")) {
                                 eventManager.publish(new FriendshipEvent(TypeConvert.jsonToObject(rawMessage, FriendshipData.class)));
+                            } else if (topic.startsWith("presence")) {
+                                if ("presence".equalsIgnoreCase(type)) {
+                                    eventManager.publish(new UserPresenceEvent(TypeConvert.convertValue(msgData, PresenceData.class)));
+                                } else if ("settings".equalsIgnoreCase(type)) {
+                                    String userId = topic.substring(topic.indexOf('.') + 1);
+                                    PresenceSettings presenceSettings = TypeConvert.convertValue(msgData, PresenceSettings.class);
+                                    eventManager.publish(new PresenceSettingsEvent(userId, presenceSettings));
+                                } else {
+                                    log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                }
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -570,6 +570,28 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Deprecated
+    public PubSubSubscription listenForChannelExtensionEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("channel-ext-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForHypeTrainEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("hype-train-events-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
     public PubSubSubscription listenForBroadcastSettingUpdateEvents(OAuth2Credential credential, String channelId) {
         PubSubRequest request = new PubSubRequest();
         request.setType(PubSubType.LISTEN);
@@ -669,12 +691,12 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Deprecated
-    public PubSubSubscription listenForVideoPlaybackEvents(OAuth2Credential credential, String userId) {
+    public PubSubSubscription listenForVideoPlaybackEvents(OAuth2Credential credential, String channelId) {
         PubSubRequest request = new PubSubRequest();
         request.setType(PubSubType.LISTEN);
         request.setNonce(UUID.randomUUID().toString());
         request.getData().put("auth_token", credential.getAccessToken());
-        request.getData().put("topics", Collections.singletonList("video-playback." + userId));
+        request.getData().put("topics", Collections.singletonList("video-playback." + channelId));
 
         return listenOnTopic(request);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -660,6 +660,17 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Deprecated
+    public PubSubSubscription listenForBountyBoardEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("channel-bounty-board-events.cta." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
     public PubSubSubscription listenForDashboardActivityFeedEvents(OAuth2Credential credential, String userId) {
         PubSubRequest request = new PubSubRequest();
         request.setType(PubSubType.LISTEN);
@@ -726,6 +737,17 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Deprecated
+    public PubSubSubscription listenForChannelSquadEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("channel-squad-updates." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
     public PubSubSubscription listenForRaidEvents(OAuth2Credential credential, String channelId) {
         PubSubRequest request = new PubSubRequest();
         request.setType(PubSubType.LISTEN);
@@ -748,6 +770,17 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Deprecated
+    public PubSubSubscription listenForExtensionControlEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("extension-control." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
     public PubSubSubscription listenForHypeTrainEvents(OAuth2Credential credential, String channelId) {
         PubSubRequest request = new PubSubRequest();
         request.setType(PubSubType.LISTEN);
@@ -765,6 +798,39 @@ public class TwitchPubSub implements AutoCloseable {
         request.setNonce(UUID.randomUUID().toString());
         request.getData().put("auth_token", credential.getAccessToken());
         request.getData().put("topics", Collections.singletonList("broadcast-settings-update." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForCelebrationEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("celebration-events-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForPublicCheerEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("channel-cheer-events-public-v1." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForStreamChangeEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("stream-change-by-channel." + channelId));
 
         return listenOnTopic(request);
     }
@@ -854,6 +920,17 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Deprecated
+    public PubSubSubscription listenForPollEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("polls." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
     public PubSubSubscription listenForPresenceEvents(OAuth2Credential credential, String userId) {
         PubSubRequest request = new PubSubRequest();
         request.setType(PubSubType.LISTEN);
@@ -871,6 +948,17 @@ public class TwitchPubSub implements AutoCloseable {
         request.setNonce(UUID.randomUUID().toString());
         request.getData().put("auth_token", credential.getAccessToken());
         request.getData().put("topics", Collections.singletonList("video-playback." + channelId));
+
+        return listenOnTopic(request);
+    }
+
+    @Deprecated
+    public PubSubSubscription listenForWatchPartyEvents(OAuth2Credential credential, String channelId) {
+        PubSubRequest request = new PubSubRequest();
+        request.setType(PubSubType.LISTEN);
+        request.setNonce(UUID.randomUUID().toString());
+        request.getData().put("auth_token", credential.getAccessToken());
+        request.getData().put("topics", Collections.singletonList("pv-watch-party-events." + channelId));
 
         return listenOnTopic(request);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -307,16 +307,37 @@ public class TwitchPubSub implements AutoCloseable {
                                 );
                                 ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
 
-                                switch(type) {
-                                    case "reward-redeemed": eventManager.publish(new RewardRedeemedEvent(timestamp, redemption)); break;
-                                    case "redemption-status-update": eventManager.publish(new RedemptionStatusUpdateEvent(timestamp, redemption)); break;
+                                switch (type) {
+                                    case "reward-redeemed":
+                                        eventManager.publish(new RewardRedeemedEvent(timestamp, redemption));
+                                        break;
+                                    case "redemption-status-update":
+                                        eventManager.publish(new RedemptionStatusUpdateEvent(timestamp, redemption));
+                                        break;
                                     case "custom-reward-created":
                                         // todo
                                     case "custom-reward-updated":
                                         // todo
                                     case "custom-reward-deleted":
                                         // todo
-                                    default: eventManager.publish(new ChannelPointsRedemptionEvent(timestamp, redemption));
+                                    case "update-redemption-statuses-progress":
+                                        // todo
+                                    case "update-redemption-statuses-finished":
+                                        // todo
+                                    default:
+                                        eventManager.publish(new ChannelPointsRedemptionEvent(timestamp, redemption));
+                                }
+
+                            } else if (topic.startsWith("raid")) {
+                                switch (type) {
+                                    case "raid_go_v2":
+                                        // todo
+                                    case "raid_update":
+                                        // todo
+                                    case "raid_update_v2":
+                                        // todo
+                                    default:
+                                        break;
                                 }
 
                             } else if (topic.startsWith("chat_moderator_actions")) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -450,6 +450,8 @@ public class TwitchPubSub implements AutoCloseable {
                                 } else {
                                     log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                                 }
+                            } else if (topic.startsWith("channel-sub-gifts-v1")) {
+                                eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(rawMessage, SubGiftData.class)));
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -16,6 +16,7 @@ import com.github.twitch4j.pubsub.domain.ChannelBitsData;
 import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import com.github.twitch4j.pubsub.domain.ChatModerationAction;
+import com.github.twitch4j.pubsub.domain.ClaimData;
 import com.github.twitch4j.pubsub.domain.CommerceData;
 import com.github.twitch4j.pubsub.domain.FollowingData;
 import com.github.twitch4j.pubsub.domain.ChatModerationAction;
@@ -24,30 +25,13 @@ import com.github.twitch4j.pubsub.domain.HypeProgression;
 import com.github.twitch4j.pubsub.domain.HypeTrainConductor;
 import com.github.twitch4j.pubsub.domain.HypeTrainEnd;
 import com.github.twitch4j.pubsub.domain.HypeTrainStart;
+import com.github.twitch4j.pubsub.domain.PointsSpent;
 import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import com.github.twitch4j.pubsub.domain.PubSubResponse;
 import com.github.twitch4j.pubsub.domain.SubscriptionData;
 import com.github.twitch4j.pubsub.enums.PubSubType;
 import com.github.twitch4j.pubsub.enums.TMIConnectionState;
-import com.github.twitch4j.pubsub.events.ChannelBitsBadgeUnlockEvent;
-import com.github.twitch4j.pubsub.events.ChannelBitsEvent;
-import com.github.twitch4j.pubsub.events.ChannelCommerceEvent;
-import com.github.twitch4j.pubsub.events.ChannelPointsRedemptionEvent;
-import com.github.twitch4j.pubsub.events.ChannelPointsUserEvent;
-import com.github.twitch4j.pubsub.events.ChannelSubscribeEvent;
-import com.github.twitch4j.pubsub.events.ChatModerationEvent;
-import com.github.twitch4j.pubsub.events.FollowingEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainConductorUpdateEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainCooldownExpirationEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainEndEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainLevelUpEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainProgressionEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainStartEvent;
-import com.github.twitch4j.pubsub.events.RaidCancelEvent;
-import com.github.twitch4j.pubsub.events.RaidGoEvent;
-import com.github.twitch4j.pubsub.events.RaidUpdateEvent;
-import com.github.twitch4j.pubsub.events.RedemptionStatusUpdateEvent;
-import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
+import com.github.twitch4j.pubsub.events.*;
 import com.neovisionaries.ws.client.WebSocket;
 import com.neovisionaries.ws.client.WebSocketAdapter;
 import com.neovisionaries.ws.client.WebSocketFactory;
@@ -410,11 +394,30 @@ public class TwitchPubSub implements AutoCloseable {
                                         break;
                                 }
                             } else if (topic.startsWith("community-points-user-v1")) {
-                                if (type.equalsIgnoreCase("points-earned")) {
-                                    final ChannelPointsEarned data = TypeConvert.convertValue(msgData, ChannelPointsEarned.class);
-                                    eventManager.publish(new ChannelPointsUserEvent(data));
-                                } else {
-                                    log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                switch (type) {
+                                    case "points-earned":
+                                        final ChannelPointsEarned pointsEarned = TypeConvert.convertValue(msgData, ChannelPointsEarned.class);
+                                        eventManager.publish(new PointsEarnedEvent(pointsEarned));
+                                        break;
+                                    case "claim-available":
+                                        final ClaimData claimAvailable = TypeConvert.convertValue(msgData, ClaimData.class);
+                                        eventManager.publish(new ClaimAvailableEvent(claimAvailable));
+                                        break;
+                                    case "claim-claimed":
+                                        final ClaimData claimClaimed = TypeConvert.convertValue(msgData, ClaimData.class);
+                                        eventManager.publish(new ClaimClaimedEvent(claimClaimed));
+                                        break;
+                                    case "points-spent":
+                                        final PointsSpent pointsSpent = TypeConvert.convertValue(msgData, PointsSpent.class);
+                                        eventManager.publish(new PointsSpentEvent(pointsSpent));
+                                        break;
+                                    case "global-last-viewed-content-updated":
+                                    case "channel-last-viewed-content-updated":
+                                        // unimportant
+                                        break;
+                                    default:
+                                        log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                        break;
                                 }
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -435,6 +435,9 @@ public class TwitchPubSub implements AutoCloseable {
                                         log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                                         break;
                                 }
+                            } else if (topic.startsWith("polls")) {
+                                PollData pollData = TypeConvert.convertValue(msgData.path("poll"), PollData.class);
+                                eventManager.publish(new PollsEvent(type, pollData));
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -694,16 +694,25 @@ public class TwitchPubSub implements AutoCloseable {
      */
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForAdsEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "ads." + userId);
     }
 
     @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForAdPropertyRefreshEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "ad-property-refresh." + userId);
+    }
+
+    @Unofficial
+    @Deprecated
     public PubSubSubscription listenForBountyBoardEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-bounty-board-events.cta." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForDashboardActivityFeedEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "dashboard-activity-feed." + userId);
     }
@@ -714,6 +723,7 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForChannelDropEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-drop-events." + channelId);
     }
@@ -721,6 +731,12 @@ public class TwitchPubSub implements AutoCloseable {
     @Unofficial
     public PubSubSubscription listenForChannelBitsLeaderboardEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-WEEK");
+    }
+
+    @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForChannelPrimeGiftStatusEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-prime-gifting-status." + channelId);
     }
 
     @Unofficial
@@ -739,6 +755,7 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForChannelSquadEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-squad-updates." + channelId);
     }
@@ -749,11 +766,13 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForChannelExtensionEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-ext-v1." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForExtensionControlEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "extension-control." + channelId);
     }
@@ -764,11 +783,19 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForHypeTrainRewardEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "hype-train-events-v1.rewards." + channelId);
+    }
+
+    @Unofficial
+    @Deprecated
     public PubSubSubscription listenForBroadcastSettingUpdateEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "broadcast-settings-update." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForCelebrationEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "celebration-events-v1." + channelId);
     }
@@ -779,31 +806,55 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForStreamChangeEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "stream-change-by-channel." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForStreamChatRoomEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "stream-chat-room-v1." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForChannelChatroomEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "chatrooms-channel-v1." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForUserChatroomEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "chatrooms-user-v1." + userId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForUserBitsUpdateEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "user-bits-updates-v1." + userId);
     }
 
     @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForUserCampaignEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "user-campaign-events." + userId);
+    }
+
+    @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForUserPropertiesUpdateEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "user-properties-update." + userId);
+    }
+
+    @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForUserSubscribeEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "user-subscribe-events-v1." + userId);
+    }
+
+    @Unofficial
+    @Deprecated
     public PubSubSubscription listenForUserImageUpdateEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "user-image-update." + userId);
     }
@@ -826,6 +877,12 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForOnsiteNotificationEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "onsite-notifications." + userId);
+    }
+
+    @Unofficial
     public PubSubSubscription listenForPollEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "polls." + channelId);
     }
@@ -836,11 +893,13 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForVideoPlaybackEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "video-playback." + channelId);
     }
 
     @Unofficial
+    @Deprecated
     public PubSubSubscription listenForWatchPartyEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "pv-watch-party-events." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -438,6 +438,8 @@ public class TwitchPubSub implements AutoCloseable {
                             } else if (topic.startsWith("polls")) {
                                 PollData pollData = TypeConvert.convertValue(msgData.path("poll"), PollData.class);
                                 eventManager.publish(new PollsEvent(type, pollData));
+                            } else if (topic.startsWith("friendship")) {
+                                eventManager.publish(new FriendshipEvent(TypeConvert.jsonToObject(rawMessage, FriendshipData.class)));
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -460,6 +460,12 @@ public class TwitchPubSub implements AutoCloseable {
                                 } else {
                                     log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                                 }
+                            } else if (topic.startsWith("onsite-notifications")) {
+                                if ("create-notification".equalsIgnoreCase(type)) {
+                                    eventManager.publish(new OnsiteNotificationCreationEvent(TypeConvert.convertValue(msgData, CreateNotificationData.class)));
+                                } else {
+                                    log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                }
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }
@@ -877,7 +883,6 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
-    @Deprecated
     public PubSubSubscription listenForOnsiteNotificationEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "onsite-notifications." + userId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -452,6 +452,14 @@ public class TwitchPubSub implements AutoCloseable {
                                 }
                             } else if (topic.startsWith("channel-sub-gifts-v1")) {
                                 eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(rawMessage, SubGiftData.class)));
+                            } else if (topic.startsWith("channel-cheer-events-public-v1")) {
+                                String channelId = topic.substring(topic.indexOf('.') + 1);
+                                if ("cheerbomb".equalsIgnoreCase(type)) {
+                                    CheerbombData cheerbomb = TypeConvert.convertValue(msgData, CheerbombData.class);
+                                    eventManager.publish(new CheerbombEvent(channelId, cheerbomb));
+                                } else {
+                                    log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                }
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsBalance.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsBalance.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChannelPointsBalance {
+    private String userId;
+    private String channelId;
+    private Long balance;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsEarned.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsEarned.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.pubsub.domain.ChannelPointsBalance;
+import com.github.twitch4j.pubsub.domain.ChannelPointsGain;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChannelPointsEarned {
+    @JsonIgnore
+    private Instant timestamp;
+    private String channelId;
+    private ChannelPointsGain pointGain;
+    private ChannelPointsBalance balance;
+
+    @JsonProperty("timestamp")
+    private void unpackTimestamp(final String timestamp) {
+        this.timestamp = Instant.parse(timestamp);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsEarned.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsEarned.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.github.twitch4j.pubsub.domain.ChannelPointsBalance;
-import com.github.twitch4j.pubsub.domain.ChannelPointsGain;
 import lombok.Data;
 
 import java.time.Instant;
@@ -15,14 +11,8 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsEarned {
-    @JsonIgnore
     private Instant timestamp;
     private String channelId;
     private ChannelPointsGain pointGain;
     private ChannelPointsBalance balance;
-
-    @JsonProperty("timestamp")
-    private void unpackTimestamp(final String timestamp) {
-        this.timestamp = Instant.parse(timestamp);
-    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsGain.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsGain.java
@@ -22,7 +22,7 @@ public class ChannelPointsGain {
     @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PointGainMultiplier {
-        private String reason_code;
+        private String reasonCode;
         private Double factor;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsGain.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsGain.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChannelPointsGain {
+    private String userId;
+    private String channelId;
+    private Integer totalPoints;
+    private Integer baselinePoints;
+    private String reasonCode;
+    private List<PointGainMultiplier> multipliers;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PointGainMultiplier {
+        private String reason_code;
+        private Double factor;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
@@ -41,7 +41,7 @@ public class ChannelPointsRedemption {
 	private String userInput;
 
 	/**
-	 * reward redemption status, will be FULFULLED if a user skips the reward queue, UNFULFILLED otherwise
+	 * reward redemption status, will be FULFILLED if a user skips the reward queue, UNFULFILLED otherwise
 	 */
 	private String status;
 

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -26,6 +26,7 @@ public class ChannelPointsReward {
 	private Boolean isInStock;
 	private MaxPerStream maxPerStream;
 	private Boolean shouldRedemptionsSkipRequestQueue;
+	private String updatedForIndicatorAt;
 
 	@Data
 	@JsonIgnoreProperties(ignoreUnknown = true)

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CheerbombData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CheerbombData.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CheerbombData {
+    private String userID;
+    private String displayName;
+    private String userLogin;
+    private Integer selectedCount;
+    private String triggerType;
+    private Integer triggerAmount;
+    private Integer totalRewardCount;
+    private String domain;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClaimData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClaimData.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClaimData {
+    @JsonIgnore
+    private Instant timestamp;
+    private Claim claim;
+
+    @JsonProperty("timestamp")
+    private void unpackTimestamp(final String timestamp) {
+        this.timestamp = Instant.parse(timestamp);
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Claim {
+        private String id;
+        private String userId;
+        private String channelId;
+        private ChannelPointsGain pointGain;
+        @JsonIgnore
+        private Instant createdAt;
+
+        @JsonProperty("created_at")
+        private void unpackCreatedAt(final String createdAt) {
+            this.createdAt = Instant.parse(createdAt);
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClaimData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClaimData.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
@@ -13,14 +11,8 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClaimData {
-    @JsonIgnore
     private Instant timestamp;
     private Claim claim;
-
-    @JsonProperty("timestamp")
-    private void unpackTimestamp(final String timestamp) {
-        this.timestamp = Instant.parse(timestamp);
-    }
 
     @Data
     @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -30,12 +22,6 @@ public class ClaimData {
         private String userId;
         private String channelId;
         private ChannelPointsGain pointGain;
-        @JsonIgnore
         private Instant createdAt;
-
-        @JsonProperty("created_at")
-        private void unpackCreatedAt(final String createdAt) {
-            this.createdAt = Instant.parse(createdAt);
-        }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreateNotificationData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreateNotificationData.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateNotificationData {
+    private OnsiteNotification notification;
+    private Boolean persistent;
+    private Boolean toast;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FollowingData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FollowingData.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FollowingData {
+    private String displayName;
+    private String username;
+    private String userId;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
@@ -1,0 +1,44 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FriendshipData {
+    private String userId;
+    private String targetUserId;
+    private Change change;
+
+    public enum Change {
+        ACCEPTED,
+        REJECTED,
+        REMOVED,
+        REQUESTED,
+        SELF_ACCEPTED,
+        SELF_REJECTED,
+        SELF_REMOVED,
+        SELF_REQUESTED;
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+
+        private static final Map<String, Change> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+
+        @JsonCreator
+        public static Change fromString(String change) {
+            return MAPPINGS.get(change);
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
@@ -13,13 +11,6 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeLevelUp {
-    @JsonIgnore
     private Instant timeToExpire;
     private HypeTrainProgress progress;
-
-    @JsonProperty("time_to_expire")
-    private void unpackTimeToExpire(final Long timeToExpire) {
-        if (timeToExpire != null)
-            this.timeToExpire = Instant.ofEpochMilli(timeToExpire);
-    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeLevelUp {
+    @JsonIgnore
+    private Instant timeToExpire;
+    private HypeTrainProgress progress;
+
+    @JsonProperty("time_to_expire")
+    private void unpackTimeToExpire(final Long timeToExpire) {
+        if (timeToExpire != null)
+            this.timeToExpire = Instant.ofEpochMilli(timeToExpire);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
@@ -8,15 +8,11 @@ import lombok.Data;
 @Data
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class RaidGo {
-    private String id;
-    private String creatorId;
-    private String sourceId;
-    private String targetId;
-    private String targetLogin;
-    private String targetDisplayName;
-    private String targetProfileImage;
-    private Integer transitionJitterSeconds;
-    private Integer forceRaidNowSeconds;
-    private Integer viewerCount;
+public class HypeProgression {
+    private String userId;
+    private Integer sequenceId;
+    private String action;
+    private String source;
+    private Integer quantity;
+    private HypeTrainProgress progress;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductor.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductor.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainConductor {
+    private String source;
+    private HypeTrainConductorUser user;
+    private HypeTrainParticipations participations;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductorUser.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductorUser.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainConductorUser {
+    private String id;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
@@ -39,7 +39,6 @@ public class HypeTrainConfig {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ConductorRewards {
         @JsonProperty("BITS")
@@ -49,7 +48,6 @@ public class HypeTrainConfig {
         private ConductorReward subs;
 
         @Data
-        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class ConductorReward {
             @JsonProperty("CURRENT")
@@ -73,7 +71,6 @@ public class HypeTrainConfig {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DifficultySettings {
         @JsonProperty("EASY")

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
@@ -1,0 +1,103 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainConfig {
+    private String channelId;
+    private Boolean isEnabled;
+    private Boolean isWhitelisted;
+    private HypeTrainKickoff kickoff;
+    private Long cooldownDuration;
+    private Long levelDuration;
+    private String difficulty;
+    // private Object rewardEndDate;
+    private HypeTrainParticipations participationConversionRates;
+    private HypeTrainParticipations notificationThresholds;
+    private DifficultySettings difficultySettings;
+    private ConductorRewards conductorRewards;
+    private String calloutEmoteId;
+    private String calloutEmoteToken;
+    private String themeColor;
+    private Boolean hasConductorBadges;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class HypeTrainKickoff {
+        private Integer numOfEvents;
+        private Integer minPoints;
+        private Long duration;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ConductorRewards {
+        @JsonProperty("BITS")
+        private ConductorReward bits;
+
+        @JsonProperty("SUBS")
+        private ConductorReward subs;
+
+        @Data
+        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class ConductorReward {
+            @JsonProperty("CURRENT")
+            private List<RewardType> current;
+
+            @JsonProperty("FORMER")
+            private List<RewardType> former;
+
+            @Data
+            @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+            @JsonIgnoreProperties(ignoreUnknown = true)
+            public static class RewardType {
+                private String type;
+                private String id;
+                private String groupId;
+                private Integer rewardLevel;
+                private String badgeId;
+                private String imageUrl;
+            }
+        }
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DifficultySettings {
+        @JsonProperty("EASY")
+        private List<DifficultySetting> easy;
+
+        @JsonProperty("MEDIUM")
+        private List<DifficultySetting> medium;
+
+        @JsonProperty("HARD")
+        private List<DifficultySetting> hard;
+
+        @JsonProperty("SUPER_HARD")
+        private List<DifficultySetting> superHard;
+
+        @JsonProperty("INSANE")
+        private List<DifficultySetting> insane;
+
+        @Data
+        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class DifficultySetting {
+            private Integer value;
+            private Integer goal;
+            private List<HypeTrainReward> rewards;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainEnd {
+    @JsonIgnore
+    private Instant endedAt;
+    private String endingReason;
+
+    @JsonProperty("ended_at")
+    private void unpackEndedAt(final Long endedAt) {
+        this.endedAt = Instant.ofEpochMilli(endedAt);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
@@ -13,12 +11,6 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainEnd {
-    @JsonIgnore
     private Instant endedAt;
     private String endingReason;
-
-    @JsonProperty("ended_at")
-    private void unpackEndedAt(final Long endedAt) {
-        this.endedAt = Instant.ofEpochMilli(endedAt);
-    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainLevel {
+    private Integer value;
+    private Integer goal;
+    private List<HypeTrainReward> rewards;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipations.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipations.java
@@ -2,12 +2,9 @@ package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainParticipations {
     @JsonProperty("BITS.CHEER")

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipations.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipations.java
@@ -1,0 +1,39 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainParticipations {
+    @JsonProperty("BITS.CHEER")
+    private Integer cheerBits;
+
+    @JsonProperty("BITS.EXTENSION")
+    private Integer extensionBits;
+
+    @JsonProperty("BITS.POLL")
+    private Integer pollBits;
+
+    @JsonProperty("SUBS.TIER_1_SUB")
+    private Integer subscribedTier1;
+
+    @JsonProperty("SUBS.TIER_2_SUB")
+    private Integer subscribedTier2;
+
+    @JsonProperty("SUBS.TIER_3_SUB")
+    private Integer subscribedTier3;
+
+    @JsonProperty("SUBS.TIER_1_GIFTED_SUB")
+    private Integer giftedTier1;
+
+    @JsonProperty("SUBS.TIER_2_GIFTED_SUB")
+    private Integer giftedTier2;
+
+    @JsonProperty("SUBS.TIER_3_GIFTED_SUB")
+    private Integer giftedTier3;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainProgress.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainProgress.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainProgress {
+    private HypeTrainLevel level;
+    private Integer value;
+    private Integer goal;
+    private Integer total;
+    private Integer remainingSeconds;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainReward.java
@@ -8,15 +8,11 @@ import lombok.Data;
 @Data
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class RaidUpdateOld {
+public class HypeTrainReward {
+    private String type;
     private String id;
-    private String creatorId;
-    private String sourceId;
-    private String targetId;
-    private String announceTime;
-    private String raidTime;
-    private Integer remainingDurationSeconds;
-    private Integer transitionJitterSeconds;
-    private Integer forceRaidNowSeconds;
-    private Integer viewerCount;
+    private String groupId;
+    private Integer rewardLevel;
+    private String setId;
+    private String token;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainRewardsData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainRewardsData.java
@@ -1,0 +1,27 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainRewardsData {
+    private String channelId;
+    private Integer completedLevel;
+    private List<Reward> rewards;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Reward {
+        private String type; // e.g. "EMOTE"
+        private String id;
+        private String groupId;
+        private Integer rewardLevel;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HypeTrainStart {
+    private String channelId;
+    private String id;
+    private HypeTrainConfig config;
+    private HypeTrainParticipations participations;
+    private HypeTrainProgress progress;
+    @JsonIgnore
+    private Instant startedAt;
+    @JsonIgnore
+    private Instant expiresAt;
+    @JsonIgnore
+    private Instant updatedAt;
+    // private Long ended_at;
+    // private String ending_reason;
+    // private Object conductors;
+
+    @JsonProperty("started_at")
+    private void unpackStartedAt(final Long startedAt) {
+        if (startedAt != null)
+            this.startedAt = Instant.ofEpochMilli(startedAt);
+    }
+
+    @JsonProperty("expires_at")
+    private void unpackExpiresAt(final Long expiresAt) {
+        if (expiresAt != null)
+            this.expiresAt = Instant.ofEpochMilli(expiresAt);
+    }
+
+    @JsonProperty("updated_at")
+    private void unpackUpdatedAt(final Long updatedAt) {
+        if (updatedAt != null)
+            this.updatedAt = Instant.ofEpochMilli(updatedAt);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
@@ -18,31 +16,7 @@ public class HypeTrainStart {
     private HypeTrainConfig config;
     private HypeTrainParticipations participations;
     private HypeTrainProgress progress;
-    @JsonIgnore
     private Instant startedAt;
-    @JsonIgnore
     private Instant expiresAt;
-    @JsonIgnore
     private Instant updatedAt;
-    // private Long ended_at;
-    // private String ending_reason;
-    // private Object conductors;
-
-    @JsonProperty("started_at")
-    private void unpackStartedAt(final Long startedAt) {
-        if (startedAt != null)
-            this.startedAt = Instant.ofEpochMilli(startedAt);
-    }
-
-    @JsonProperty("expires_at")
-    private void unpackExpiresAt(final Long expiresAt) {
-        if (expiresAt != null)
-            this.expiresAt = Instant.ofEpochMilli(expiresAt);
-    }
-
-    @JsonProperty("updated_at")
-    private void unpackUpdatedAt(final Long updatedAt) {
-        if (updatedAt != null)
-            this.updatedAt = Instant.ofEpochMilli(updatedAt);
-    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Leaderboard.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Leaderboard.java
@@ -1,0 +1,57 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Leaderboard {
+    private Identifier identifier;
+    private List<Entry> top;
+    private Context entryContext;
+    private Event event;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Identifier {
+        private String domain;
+        private String groupingKey;
+        private String timeAggregationUnit;
+        private String timeBucket;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Entry {
+        private Integer rank;
+        private Long score;
+        private String entryKey;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Context {
+        private Entry entry;
+        private List<Entry> context;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Event {
+        private String domain;
+        private String id;
+        private Long timeOfEvent;
+        private String groupingKey;
+        private String entryKey;
+        private Long eventValue;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/OnsiteNotification.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/OnsiteNotification.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OnsiteNotification {
+    private String userId;
+    private String id;
+    private String body;
+    private String bodyMd;
+    private String type; // e.g. "streamup"
+    private String renderStyle;
+    private String thumbnailUrl;
+    private List<Action> actions;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Boolean read;
+    private List<Creator> creators;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Action {
+        private String id;
+        private String type;
+        private String url;
+        private String modalId;
+        private String body;
+        private String label;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Creator {
+        private String userId;
+        private String userName;
+        private String thumbnailUrl;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PointsSpent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PointsSpent.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
@@ -13,14 +11,8 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PointsSpent {
-    @JsonIgnore
     private Instant timestamp;
     private Balance balance;
-
-    @JsonProperty("timestamp")
-    private void unpackTimestamp(final String timestamp) {
-        this.timestamp = Instant.parse(timestamp);
-    }
 
     @Data
     @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PointsSpent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PointsSpent.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PointsSpent {
+    @JsonIgnore
+    private Instant timestamp;
+    private Balance balance;
+
+    @JsonProperty("timestamp")
+    private void unpackTimestamp(final String timestamp) {
+        this.timestamp = Instant.parse(timestamp);
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Balance {
+        private String userId;
+        private String channelId;
+        private Long balance;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
@@ -1,0 +1,98 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PollData {
+    private String pollId;
+    private String ownedBy;
+    private String createdBy;
+    private String title;
+    private Instant startedAt;
+    private Instant endedAt;
+    private String endedBy;
+    private Long durationSeconds;
+    private PollSettings settings;
+    private Status status;
+    private List<PollChoice> choices;
+    private Votes votes;
+    private Tokens tokens;
+    private Integer totalVoters;
+    private Long remainingDurationMilliseconds;
+    private Contributor topContributor;
+    private Contributor topBitsContributor;
+    private Contributor topChannelPointsContributor;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PollSettings {
+        private Setting multiChoice;
+        private Setting subscriberOnly;
+        private Setting subscriberMultiplier;
+        private Setting bitsVotes;
+        private Setting channelPointsVotes;
+
+        @Data
+        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Setting {
+            private Boolean isEnabled;
+            private Long cost;
+        }
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PollChoice {
+        private String choiceId;
+        private String title;
+        private Votes votes;
+        private Tokens tokens;
+        private Integer totalVoters;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Votes {
+        private Long total;
+        private Long bits;
+        private Long channelPoints;
+        private Long base;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Tokens {
+        private Long bits;
+        private Long channelPoints;
+    }
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Contributor {
+        private String userId;
+        private String displayName;
+        private Long bitsContributed;
+        private Long channelPointsContributed;
+    }
+
+    @SuppressWarnings("unused")
+    public enum Status {
+        ACTIVE,
+        COMPLETED,
+        ARCHIVED
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceData.java
@@ -1,0 +1,43 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PresenceData {
+    private String userId;
+    private String userLogin;
+    /**
+     * User's availability. Examples include: "busy", "idle", "offline", "online"
+     */
+    private String availability;
+    private Integer index;
+    private Instant updatedAt;
+    private Activity activity;
+    private List<Activity> activities;
+
+    @Data
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Activity {
+        /**
+         * Activity Type. Examples include: "none", "watching", "broadcasting"
+         */
+        private String type;
+        private String channelId;
+        private String channelLogin;
+        private String channelDisplayName;
+        private String streamId;
+        private String gameId;
+        @JsonProperty("game")
+        private String gameName;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceSettings.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceSettings.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PresenceSettings {
+    private Boolean shareActivity;
+    private String availabilityOverride;
+    private Boolean isInvisible;
+    private String share;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidData.java
@@ -8,7 +8,7 @@ import lombok.Data;
 @Data
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class RaidUpdate {
+public class RaidData {
     private String id;
     private String creatorId;
     private String sourceId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidGo.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidGo.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RaidGo {
+    private String id;
+    private String creatorId;
+    private String sourceId;
+    private String targetId;
+    private String targetLogin;
+    private String targetDisplayName;
+    private String targetProfileImage;
+    private Integer transitionJitterSeconds;
+    private Integer forceRaidNowSeconds;
+    private Integer viewerCount;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidUpdate.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidUpdate.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RaidUpdate {
+    private String id;
+    private String creatorId;
+    private String sourceId;
+    private String targetId;
+    private String targetLogin;
+    private String targetDisplayName;
+    private String targetProfileImage;
+    private Integer transitionJitterSeconds;
+    private Integer forceRaidNowSeconds;
+    private Integer viewerCount;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidUpdateOld.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidUpdateOld.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RaidUpdateOld {
+    private String id;
+    private String creatorId;
+    private String sourceId;
+    private String targetId;
+    private String announceTime;
+    private String raidTime;
+    private Integer remainingDurationSeconds;
+    private Integer transitionJitterSeconds;
+    private Integer forceRaidNowSeconds;
+    private Integer viewerCount;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RedemptionProgress.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RedemptionProgress.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RedemptionProgress {
+    private String id;
+    private String channelId;
+    private String rewardId;
+    private String method;
+    private String newStatus;
+    private Integer processed;
+    private Integer total;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubGiftData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubGiftData.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SubGiftData {
+    private Integer count;
+    private SubscriptionPlan tier;
+    private String userId;
+    private String channelId;
+    private String uuid;
+    private String type;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubscriptionData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubscriptionData.java
@@ -89,6 +89,8 @@ public class SubscriptionData {
 
     /**
      * The id of the user that received the subscription
+     *
+     * @return the recipient id
      */
     public String getRecipientId() {
         return this.recipientId != null ? this.recipientId : this.userId;
@@ -96,6 +98,8 @@ public class SubscriptionData {
 
     /**
      * The login name of the user that received the subscription
+     *
+     * @return the recipient name
      */
     public String getRecipientUserName() {
         return this.recipientUserName != null ? this.recipientUserName : this.userName;
@@ -103,6 +107,8 @@ public class SubscriptionData {
 
     /**
      * The display name of the user that received the subscription
+     *
+     * @return the recipient display name
      */
     public String getRecipientDisplayName() {
         return this.recipientDisplayName != null ? this.recipientDisplayName : this.displayName;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/BitsLeaderboardEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/BitsLeaderboardEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.Leaderboard;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class BitsLeaderboardEvent extends LeaderboardEvent {
+    public BitsLeaderboardEvent(Leaderboard data) {
+        super(data);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelPointsUserEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelPointsUserEvent.java
@@ -1,12 +1,12 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidData;
+import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class RaidUpdateEvent extends TwitchEvent {
-    private final RaidData raid;
+public class ChannelPointsUserEvent extends TwitchEvent {
+    private final ChannelPointsEarned data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelSubGiftEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelSubGiftEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.SubGiftData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ChannelSubGiftEvent extends TwitchEvent {
+    private final SubGiftData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CheerbombEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CheerbombEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.CheerbombData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CheerbombEvent extends TwitchEvent {
+    private final String channelId;
+    private final CheerbombData cheerbomb;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ClaimAvailableEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ClaimAvailableEvent.java
@@ -1,12 +1,12 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
+import com.github.twitch4j.pubsub.domain.ClaimData;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class ChannelPointsUserEvent extends TwitchEvent {
-    private final ChannelPointsEarned data;
+public class ClaimAvailableEvent extends TwitchEvent {
+    private final ClaimData data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ClaimClaimedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ClaimClaimedEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ClaimData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ClaimClaimedEvent extends TwitchEvent {
+    private final ClaimData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardCreatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CustomRewardCreatedEvent extends CustomRewardEvent {
+    public CustomRewardCreatedEvent(Instant timestamp, ChannelPointsReward reward) {
+        super(timestamp, reward);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardDeletedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardDeletedEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CustomRewardDeletedEvent extends CustomRewardEvent {
+    public CustomRewardDeletedEvent(Instant timestamp, ChannelPointsReward reward) {
+        super(timestamp, reward);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.Instant;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public abstract class CustomRewardEvent extends TwitchEvent {
+    private final Instant timestamp;
+    private final ChannelPointsReward reward;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardUpdatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CustomRewardUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CustomRewardUpdatedEvent extends CustomRewardEvent {
+    public CustomRewardUpdatedEvent(Instant timestamp, ChannelPointsReward reward) {
+        super(timestamp, reward);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/FollowingEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/FollowingEvent.java
@@ -1,12 +1,13 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidUpdateOld;
+import com.github.twitch4j.pubsub.domain.FollowingData;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class RaidUpdateOldEvent extends TwitchEvent {
-    private final RaidUpdateOld raid;
+public class FollowingEvent extends TwitchEvent {
+    private final String channelId;
+    private final FollowingData data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/FriendshipEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/FriendshipEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.FriendshipData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class FriendshipEvent extends TwitchEvent {
+    private final FriendshipData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainConductorUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainConductorUpdateEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.HypeTrainConductor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class HypeTrainConductorUpdateEvent extends TwitchEvent {
+    private final String channelId;
+    private final HypeTrainConductor data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainCooldownExpirationEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainCooldownExpirationEvent.java
@@ -1,0 +1,11 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class HypeTrainCooldownExpirationEvent extends TwitchEvent {
+    private final String channelId;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainEndEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainEndEvent.java
@@ -1,12 +1,13 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidData;
+import com.github.twitch4j.pubsub.domain.HypeTrainEnd;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class RaidUpdateEvent extends TwitchEvent {
-    private final RaidData raid;
+public class HypeTrainEndEvent extends TwitchEvent {
+    private final String channelId;
+    private final HypeTrainEnd data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainLevelUpEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainLevelUpEvent.java
@@ -1,12 +1,13 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidData;
+import com.github.twitch4j.pubsub.domain.HypeLevelUp;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class RaidUpdateEvent extends TwitchEvent {
-    private final RaidData raid;
+public class HypeTrainLevelUpEvent extends TwitchEvent {
+    private final String channelId;
+    private final HypeLevelUp data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainProgressionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainProgressionEvent.java
@@ -1,12 +1,13 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidData;
+import com.github.twitch4j.pubsub.domain.HypeProgression;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class RaidUpdateEvent extends TwitchEvent {
-    private final RaidData raid;
+public class HypeTrainProgressionEvent extends TwitchEvent {
+    private final String channelId;
+    private final HypeProgression data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainRewardsEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainRewardsEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.HypeTrainRewardsData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class HypeTrainRewardsEvent extends TwitchEvent {
+    private final HypeTrainRewardsData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainStartEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainStartEvent.java
@@ -1,12 +1,12 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidData;
+import com.github.twitch4j.pubsub.domain.HypeTrainStart;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class RaidUpdateEvent extends TwitchEvent {
-    private final RaidData raid;
+public class HypeTrainStartEvent extends TwitchEvent {
+    private final HypeTrainStart data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/LeaderboardEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/LeaderboardEvent.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.Leaderboard;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public abstract class LeaderboardEvent extends TwitchEvent {
+    private final Leaderboard data;
+
+    public String getChannelId() {
+        return this.data.getIdentifier().getGroupingKey();
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/OnsiteNotificationCreationEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/OnsiteNotificationCreationEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.CreateNotificationData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class OnsiteNotificationCreationEvent extends TwitchEvent {
+    private final CreateNotificationData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PointsEarnedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PointsEarnedEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PointsEarnedEvent extends TwitchEvent {
+    private final ChannelPointsEarned data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PointsSpentEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PointsSpentEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PointsSpent;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PointsSpentEvent extends TwitchEvent {
+    private final PointsSpent data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PollsEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PollsEvent.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PollData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PollsEvent extends TwitchEvent {
+    private final EventType type;
+    private final PollData data;
+
+    public PollsEvent(String type, PollData data) {
+        this.type = EventType.MAPPINGS.get(type);
+        this.data = data;
+    }
+
+    public enum EventType {
+        POLL_CREATE,
+        POLL_UPDATE,
+        POLL_COMPLETE,
+        POLL_ARCHIVE,
+        POLL_TERMINATE;
+
+        private static final Map<String, EventType> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PresenceSettingsEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PresenceSettingsEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PresenceSettings;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PresenceSettingsEvent extends TwitchEvent {
+    private final String userId;
+    private final PresenceSettings data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidCancelEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidCancelEvent.java
@@ -15,6 +15,6 @@ import lombok.Setter;
 @Setter(AccessLevel.NONE)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class RaidUpdateEvent extends TwitchEvent {
+public class RaidCancelEvent extends TwitchEvent {
     private RaidData raid;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
@@ -1,12 +1,20 @@
 package com.github.twitch4j.pubsub.events;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.RaidData;
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RaidGoEvent extends TwitchEvent {
-    private final RaidData raid;
+    private RaidData raid;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.RaidGo;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RaidGoEvent extends TwitchEvent {
+    private final RaidGo raid;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
@@ -1,12 +1,12 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
-import com.github.twitch4j.pubsub.domain.RaidGo;
+import com.github.twitch4j.pubsub.domain.RaidData;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class RaidGoEvent extends TwitchEvent {
-    private final RaidGo raid;
+    private final RaidData raid;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.RaidUpdate;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RaidUpdateEvent extends TwitchEvent {
+    private final RaidUpdate raid;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidUpdateOldEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidUpdateOldEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.RaidUpdateOld;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RaidUpdateOldEvent extends TwitchEvent {
+    private final RaidUpdateOld raid;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/SubLeaderboardEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/SubLeaderboardEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.Leaderboard;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class SubLeaderboardEvent extends LeaderboardEvent {
+    public SubLeaderboardEvent(Leaderboard data) {
+        super(data);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateRedemptionFinishedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateRedemptionFinishedEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.RedemptionProgress;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class UpdateRedemptionFinishedEvent extends UpdateRedemptionStatusesEvent {
+    public UpdateRedemptionFinishedEvent(Instant timestamp, RedemptionProgress progress) {
+        super(timestamp, progress);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateRedemptionProgressEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateRedemptionProgressEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.RedemptionProgress;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class UpdateRedemptionProgressEvent extends UpdateRedemptionStatusesEvent {
+    public UpdateRedemptionProgressEvent(Instant timestamp, RedemptionProgress progress) {
+        super(timestamp, progress);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateRedemptionStatusesEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateRedemptionStatusesEvent.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.RedemptionProgress;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.Instant;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public abstract class UpdateRedemptionStatusesEvent extends TwitchEvent {
+    private final Instant timestamp;
+    private final RedemptionProgress progress;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPresenceEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPresenceEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PresenceData;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class UserPresenceEvent extends TwitchEvent {
+    private final PresenceData data;
+}

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeGameEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeGameEvent.java
@@ -25,6 +25,8 @@ public class ChannelChangeGameEvent extends TwitchEvent {
 
     /**
      * The new stream gameId
+     *
+     * @return id of the game
      */
     public String getGameId() {
         return stream.getGameId();

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeTitleEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeTitleEvent.java
@@ -25,6 +25,8 @@ public class ChannelChangeTitleEvent extends TwitchEvent {
 
     /**
      * The new stream title
+     *
+     * @return current title for the stream
      */
     public String getTitle() {
         return stream.getTitle();


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add LISTEN methods for a bunch of unofficial topics
* Implement `hype-train-events-v1` & `hype-train-events-v1.rewards`
* Implement `community-points-user-v1`
* Implement `raid`
* Implement `following`
* Implement `leaderboard-events-v1` (`bits-usage-by-channel-v1` & `sub-gifts-sent`)
* Implement `polls`
* Implement `friendship`
* Implement `presence`
* Implement `channel-sub-gifts-v1`
* Implement `channel-cheer-events-public-v1`
* Implement `onsite-notifications`
* Handle more message types under `community-points-channel-v1` that are not officially documented
* Improve thread-safety
 