### PR TITLE
ClientHelper: Use login and Stream in events, address potential thread contention

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/events/channel/ChannelChangeGameEvent.java
+++ b/common/src/main/java/com/github/twitch4j/common/events/channel/ChannelChangeGameEvent.java
@@ -12,6 +12,7 @@ import lombok.Value;
 @Value
 @Getter
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class ChannelChangeGameEvent extends TwitchEvent {
 
     /**

--- a/common/src/main/java/com/github/twitch4j/common/events/channel/ChannelChangeTitleEvent.java
+++ b/common/src/main/java/com/github/twitch4j/common/events/channel/ChannelChangeTitleEvent.java
@@ -12,6 +12,7 @@ import lombok.Value;
 @Value
 @Getter
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class ChannelChangeTitleEvent extends TwitchEvent {
 
     /**

--- a/common/src/main/java/com/github/twitch4j/common/events/channel/ChannelGoLiveEvent.java
+++ b/common/src/main/java/com/github/twitch4j/common/events/channel/ChannelGoLiveEvent.java
@@ -12,6 +12,7 @@ import lombok.Value;
 @Value
 @Getter
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class ChannelGoLiveEvent extends TwitchEvent {
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -216,8 +216,12 @@ public class TwitchClientHelper implements AutoCloseable {
                     if (currentChannelCache.getLastFollowCheck() != null) {
                         List<Follow> followList = commandGetFollowers.execute().getFollows();
                         EventChannel channel = null;
-                        if (!followList.isEmpty())
-                            channel = new EventChannel(channelId, followList.get(0).getToName());
+                        if (!followList.isEmpty()) {
+                            // Prefer login (even if old) to display_name https://github.com/twitchdev/issues/issues/3#issuecomment-562713594
+                            if (currentChannelCache.getUserName() == null)
+                                currentChannelCache.setUserName(followList.get(0).getToName());
+                            channel = new EventChannel(channelId, currentChannelCache.getUserName());
+                        }
                         for (Follow follow : followList) {
                             // update lastFollowDate
                             if (lastFollowDate == null || follow.getFollowedAt().compareTo(lastFollowDate) > 0) {

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeGameEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeGameEvent.java
@@ -26,6 +26,8 @@ public class ChannelChangeGameEvent extends TwitchEvent {
     /**
      * The new stream gameId
      */
-    String gameId = stream.getGameId();
+    public String getGameId() {
+        return stream.getGameId();
+    }
 
 }

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeGameEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeGameEvent.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.helix.domain.Stream;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+/**
+ * This event gets called when a channel changes the game
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChannelChangeGameEvent extends TwitchEvent {
+
+    /**
+     * The channel that changed their game
+     */
+    EventChannel channel;
+
+    /**
+     * The stream data
+     */
+    Stream stream;
+
+    /**
+     * The new stream gameId
+     */
+    String gameId = stream.getGameId();
+
+}

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeTitleEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeTitleEvent.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.helix.domain.Stream;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+/**
+ * This event gets called when a channel changes the title
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChannelChangeTitleEvent extends TwitchEvent {
+
+    /**
+     * The channel that changed their title
+     */
+    EventChannel channel;
+
+    /**
+     * The stream data
+     */
+    Stream stream;
+
+    /**
+     * The new stream title
+     */
+    String title = stream.getTitle();
+
+}

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeTitleEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelChangeTitleEvent.java
@@ -26,6 +26,8 @@ public class ChannelChangeTitleEvent extends TwitchEvent {
     /**
      * The new stream title
      */
-    String title = stream.getTitle();
+    public String getTitle() {
+        return stream.getTitle();
+    }
 
 }

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelGoLiveEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelGoLiveEvent.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.helix.domain.Stream;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+/**
+ * This event gets called when a channel goes live
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChannelGoLiveEvent extends TwitchEvent {
+
+    /**
+     * The channel that went live
+     */
+    EventChannel channel;
+
+    /**
+     * The stream data
+     */
+    Stream stream;
+
+}

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelGoOfflineEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelGoOfflineEvent.java
@@ -1,31 +1,20 @@
-package com.github.twitch4j.common.events.channel;
+package com.github.twitch4j.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 
 /**
  * This event gets called when a channel goes offline
  */
 @Value
-@Getter
 @EqualsAndHashCode(callSuper = false)
-@Deprecated
 public class ChannelGoOfflineEvent extends TwitchEvent {
 
     /**
-     * Channel
+     * The channel that went offline
      */
-    private final EventChannel channel;
+    EventChannel channel;
 
-    /**
-     * Event Constructor
-     *
-     * @param channel        The channel that went offline
-     */
-    public ChannelGoOfflineEvent(EventChannel channel) {
-        this.channel = channel;
-    }
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* Fixes #137 

### Changes Proposed
* Prefer `login` to `display_name` in EventChannel, even if out of date. (important for channels where the login differs from the display_name beyond capitalization)
* Create new stream status events that include the `Stream` object
* Deprecate the old stream status events
* Address potential thread contention issues with `startOrStopEventGenerationThread` by synchronizing and avoiding side-effects in AtomicReference updates

### Additional Information
Progress on the `display_name` vs. `login` helix inconsistency can be tracked here: https://github.com/twitchdev/issues/issues/3
