### PR TITLE
feat: implement proxy support

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -140,11 +140,6 @@ public class TwitchChat implements AutoCloseable {
     protected final long chatQueueTimeout;
 
     /**
-     * Proxy Configuration
-     */
-    protected final ProxyConfig proxyConfig;
-
-    /**
      * WebSocket Factory
      */
     protected final WebSocketFactory webSocketFactory;
@@ -174,7 +169,6 @@ public class TwitchChat implements AutoCloseable {
         this.whisperRateLimit = whisperRateLimit;
         this.taskExecutor = taskExecutor;
         this.chatQueueTimeout = chatQueueTimeout;
-        this.proxyConfig = proxyConfig;
 
         // Create WebSocketFactory and apply proxy settings
         this.webSocketFactory = new WebSocketFactory();

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.CredentialManagerBuilder;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.core.EventManager;
+import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.util.ThreadUtils;
 import io.github.bucket4j.Bandwidth;
@@ -18,7 +19,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 /**
  * Twitch Chat
- *
+ * <p>
  * Documentation: https://dev.twitch.tv/docs/irc
  */
 @Slf4j
@@ -99,7 +100,14 @@ public class TwitchChatBuilder {
     private long chatQueueTimeout = 1000L;
 
     /**
+     * Proxy Configuraiton
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
+
+    /**
      * Initialize the builder
+     *
      * @return Twitch Chat Builder
      */
     public static TwitchChatBuilder builder() {
@@ -108,21 +116,22 @@ public class TwitchChatBuilder {
 
     /**
      * Twitch API Client (Helix)
+     *
      * @return TwitchHelix
      */
     public TwitchChat build() {
         log.debug("TwitchChat: Initializing ErrorTracking ...");
 
-        if(scheduledThreadPoolExecutor == null)
+        if (scheduledThreadPoolExecutor == null)
             scheduledThreadPoolExecutor = ThreadUtils.getDefaultScheduledThreadPoolExecutor();
 
-        if(eventManager == null) {
+        if (eventManager == null) {
             eventManager = new EventManager();
             eventManager.autoDiscovery();
         }
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig);
     }
 
     /**

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,6 +10,9 @@ dependencies {
 	compileOnly group: 'io.github.openfeign', name: 'feign-slf4j'
 	compileOnly group: 'io.github.openfeign', name: 'feign-hystrix'
 
+	// Websocket (for common proxy settings)
+	api group: 'com.neovisionaries', name: 'nv-websocket-client'
+
 	// Twitch4J Modules
 	api project(':' + rootProject.name + '-auth')
 }

--- a/common/src/main/java/com/github/twitch4j/common/config/ProxyConfig.java
+++ b/common/src/main/java/com/github/twitch4j/common/config/ProxyConfig.java
@@ -1,0 +1,97 @@
+package com.github.twitch4j.common.config;
+
+import com.neovisionaries.ws.client.ProxySettings;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.SocketAddress;
+import java.util.Arrays;
+
+/**
+ * Wrapper around a HTTP(S) proxy to be used by Twitch4J modules
+ */
+@Data
+@Builder
+public class ProxyConfig {
+    /*
+     * Only HTTP(S) proxies are supported due to library limitations
+     */
+    private static final Proxy.Type TYPE = Proxy.Type.HTTP;
+
+    /**
+     * The hostname or IP address of the proxy server
+     */
+    @NonNull
+    private final String hostname;
+
+    /**
+     * The port of the proxy server
+     */
+    @NonNull
+    private final Integer port;
+
+    /**
+     * The username used to authenticate with the proxy, if applicable
+     */
+    private final String username;
+
+    /**
+     * The password used to authenticate with the proxy, if applicable
+     */
+    private final char[] password;
+
+    @Getter(lazy = true)
+    private final Proxy proxy = new Proxy(TYPE, buildAddress());
+
+    @Getter(lazy = true)
+    private final Authenticator authenticator = buildAuthenticator();
+
+    /**
+     * Applies this proxy configuration to an OkHttpClient
+     *
+     * @param builder the builder of the Http Client
+     */
+    public void apply(OkHttpClient.Builder builder) {
+        builder.proxy(getProxy()).proxyAuthenticator(getAuthenticator());
+    }
+
+    /**
+     * Applies this proxy configuration to a websocket factory's settings
+     *
+     * @param settings WebSocket's proxy settings
+     */
+    public void apply(ProxySettings settings) {
+        settings.setHost(this.hostname)
+            .setPort(this.port)
+            .setId(this.username)
+            .setPassword(password == null ? null : String.valueOf(this.password));
+    }
+
+    /**
+     * Clears the character array storing the proxy password.
+     * Call this method once the proxy is no longer in use to reduce the likelihood of the password being accessible in memory
+     */
+    public void clearPassword() {
+        Arrays.fill(this.password, '0');
+    }
+
+    private Authenticator buildAuthenticator() {
+        if (username == null && password == null)
+            return Authenticator.NONE;
+
+        return (route, response) -> response.request().newBuilder()
+            .header("Proxy-Authorization", Credentials.basic(username, String.valueOf(password)))
+            .build();
+    }
+
+    private SocketAddress buildAddress() {
+        return new InetSocketAddress(hostname, port);
+    }
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.graphql;
 
 import com.github.philippheuer.events4j.core.EventManager;
+import com.github.twitch4j.common.config.ProxyConfig;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +19,12 @@ public class TwitchGraphQLBuilder {
      */
     @With
     private EventManager eventManager = new EventManager();
+
+    /**
+     * Proxy Configuration
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
 
     /**
      * Client Id
@@ -58,7 +65,7 @@ public class TwitchGraphQLBuilder {
     public TwitchGraphQL build() {
         log.debug("GraphQL: Initializing Module ...");
         log.warn("GraphQL: GraphQL is a experimental module, please take care as some features might break unannounced.");
-        TwitchGraphQL client = new TwitchGraphQL(eventManager, clientId, clientSecret);
+        TwitchGraphQL client = new TwitchGraphQL(eventManager, clientId, clientSecret, proxyConfig);
 
         // register with serviceMediator
         this.eventManager.getServiceMediator().addService("twitch4j-graphql", client);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.pubsub;
 
 import com.github.philippheuer.events4j.core.EventManager;
+import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.ThreadUtils;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,14 @@ public class TwitchPubSubBuilder {
     private ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = null;
 
     /**
+     * Proxy Configuration
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
+
+    /**
      * Initialize the builder
+     *
      * @return Twitch Chat Builder
      */
     public static TwitchPubSubBuilder builder() {
@@ -38,19 +46,20 @@ public class TwitchPubSubBuilder {
 
     /**
      * Twitch API Client (Helix)
+     *
      * @return TwitchHelix
      */
     public TwitchPubSub build() {
         log.debug("PubSub: Initializing Module ...");
-        if(scheduledThreadPoolExecutor == null)
+        if (scheduledThreadPoolExecutor == null)
             scheduledThreadPoolExecutor = ThreadUtils.getDefaultScheduledThreadPoolExecutor();
 
-        if(eventManager == null) {
+        if (eventManager == null) {
             eventManager = new EventManager();
             eventManager.autoDiscovery();
         }
 
-        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor);
+        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig);
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.helix;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor;
 import com.netflix.config.ConfigurationManager;
@@ -68,6 +69,12 @@ public class TwitchHelixBuilder {
     private Integer timeout = 5000;
 
     /**
+     * Proxy Configuration
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Helix Builder
@@ -95,9 +102,14 @@ public class TwitchHelixBuilder {
         // - Modules
         mapper.findAndRegisterModules();
 
+        // Create HttpClient with proxy
+        okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();
+        if (proxyConfig != null)
+            proxyConfig.apply(clientBuilder);
+
         // Feign
         TwitchHelix client = HystrixFeign.builder()
-            .client(new OkHttpClient())
+            .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder(mapper))
             .decoder(new JacksonDecoder(mapper))
             .logger(new Logger.ErrorLogger())

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.kraken;
 
+import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.feign.interceptor.TwitchClientIdInterceptor;
 import com.netflix.config.ConfigurationManager;
@@ -57,6 +58,12 @@ public class TwitchKrakenBuilder {
     private Integer timeout = 5000;
 
     /**
+     * ProxyConfiguration
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Kraken Builder
@@ -79,9 +86,14 @@ public class TwitchKrakenBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Create HttpClient with proxy
+        okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();
+        if (proxyConfig != null)
+            proxyConfig.apply(clientBuilder);
+
         // Build
         TwitchKraken client = HystrixFeign.builder()
-            .client(new OkHttpClient())
+            .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder())
             .decoder(new JacksonDecoder())
             .logger(new Logger.ErrorLogger())

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.tmi;
 
+import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.feign.interceptor.TwitchClientIdInterceptor;
 import com.netflix.config.ConfigurationManager;
@@ -60,6 +61,12 @@ public class TwitchMessagingInterfaceBuilder {
     private Integer timeout = 5000;
 
     /**
+     * Proxy Configuration
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Helix Builder
@@ -82,9 +89,14 @@ public class TwitchMessagingInterfaceBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Create HttpClient with proxy
+        okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();
+        if (proxyConfig != null)
+            proxyConfig.apply(clientBuilder);
+
         // Build
         TwitchMessagingInterface client = HystrixFeign.builder()
-            .client(new OkHttpClient())
+            .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder())
             .decoder(new JacksonDecoder())
             .logger(new Logger.ErrorLogger())

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -7,6 +7,7 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.auth.TwitchAuth;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.TwitchChatBuilder;
+import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.util.ThreadUtils;
 import com.github.twitch4j.graphql.TwitchGraphQL;
@@ -169,6 +170,12 @@ public class TwitchClientBuilder {
     private OAuth2Credential defaultAuthToken = null;
 
     /**
+     * Proxy Configuration
+     */
+    @With
+    private ProxyConfig proxyConfig = null;
+
+    /**
      * With a CommandTrigger
      *
      * @param commandTrigger Command Trigger (Prefix)
@@ -219,6 +226,7 @@ public class TwitchClientBuilder {
                 .withDefaultAuthToken(defaultAuthToken)
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
+                .withProxyConfig(proxyConfig)
                 .build();
         }
 
@@ -231,6 +239,7 @@ public class TwitchClientBuilder {
                 .withUserAgent(userAgent)
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
+                .withProxyConfig(proxyConfig)
                 .build();
         }
 
@@ -243,6 +252,7 @@ public class TwitchClientBuilder {
                 .withUserAgent(userAgent)
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
+                .withProxyConfig(proxyConfig)
                 .build();
         }
 
@@ -258,6 +268,7 @@ public class TwitchClientBuilder {
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withChatQueueTimeout(chatQueueTimeout)
                 .withCommandTriggers(commandPrefixes)
+                .withProxyConfig(proxyConfig)
                 .build();
         }
 
@@ -267,6 +278,7 @@ public class TwitchClientBuilder {
             pubSub = TwitchPubSubBuilder.builder()
                 .withEventManager(eventManager)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
+                .withProxyConfig(proxyConfig)
                 .build();
         }
 
@@ -277,6 +289,7 @@ public class TwitchClientBuilder {
                 .withEventManager(eventManager)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
+                .withProxyConfig(proxyConfig)
                 .build();
         }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Create `ProxyConfig`
* Allow for its specification across the builders
* Use the settings in the various websockets/httpclients when supplied

### Additional Information
While regular HTTP proxies are supported, I've only had luck with HTTPS when trying to interact with twitch's APIs. Also, SOCKS(4/5) is not supported, as the websocket library does not seem compatible with them (and in my testing they weren't even working with the modules that use OkHttpClient)
