### PR TITLE
feat: allow twitch chat websocket url to be configured

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -65,6 +65,22 @@ public class TwitchChatBuilder {
     private OAuth2Credential chatAccount;
 
     /**
+     * A custom websocket url for {@link TwitchChat} to connect to.
+     * Must include the scheme (e.g. ws:// or wss://).
+     */
+    @With
+    private String baseUrl = TwitchChat.TWITCH_WEB_SOCKET_SERVER;
+
+    /**
+     * Whether the {@link OAuth2Credential} password should be sent when the baseUrl does not
+     * match the official twitch websocket server, thus bypassing a security check in the library.
+     * <p>
+     * Do not depart from the default false value unless you understand the consequences.
+     */
+    @With
+    private boolean sendCredentialToThirdPartyHost = false;
+
+    /**
      * IRC Command Handlers
      */
     protected final List<String> commandPrefixes = new ArrayList<>();
@@ -131,7 +147,7 @@ public class TwitchChatBuilder {
         }
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig);
     }
 
     /**

--- a/common/src/main/java/com/github/twitch4j/common/config/ProxyConfig.java
+++ b/common/src/main/java/com/github/twitch4j/common/config/ProxyConfig.java
@@ -67,7 +67,7 @@ public class ProxyConfig {
      *
      * @param settings WebSocket's proxy settings
      */
-    public void apply(ProxySettings settings) {
+    public void applyWs(ProxySettings settings) {
         settings.setHost(this.hostname)
             .setPort(this.port)
             .setId(this.username)

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -135,7 +135,7 @@ public class TwitchPubSub implements AutoCloseable {
         // WebSocket Factory and proxy settings
         this.webSocketFactory = new WebSocketFactory();
         if (proxyConfig != null)
-            proxyConfig.apply(webSocketFactory.getProxySettings());
+            proxyConfig.applyWs(webSocketFactory.getProxySettings());
 
         // connect
         this.connect();


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* TwitchChat: Allow `baseUrl` to be set
* TwitchChat: Do not send the actual oauth password when the `baseUrl` does not correspond to twitch's official URL... unless `sendCredentialToThirdPartyHost` is set to `true`.

### Additional Information 
This adds support for development tools such as [fdgt](https://github.com/fdgt-apis/api) or even a irc-ws proxy for forwarding to twitch.

### Issues Fixed (Secondary)
* `TwitchChat#timeout(String, String, Duration, String)` was missing a space between the target name and the duration in the command string
* [Build error](https://gitlab.com/twitch4j/twitch4j/-/jobs/631961846) from the interaction of `compileOnly` and two methods with the same name (`ProxyConfig#apply`)
