### PR TITLE
refactor: avoid eating a whole thread for each pubsub connection

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -39,21 +39,21 @@ public class TwitchPubSubBuilder {
     /**
      * Initialize the builder
      *
-     * @return Twitch Chat Builder
+     * @return Twitch PubSub Builder
      */
     public static TwitchPubSubBuilder builder() {
         return new TwitchPubSubBuilder();
     }
 
     /**
-     * Twitch API Client (Helix)
+     * Twitch PubSub Client
      *
-     * @return TwitchHelix
+     * @return TwitchPubSub
      */
     public TwitchPubSub build() {
         log.debug("PubSub: Initializing Module ...");
         if (scheduledThreadPoolExecutor == null)
-            scheduledThreadPoolExecutor = ThreadUtils.getDefaultScheduledThreadPoolExecutor("twitch4j-pubsub-"+ RandomStringUtils.random(4, true, true), TwitchPubSub.REQUIRED_THREAD_COUNT);
+            scheduledThreadPoolExecutor = ThreadUtils.getDefaultScheduledThreadPoolExecutor("twitch4j-pubsub-" + RandomStringUtils.random(4, true, true), TwitchPubSub.REQUIRED_THREAD_COUNT);
 
         if (eventManager == null) {
             eventManager = new EventManager();

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -29,7 +29,7 @@ public class VideoPlaybackData {
     /**
      * Sent when {@link #getType()} is {@link Type#VIEW_COUNT}.
      */
-    private Integer viewCount;
+    private Integer viewers;
 
     /**
      * Sent when {@link #getType()} is {@link Type#COMMERCIAL}.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Work towards modules misbehaving if the processor has a low core count

### Changes Proposed
#### Primary
* Instead of creating a dedicated thread in each pubsub instance, schedule a repeating task to flush the command queue (2.5 seconds between execution)
* Upon a request (e.g. LISTEN), schedule a task 50ms later for expedited flushing (& only allow one such task to be queued at a time)

#### Secondary
* Fix some docs in the builder
* Fix incorrect field name in `VideoPlaybackData` (no deprecation as this topic is unofficial)
