### PR TITLE
feat: implement video-playback topic, handle update-summary, allow leaderboard time spec, add another listen method

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -465,6 +465,10 @@ public class TwitchPubSub implements AutoCloseable {
                             } else if (topic.startsWith("onsite-notifications")) {
                                 if ("create-notification".equalsIgnoreCase(type)) {
                                     eventManager.publish(new OnsiteNotificationCreationEvent(TypeConvert.convertValue(msgData, CreateNotificationData.class)));
+                                } else if ("update-summary".equalsIgnoreCase(type)) {
+                                    String id = topic.substring(topic.indexOf('.') + 1);
+                                    UpdateSummaryData data = TypeConvert.convertValue(msgData, UpdateSummaryData.class);
+                                    eventManager.publish(new UpdateOnsiteNotificationSummaryEvent(id, data));
                                 } else {
                                     log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                                 }
@@ -744,7 +748,17 @@ public class TwitchPubSub implements AutoCloseable {
 
     @Unofficial
     public PubSubSubscription listenForChannelBitsLeaderboardEvents(OAuth2Credential credential, String channelId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-WEEK");
+        return listenForChannelBitsLeaderboardEvents(credential, channelId, "WEEK");
+    }
+
+    @Unofficial
+    public PubSubSubscription listenForChannelBitsLeaderboardMonthlyEvents(OAuth2Credential credential, String channelId) {
+        return listenForChannelBitsLeaderboardEvents(credential, channelId, "MONTH");
+    }
+
+    @Unofficial
+    private PubSubSubscription listenForChannelBitsLeaderboardEvents(OAuth2Credential credential, String channelId, String timeAggregationUnit) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-" + timeAggregationUnit);
     }
 
     @Unofficial
@@ -755,12 +769,37 @@ public class TwitchPubSub implements AutoCloseable {
 
     @Unofficial
     public PubSubSubscription listenForChannelSubLeaderboardEvents(OAuth2Credential credential, String channelId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.sub-gift-sent-" + channelId + "-WEEK");
+        return listenForChannelSubLeaderboardEvents(credential, channelId, "WEEK");
+    }
+
+    @Unofficial
+    public PubSubSubscription listenForChannelSubLeaderboardMonthlyEvents(OAuth2Credential credential, String channelId) {
+        return listenForChannelSubLeaderboardEvents(credential, channelId, "MONTH");
+    }
+
+    @Unofficial
+    private PubSubSubscription listenForChannelSubLeaderboardEvents(OAuth2Credential credential, String channelId, String timeAggregationUnit) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.sub-gift-sent-" + channelId + "-" + timeAggregationUnit);
     }
 
     @Unofficial
     public PubSubSubscription listenForLeaderboardEvents(OAuth2Credential credential, String channelId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-WEEK", "leaderboard-events-v1.sub-gift-sent-" + channelId + "-WEEK");
+        return listenForLeaderboardEvents(credential, channelId, "WEEK");
+    }
+
+    @Unofficial
+    public PubSubSubscription listenForLeaderboardMonthlyEvents(OAuth2Credential credential, String channelId) {
+        return listenForLeaderboardEvents(credential, channelId, "MONTH");
+    }
+
+    @Unofficial
+    private PubSubSubscription listenForLeaderboardEvents(OAuth2Credential credential, String channelId, String timeAggregationUnit) {
+        return listenOnTopic(
+            PubSubType.LISTEN,
+            credential,
+            "leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-" + timeAggregationUnit,
+            "leaderboard-events-v1.sub-gift-sent-" + channelId + "-" + timeAggregationUnit
+        );
     }
 
     @Unofficial
@@ -811,6 +850,12 @@ public class TwitchPubSub implements AutoCloseable {
     @Deprecated
     public PubSubSubscription listenForCelebrationEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "celebration-events-v1." + channelId);
+    }
+
+    @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForPublicBitEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-bit-events-public." + channelId);
     }
 
     @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -468,6 +468,12 @@ public class TwitchPubSub implements AutoCloseable {
                                 } else {
                                     log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                                 }
+                            } else if (topic.startsWith("video-playback")) {
+                                int dot = topic.indexOf('.');
+                                String channel = topic.substring(dot + 1);
+                                boolean hasId = topic.charAt(dot - 1) == 'd';
+                                VideoPlaybackData data = TypeConvert.jsonToObject(rawMessage, VideoPlaybackData.class);
+                                eventManager.publish(new VideoPlaybackEvent(hasId ? channel : null, hasId ? null : channel, data));
                             } else {
                                 log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                             }
@@ -899,9 +905,13 @@ public class TwitchPubSub implements AutoCloseable {
     }
 
     @Unofficial
-    @Deprecated
     public PubSubSubscription listenForVideoPlaybackEvents(OAuth2Credential credential, String channelId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "video-playback." + channelId);
+        return listenOnTopic(PubSubType.LISTEN, credential, "video-playback-by-id." + channelId);
+    }
+
+    @Unofficial
+    public PubSubSubscription listenForVideoPlaybackByNameEvents(OAuth2Credential credential, String channelName) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "video-playback." + channelName.toLowerCase());
     }
 
     @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/NotificationSummary.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/NotificationSummary.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NotificationSummary {
+    private Integer unseenViewCount;
+    private Instant lastSeenAt;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdateSummaryData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdateSummaryData.java
@@ -5,9 +5,6 @@ import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class CreateNotificationData {
+public class UpdateSummaryData {
     private NotificationSummary summary;
-    private OnsiteNotification notification;
-    private Boolean persistent;
-    private Boolean toast;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -1,0 +1,63 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VideoPlaybackData {
+    /**
+     * The type of the video playback event.
+     */
+    private Type type;
+
+    /**
+     * Always sent. May have a fractional part.
+     */
+    private String serverTime;
+
+    /**
+     * Sent when {@link #getType()} is {@link Type#STREAM_UP}.
+     */
+    private Integer playDelay;
+
+    /**
+     * Sent when {@link #getType()} is {@link Type#VIEW_COUNT}.
+     */
+    private Integer viewCount;
+
+    /**
+     * Sent when {@link #getType()} is {@link Type#COMMERCIAL}.
+     */
+    private Integer length;
+
+    @RequiredArgsConstructor
+    public enum Type {
+        COMMERCIAL("commercial"),
+        STREAM_DOWN("stream-down"),
+        STREAM_UP("stream-up"),
+        VIEW_COUNT("viewcount");
+
+        private final String type;
+
+        @Override
+        public String toString() {
+            return this.type;
+        }
+
+        @JsonCreator
+        public static Type fromString(String type) {
+            for (Type t : Type.values()) {
+                if (t.type.equalsIgnoreCase(type))
+                    return t;
+            }
+
+            return null;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateOnsiteNotificationSummaryEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UpdateOnsiteNotificationSummaryEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.UpdateSummaryData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UpdateOnsiteNotificationSummaryEvent extends TwitchEvent {
+    String userId;
+    UpdateSummaryData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/VideoPlaybackEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/VideoPlaybackEvent.java
@@ -1,0 +1,21 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.pubsub.domain.VideoPlaybackData;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class VideoPlaybackEvent extends TwitchEvent {
+    String channelId;
+    String channelName;
+    @NonNull
+    VideoPlaybackData data;
+
+    public EventChannel getChannel() {
+        return new EventChannel(channelId, channelName);
+    }
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Implement `video-playback` / `video-playback-by-id`
* Handle `update-summary` of `onsite-notifications`
* Allow for `timeAggregationUnit` to be specified for leaderboard events
* Add listen method for `channel-bit-events-public`
