### PR TITLE
feat: expand sub handling to include multi-month gifts, paid upgrades, extensions, and anonymous variations. also fix Subscription deserialization

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.events.channel.*;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import com.github.twitch4j.common.events.user.PrivateMessageEvent;
@@ -175,6 +176,28 @@ public class IRCEventHandler {
 
                 // Dispatch Event
                 eventManager.publish(new GiftSubscriptionsEvent(channel, user != null ? user : ANONYMOUS_GIFTER, subPlan, subsGifted, subsGiftedTotal));
+            }
+            // Upgrading from a gifted sub
+            else if (msgId.equalsIgnoreCase("giftpaidupgrade") || msgId.equalsIgnoreCase("anongiftpaidupgrade")) {
+                // Load Info
+                EventUser user = event.getUser();
+                String promoName = event.getTagValue("msg-param-promo-name").orElse(null);
+                String giftTotalParam = event.getTags().get("msg-param-promo-gift-total");
+                Integer giftTotal = giftTotalParam != null ? Integer.parseInt(giftTotalParam) : null;
+                String senderLogin = event.getTagValue("msg-param-sender-login").orElse(null);
+                String senderName = event.getTagValue("msg-param-sender-name").orElse(null);
+
+                // Dispatch Event
+                eventManager.publish(new GiftSubUpgradeEvent(channel, user, promoName, giftTotal, senderLogin, senderName));
+            }
+            // Upgrading from a Prime sub to a normal one
+            else if (msgId.equalsIgnoreCase("primepaidupgrade")) {
+                // Load Info
+                EventUser user = event.getUser();
+                SubscriptionPlan subPlan = event.getTagValue("msg-param-sub-plan").map(SubscriptionPlan::fromString).orElse(null);
+
+                // Dispatch Event
+                eventManager.publish(new PrimeSubUpgradeEvent(channel, user, subPlan));
             }
         }
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -13,6 +13,9 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.github.twitch4j.common.util.TwitchUtils.ANONYMOUS_CHEERER;
+import static com.github.twitch4j.common.util.TwitchUtils.ANONYMOUS_GIFTER;
+
 /**
  * IRC Event Handler
  *
@@ -107,7 +110,7 @@ public class IRCEventHandler {
                 Integer bits = Integer.parseInt(event.getTags().get("bits"));
 
                 // Dispatch Event
-                eventManager.publish(new CheerEvent(channel, user, message, bits));
+                eventManager.publish(new CheerEvent(channel, user != null ? user : ANONYMOUS_CHEERER, message, bits));
             }
         }
     }
@@ -160,7 +163,7 @@ public class IRCEventHandler {
                 int giftMonths = giftMonthsParam != null ? Integer.parseInt(giftMonthsParam) : 1;
 
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy, 0, giftMonths));
+                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths));
             }
             // Gift X Subs
             else if (msgId.equalsIgnoreCase("submysterygift") || msgId.equalsIgnoreCase("anonsubmysterygift")) {
@@ -171,7 +174,7 @@ public class IRCEventHandler {
                 Integer subsGiftedTotal = (event.getTags().containsKey("msg-param-sender-count")) ? Integer.parseInt(event.getTags().get("msg-param-sender-count")) : 0;
 
                 // Dispatch Event
-                eventManager.publish(new GiftSubscriptionsEvent(channel, user, subPlan, subsGifted, subsGiftedTotal));
+                eventManager.publish(new GiftSubscriptionsEvent(channel, user != null ? user : ANONYMOUS_GIFTER, subPlan, subsGifted, subsGiftedTotal));
             }
         }
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -161,7 +161,7 @@ public class IRCEventHandler {
                 }
 
                 // Handle multi-month gifts
-                String giftMonthsParam = event.getTags().get("msg-params-gift-months");
+                String giftMonthsParam = event.getTags().get("msg-param-gift-months");
                 int giftMonths = giftMonthsParam != null ? Integer.parseInt(giftMonthsParam) : 1;
 
                 // Dispatch Event

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -10,6 +10,7 @@ import com.github.twitch4j.common.events.domain.EventUser;
 import com.github.twitch4j.common.events.user.PrivateMessageEvent;
 import lombok.Getter;
 
+import java.time.Month;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -198,6 +199,21 @@ public class IRCEventHandler {
 
                 // Dispatch Event
                 eventManager.publish(new PrimeSubUpgradeEvent(channel, user, subPlan));
+            }
+            // Extend Subscription
+            else if (msgId.equalsIgnoreCase("extendsub")) {
+                // Load Info
+                EventUser user = event.getUser();
+                SubscriptionPlan subPlan = event.getTagValue("msg-param-sub-plan").map(SubscriptionPlan::fromString).orElse(null);
+
+                String cumMonthsParam = event.getTags().get("msg-param-cumulative-months");
+                int cumulativeMonths = cumMonthsParam != null ? Math.max(Integer.parseInt(cumMonthsParam), 1) : 1;
+
+                String endMonthParam = event.getTags().get("msg-param-sub-benefit-end-month");
+                Month endMonth = endMonthParam != null ? Month.of(Integer.parseInt(endMonthParam)) : null;
+
+                // Dispatch Event
+                eventManager.publish(new ExtendSubscriptionEvent(channel, user, subPlan, cumulativeMonths, endMonth));
             }
         }
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ExtendSubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ExtendSubscriptionEvent.java
@@ -1,0 +1,58 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.events.domain.EventUser;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+
+import java.time.Month;
+
+/**
+ * Called when a user extends their existing subscription into a future month.
+ *
+ * @see <a href="https://discuss.dev.twitch.tv/t/ios-sub-tokens-launch/22794">Official Announcement</a>
+ */
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ExtendSubscriptionEvent extends AbstractChannelEvent {
+    /**
+     * The user extending their subscription.
+     */
+    EventUser user;
+
+    /**
+     * The type of subscription plan being used.
+     */
+    SubscriptionPlan subPlan;
+
+    /**
+     * The total number of months the user has subscribed.
+     */
+    int cumulativeMonths;
+
+    /**
+     * The new month that the subscription will end on.
+     */
+    Month benefitEndMonth;
+
+    /**
+     * Event Constructor
+     *
+     * @param channel          The channel that this event originates from.
+     * @param user             The user extending their subscription.
+     * @param subPlan          The type of subscription plan being used.
+     * @param cumulativeMonths The total number of months the user has subscribed.
+     * @param benefitEndMonth  The new month that the subscription will end on.
+     */
+    public ExtendSubscriptionEvent(EventChannel channel, EventUser user, SubscriptionPlan subPlan, int cumulativeMonths, Month benefitEndMonth) {
+        super(channel);
+        this.user = user;
+        this.subPlan = subPlan;
+        this.cumulativeMonths = cumulativeMonths;
+        this.benefitEndMonth = benefitEndMonth;
+    }
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubUpgradeEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubUpgradeEvent.java
@@ -1,0 +1,60 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.events.domain.EventUser;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+
+/**
+ * Called when a user upgrades to a paid subscription from previously being gifted a subscription.
+ */
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class GiftSubUpgradeEvent extends AbstractChannelEvent {
+    /**
+     * The user that is upgrading their subscription.
+     */
+    EventUser upgradingUser;
+
+    /**
+     * The subscriptions promo, if any, that is ongoing; e.g. Subtember 2018.
+     */
+    String promoName;
+
+    /**
+     * The number of gifts the gifter has given during the promo indicated by {@link #getPromoName()}.
+     */
+    Integer promoGiftTotal;
+
+    /**
+     * The login of the user who gifted the subscription, if applicable.
+     */
+    String gifterLogin;
+
+    /**
+     * The display name of the user who gifted the subscription, if applicable.
+     */
+    String gifterName;
+
+    /**
+     * Constructor
+     *
+     * @param channel        the channel where the event took place
+     * @param upgradingUser  the user that is upgrading their subscription
+     * @param promoName      the ongoing subscriptions promo, if applicable
+     * @param promoGiftTotal the number of gifts the gifter has given during the promo
+     * @param gifterLogin    the login of the user who gifted the subscription, if applicable
+     * @param gifterName     the display name of the user who gifted the subscription, if applicable
+     */
+    public GiftSubUpgradeEvent(EventChannel channel, EventUser upgradingUser, String promoName, Integer promoGiftTotal, String gifterLogin, String gifterName) {
+        super(channel);
+        this.upgradingUser = upgradingUser;
+        this.promoName = promoName;
+        this.promoGiftTotal = promoGiftTotal;
+        this.gifterLogin = gifterLogin;
+        this.gifterName = gifterName;
+    }
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/PrimeSubUpgradeEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/PrimeSubUpgradeEvent.java
@@ -1,0 +1,40 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.events.domain.EventUser;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+
+/**
+ * Called when a user upgrades from a prime sub to a tiered subscription.
+ */
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class PrimeSubUpgradeEvent extends AbstractChannelEvent {
+    /**
+     * The user that is upgrading their subscription.
+     */
+    EventUser user;
+
+    /**
+     * The new subscription plan of the user.
+     */
+    SubscriptionPlan subscriptionPlan;
+
+    /**
+     * Constructor
+     *
+     * @param channel          the channel where the event took place
+     * @param user             the user that is upgrading their subscription
+     * @param subscriptionPlan the new subscription plan of the user
+     */
+    public PrimeSubUpgradeEvent(EventChannel channel, EventUser user, SubscriptionPlan subscriptionPlan) {
+        super(channel);
+        this.user = user;
+        this.subscriptionPlan = subscriptionPlan;
+    }
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/PrimeSubUpgradeEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/PrimeSubUpgradeEvent.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -14,6 +15,7 @@ import lombok.Value;
 @Value
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Unofficial
 public class PrimeSubUpgradeEvent extends AbstractChannelEvent {
     /**
      * The user that is upgrading their subscription.

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.chat.events.channel;
 
-import com.github.twitch4j.chat.enums.SubscriptionPlan;
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
@@ -21,71 +21,86 @@ import java.util.Optional;
 @EqualsAndHashCode(callSuper = false)
 public class SubscriptionEvent extends AbstractChannelEvent {
 
-	/**
-	 * Event Target User
-	 */
-	private EventUser user;
+    /**
+     * Event Target User
+     */
+    EventUser user;
 
-	/**
-	 * Subscription Plan
-	 */
-    private String subscriptionPlan;
+    /**
+     * Subscription Plan
+     */
+    String subscriptionPlan;
 
-	/**
-	 * Subscription Message
-	 */
-	private Optional<String> message;
+    /**
+     * Subscription Plan, in enum form
+     */
+    @Getter(lazy = true)
+    SubscriptionPlan subPlan = SubscriptionPlan.fromString(subscriptionPlan);
 
-	/**
-	 * Cumulative months subscribed
-	 */
-	private Integer months;
+    /**
+     * Subscription Message
+     */
+    Optional<String> message;
 
-	/**
-	 * Was this sub gifted?
-	 */
-	private Boolean gifted;
+    /**
+     * Cumulative months subscribed
+     */
+    Integer months;
 
-	/**
-	 * User that gifted the sub
-	 */
-	private EventUser giftedBy;
-        
-        
-        /**
-         * Consecutive months subscribed
-         */
-        private Integer subStreak;
+    /**
+     * Was this sub gifted?
+     */
+    Boolean gifted;
+
+    /**
+     * User that gifted the sub
+     */
+    EventUser giftedBy;
+
+    /**
+     * Consecutive months subscribed
+     */
+    Integer subStreak;
+
+    /**
+     * The number of months gifted as part of a single, multi-month gift
+     */
+    Integer giftMonths;
 
     /**
      * Event Constructor
      *
-     * @param channel ChatChannel the user subscribed to
-     * @param user User that subscribed
-     * @param subPlan Sub Plan
-     * @param message Sub Message
-     * @param months Cumulative number of months user has been subscribed (not consecutive)
-     * @param gifted Is gifted?
-     * @param giftedBy User that gifted the sub
-     * @param subStreak Consecutive number of months user has been subscribed (not cumulative); 0 if no streak or user chooses not to share their streak
+     * @param channel    ChatChannel the user subscribed to
+     * @param user       User that subscribed
+     * @param subPlan    Sub Plan
+     * @param message    Sub Message
+     * @param months     Cumulative number of months user has been subscribed (not consecutive)
+     * @param gifted     Is gifted?
+     * @param giftedBy   User that gifted the sub
+     * @param subStreak  Consecutive number of months user has been subscribed (not cumulative); 0 if no streak or user chooses not to share their streak
+     * @param giftMonths The number of months gifted as part of a single, multi-month gift
      */
-	public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak) {
-		super(channel);
-		this.user = user;
-		this.subscriptionPlan = subPlan;
-		this.message = message;
-		this.months = months;
-		this.gifted = gifted;
-		this.giftedBy = giftedBy;
-                this.subStreak = subStreak;
-	}
+    public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths) {
+        super(channel);
+        this.user = user;
+        this.subscriptionPlan = subPlan;
+        this.message = message;
+        this.months = months;
+        this.gifted = gifted;
+        this.giftedBy = giftedBy;
+        this.subStreak = subStreak;
+        this.giftMonths = giftMonths;
+    }
 
     /**
      * Gets the Subscription Plan
+     *
      * @return SubscriptionPlan
+     * @deprecated will be removed in favor of .getSubPlan()
      */
-	public SubscriptionPlan getSubscriptionPlanName() {
-        return SubscriptionPlan.fromString(this.subscriptionPlan);
+    @Deprecated
+    public com.github.twitch4j.chat.enums.SubscriptionPlan getSubscriptionPlanName() {
+        return com.github.twitch4j.chat.enums.SubscriptionPlan.fromString(this.subscriptionPlan);
     }
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/enums/SubscriptionType.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/SubscriptionType.java
@@ -11,7 +11,9 @@ public enum SubscriptionType {
     SUB,
     RESUB,
     SUB_GIFT,
-    ANON_SUB_GIFT;
+    ANON_SUB_GIFT,
+    RESUB_GIFT,
+    ANON_RESUB_GIFT;
 
     @Getter
     @Accessors(fluent = true)

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -1,11 +1,24 @@
 package com.github.twitch4j.common.util;
 
 import com.github.twitch4j.common.enums.CommandPermission;
+import com.github.twitch4j.common.events.domain.EventUser;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 
 public class TwitchUtils {
+
+    /**
+     * The account used by twitch to signify an anonymous subscription gifter
+     *
+     * @see <a href="https://discuss.dev.twitch.tv/t/anonymous-sub-gifting-to-launch-11-15-launch-details/18683">Official Announcement</a>
+     */
+    public static final EventUser ANONYMOUS_GIFTER = new EventUser("274598607", "AnAnonymousGifter");
+
+    /**
+     * The account used by twitch to signify an anonymous cheerer
+     */
+    public static final EventUser ANONYMOUS_CHEERER = new EventUser("407665396", "AnAnonymousCheerer");
 
     public static Set<CommandPermission> getPermissionsFromTags(Map<String, Object> tags) {
         Set<CommandPermission> permissionSet = EnumSet.of(CommandPermission.EVERYONE);

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -13,12 +13,12 @@ public class TwitchUtils {
      *
      * @see <a href="https://discuss.dev.twitch.tv/t/anonymous-sub-gifting-to-launch-11-15-launch-details/18683">Official Announcement</a>
      */
-    public static final EventUser ANONYMOUS_GIFTER = new EventUser("274598607", "AnAnonymousGifter");
+    public static final EventUser ANONYMOUS_GIFTER = new EventUser("274598607", "ananonymousgifter");
 
     /**
      * The account used by twitch to signify an anonymous cheerer
      */
-    public static final EventUser ANONYMOUS_CHEERER = new EventUser("407665396", "AnAnonymousCheerer");
+    public static final EventUser ANONYMOUS_CHEERER = new EventUser("407665396", "ananonymouscheerer");
 
     public static Set<CommandPermission> getPermissionsFromTags(Map<String, Object> tags) {
         Set<CommandPermission> permissionSet = EnumSet.of(CommandPermission.EVERYONE);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubscriptionData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubscriptionData.java
@@ -77,6 +77,16 @@ public class SubscriptionData {
     private SubscriptionType context;
 
     /**
+     * Whether this sub message was caused by a gift subscription
+     */
+    private Boolean isGift;
+
+    /**
+     * Number of months gifted as part of a single, multi-month gift
+     */
+    private Integer multiMonthDuration;
+
+    /**
      * The accompanying message when the subscription was shared
      */
     private CommerceMessage subMessage;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -50,6 +51,7 @@ public class Subscription {
      * @deprecated will be removed in favor of .getPlanName()
      */
     @Deprecated
+    @JsonIgnore
     public String getPlan_name() {
         return this.planName;
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Handle multi-month sub gifts in pubsub
* Handle multi-month sub gifts in chat
* Handle `anonsubgift` & `anonsubmysterygift`
* Handle `giftpaidupgrade` & `anongiftpaidupgrade`
* Handle `primepaidupgrade`
* Handle `extendsub`
* Fix (de)serialization of `Subscription`

### Additional Information
Announcement for multi-month gifts: https://discuss.dev.twitch.tv/t/updates-to-pubsub-messages-and-irc-for-multi-month-subscription-gifting/26873
