### PR TITLE
feat: add helpers for unofficial flags tag in chat messages

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -1,6 +1,9 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.TwitchEvent;
+import com.github.twitch4j.chat.flag.AutoModFlag;
+import com.github.twitch4j.chat.flag.FlagParser;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -65,6 +68,13 @@ public class IRCMessageEvent extends TwitchEvent {
 	 * Client Permissions
 	 */
 	private final Set<CommandPermission> clientPermissions = EnumSet.noneOf(CommandPermission.class);
+
+    /**
+     * AutoMod Message Flag Indicators, relevant for PRIVMSG and USERNOTICE
+     */
+    @Unofficial
+    @Getter(lazy = true)
+    private final List<AutoModFlag> flags = FlagParser.parseFlags(this);
 
 	/**
 	 * RAW Message

--- a/chat/src/main/java/com/github/twitch4j/chat/flag/AutoModFlag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/flag/AutoModFlag.java
@@ -1,0 +1,36 @@
+package com.github.twitch4j.chat.flag;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * Represents a region of a chat message that was flagged by AutoMod.
+ */
+@Value
+@Builder
+@Unofficial
+public class AutoModFlag {
+    /**
+     * The index in the message where the flagged item starts.
+     */
+    int startIndex;
+
+    /**
+     * The index where the flagged item ends.
+     */
+    int endIndex;
+
+    /**
+     * Scores for the various {@link FlagType}s for this region of the message.
+     * <p>
+     * Can be empty, for example, if the region is a HTTP(S) link.
+     */
+    @NotNull
+    @Singular
+    Map<FlagType, Integer> scores;
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/flag/FlagParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/flag/FlagParser.java
@@ -1,0 +1,57 @@
+package com.github.twitch4j.chat.flag;
+
+import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@UtilityClass
+public class FlagParser {
+
+    private final String IRC_TAG_NAME = "flags";
+
+    @NonNull
+    public List<AutoModFlag> parseFlags(@NonNull String rawFlags) {
+        final String[] splitFlags = rawFlags.split(",");
+        final List<AutoModFlag> flags = new ArrayList<>(splitFlags.length);
+
+        for (String rawFlag : splitFlags) {
+            String[] parts = rawFlag.split(":", -1);
+            if (parts.length != 2)
+                continue;
+
+            String[] indices = parts[0].split("-");
+            if (indices.length != 2)
+                continue;
+            int start = Integer.parseInt(indices[0]);
+            int end = Integer.parseInt(indices[1]);
+
+            AutoModFlag.AutoModFlagBuilder builder = AutoModFlag.builder()
+                .startIndex(start)
+                .endIndex(end);
+
+            String[] scores = parts[1].split("/");
+            for (String score : scores) {
+                String[] scoreParts = score.split("\\.");
+                if (scoreParts.length != 2)
+                    continue;
+                FlagType type = FlagType.parse(scoreParts[0]);
+                if (type != null)
+                    builder.score(type, Integer.parseInt(scoreParts[1]));
+            }
+
+            flags.add(builder.build());
+        }
+
+        return Collections.unmodifiableList(flags);
+    }
+
+    @NonNull
+    public List<AutoModFlag> parseFlags(@NonNull IRCMessageEvent event) {
+        return event.getTagValue(IRC_TAG_NAME).map(FlagParser::parseFlags).orElse(Collections.emptyList());
+    }
+
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/flag/FlagType.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/flag/FlagType.java
@@ -1,0 +1,45 @@
+package com.github.twitch4j.chat.flag;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The AutoMod moderation categories.
+ *
+ * @see <a href="https://help.twitch.tv/s/article/how-to-use-automod">Official documentation</a>
+ */
+@RequiredArgsConstructor
+public enum FlagType {
+    /**
+     * Identity language - Words referring to race, religion, gender, orientation, disability, or similar. Hate speech falls under this category.
+     */
+    IDENTITY('I'),
+    /**
+     * Sexually explicit language - Words or phrases referring to sexual acts, sexual content, and body parts.
+     */
+    SEXUAL('S'),
+    /**
+     * Aggressive language - Hostility towards other people, often associated with bullying.
+     */
+    AGGRESSIVE('A'),
+    /**
+     * Profanity - Expletives, curse words, and vulgarity. This filter especially helps those who wish to keep their community family-friendly.
+     */
+    PROFANITY('P');
+
+    final char code;
+
+    private static final FlagType[] VALUES = values();
+
+    public static FlagType parse(final String string) {
+        if (string == null || string.length() != 1)
+            return null;
+
+        final char match = string.charAt(0);
+        for (FlagType type : VALUES) {
+            if (type.code == match)
+                return type;
+        }
+
+        return null;
+    }
+}

--- a/chat/src/test/java/com/github/twitch4j/chat/flag/FlagParserTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/flag/FlagParserTest.java
@@ -1,0 +1,112 @@
+package com.github.twitch4j.chat.flag;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static com.github.twitch4j.chat.flag.FlagParser.parseFlags;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+@Tag("integration")
+public class FlagParserTest {
+
+    @Test
+    @DisplayName("No flags in an empty string")
+    public void testEmpty() {
+        assertTrue(parseFlags("").isEmpty());
+    }
+
+    @Test
+    @DisplayName("Single flag with empty score")
+    public void singleEmpty() {
+        assertEquals(
+            Collections.singletonList(AutoModFlag.builder().startIndex(69).endIndex(420).build()),
+            parseFlags("69-420:")
+        );
+    }
+
+    @Test
+    @DisplayName("Single flag with an empty score and actual score")
+    public void singleEmptyAndScored() {
+        assertEquals(
+            Collections.singletonList(AutoModFlag.builder().startIndex(69).endIndex(420).score(FlagType.SEXUAL, 6).build()),
+            parseFlags("69-420:/S.6") // Note: this is a hypothetical edge case
+        );
+    }
+
+    @Test
+    @DisplayName("Multiple flags with no scores")
+    public void multipleEmpty() {
+        assertEquals(
+            Arrays.asList(
+                AutoModFlag.builder().startIndex(69).endIndex(420).build(),
+                AutoModFlag.builder().startIndex(1337).endIndex(1338).build()
+            ),
+            parseFlags("69-420:,1337-1338:")
+        );
+    }
+
+    @Test
+    @DisplayName("Multiple flags with scores ranging from empty to multiple")
+    public void multipleEmptyAndScored() {
+        assertEquals(
+            Arrays.asList(
+                AutoModFlag.builder().startIndex(69).endIndex(420).build(),
+                AutoModFlag.builder().startIndex(500).endIndex(501).build(),
+                AutoModFlag.builder().startIndex(665).endIndex(667).score(FlagType.IDENTITY, 2).build(),
+                AutoModFlag.builder().startIndex(1337).endIndex(1338).score(FlagType.AGGRESSIVE, 3).score(FlagType.SEXUAL, 4).build()
+            ),
+            parseFlags("69-420:,500-501:,665-667:I.2,1337-1338:A.3/S.4")
+        );
+    }
+
+    @Test
+    @DisplayName("A single flag and single score")
+    public void singleFlagSingleScore() {
+        assertEquals(
+            Collections.singletonList(AutoModFlag.builder().startIndex(54).endIndex(60).score(FlagType.PROFANITY, 6).build()),
+            parseFlags("54-60:P.6")
+        );
+    }
+
+    @Test
+    @DisplayName("A single flag with multiple scores")
+    public void singleFlagMultiScore() {
+        assertEquals(
+            Collections.singletonList(AutoModFlag.builder().startIndex(0).endIndex(2).score(FlagType.AGGRESSIVE, 0).score(FlagType.PROFANITY, 6).build()),
+            parseFlags("0-2:A.0/P.6")
+        );
+    }
+
+    @Test
+    @DisplayName("Multiple flags with single scores")
+    public void multiFlagSingleScore() {
+        assertEquals(
+            Arrays.asList(
+                AutoModFlag.builder().startIndex(20).endIndex(21).score(FlagType.PROFANITY, 7).build(),
+                AutoModFlag.builder().startIndex(34).endIndex(37).score(FlagType.SEXUAL, 6).build()
+            ),
+            parseFlags("20-21:P.7,34-37:S.6")
+        );
+    }
+
+    @Test
+    @DisplayName("Multiple flags with multiple scores")
+    public void multiFlagMultiScore() {
+        assertEquals(
+            Arrays.asList(
+                AutoModFlag.builder().startIndex(14).endIndex(22).score(FlagType.AGGRESSIVE, 5).score(FlagType.PROFANITY, 6).build(),
+                AutoModFlag.builder().startIndex(69).endIndex(75).score(FlagType.PROFANITY, 6).build(),
+                AutoModFlag.builder().startIndex(101).endIndex(104).score(FlagType.AGGRESSIVE, 0).score(FlagType.PROFANITY, 6).build()
+            ),
+            parseFlags("14-22:A.5/P.6,69-75:P.6,101-104:A.0/P.6")
+        );
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `FlagType` + `AutoModFlag` + `FlagParser`
* Include lazy getter in `IRCMessageEvent` for the parsed `flags` (existing usernotice-based events that do not contain a reference to this event will require some more work to have these parsed flags accessible)

### Additional Information 
Brief summary of the tag from others who also found this: https://github.com/Chatterino/chatterino2/issues/1772
