### PR TITLE
feat: expand access to the unofficial flags tag in chat events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -137,7 +137,7 @@ public class IRCEventHandler {
                 Integer bits = Integer.parseInt(event.getTags().get("bits"));
 
                 // Dispatch Event
-                eventManager.publish(new CheerEvent(channel, user != null ? user : ANONYMOUS_CHEERER, message, bits));
+                eventManager.publish(new CheerEvent(channel, user != null ? user : ANONYMOUS_CHEERER, message, bits, event.getFlags()));
             }
         }
     }
@@ -170,7 +170,7 @@ public class IRCEventHandler {
                 Integer streak = event.getTags().containsKey("msg-param-streak-months") ? Integer.parseInt(event.getTags().get("msg-param-streak-months")) : 0;
 
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak, null));
+                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak, null, event.getFlags()));
             }
             // Receive Gifted Sub
             else if (msgId.equalsIgnoreCase("subgift") || msgId.equalsIgnoreCase("anonsubgift")) {
@@ -190,7 +190,7 @@ public class IRCEventHandler {
                 int giftMonths = giftMonthsParam != null ? Integer.parseInt(giftMonthsParam) : 1;
 
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths));
+                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths, event.getFlags()));
             }
             // Gift X Subs
             else if (msgId.equalsIgnoreCase("submysterygift") || msgId.equalsIgnoreCase("anonsubmysterygift")) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.chat.flag.AutoModFlag;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -8,6 +10,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -54,4 +57,12 @@ public class ChannelMessageActionEvent extends AbstractChannelEvent {
 		this.message = message;
 		this.permissions = permissions;
 	}
+
+    /**
+     * @return the regions of the message that were flagged by AutoMod.
+     */
+	@Unofficial
+	public List<AutoModFlag> getFlags() {
+	    return this.messageEvent.getFlags();
+    }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.chat.flag.AutoModFlag;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -8,6 +10,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -54,4 +57,12 @@ public class ChannelMessageEvent extends AbstractChannelEvent {
 		this.message = message;
 		this.permissions = permissions;
 	}
+
+    /**
+     * @return the regions of the message that were flagged by AutoMod.
+     */
+    @Unofficial
+    public List<AutoModFlag> getFlags() {
+        return this.messageEvent.getFlags();
+    }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
@@ -1,11 +1,15 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.chat.flag.AutoModFlag;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
+
+import java.util.List;
 
 /**
  * This event gets called when a user receives bits.
@@ -30,6 +34,12 @@ public class CheerEvent extends AbstractChannelEvent {
 	 */
 	private Integer bits;
 
+    /**
+     * Regions of {@link #getMessage()} that were flagged by AutoMod (Unofficial)
+     */
+    @Unofficial
+    private List<AutoModFlag> flags;
+
 	/**
 	 * Event Constructor
 	 *
@@ -37,11 +47,13 @@ public class CheerEvent extends AbstractChannelEvent {
 	 * @param user The donating user.
 	 * @param message The donation message.
 	 * @param bits The amount of bits.
+	 * @param flags The regions of the message that were flagged by AutoMod.
 	 */
-	public CheerEvent(EventChannel channel, EventUser user, String message, Integer bits) {
+	public CheerEvent(EventChannel channel, EventUser user, String message, Integer bits, List<AutoModFlag> flags) {
 		super(channel);
 		this.user = user;
 		this.message = message;
 		this.bits = bits;
+		this.flags = flags;
 	}
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.chat.flag.AutoModFlag;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -8,6 +10,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -68,6 +71,12 @@ public class SubscriptionEvent extends AbstractChannelEvent {
     Integer giftMonths;
 
     /**
+     * The regions of {@link #getMessage()} that were flagged by AutoMod (Unofficial)
+     */
+    @Unofficial
+    List<AutoModFlag> flags;
+
+    /**
      * Event Constructor
      *
      * @param channel    ChatChannel the user subscribed to
@@ -79,8 +88,9 @@ public class SubscriptionEvent extends AbstractChannelEvent {
      * @param giftedBy   User that gifted the sub
      * @param subStreak  Consecutive number of months user has been subscribed (not cumulative); 0 if no streak or user chooses not to share their streak
      * @param giftMonths The number of months gifted as part of a single, multi-month gift
+     * @param flags      The regions of the message that were flagged by AutoMod.
      */
-    public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths) {
+    public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths, List<AutoModFlag> flags) {
         super(channel);
         this.user = user;
         this.subscriptionPlan = subPlan;
@@ -90,6 +100,7 @@ public class SubscriptionEvent extends AbstractChannelEvent {
         this.giftedBy = giftedBy;
         this.subStreak = subStreak;
         this.giftMonths = giftMonths;
+        this.flags = flags;
     }
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `flags` field to `CheerEvent` and `SubscriptionEvent`
* Add convenient helpers to `ChannelMessageEvent` and `ChannelMessageActionEvent` for grabbing the flags from the underlying `IRCMessageEvent`
