### PR TITLE
feat: add kraken endpoints that are missing from helix

### DIFF
--- a/rest-kraken/build.gradle
+++ b/rest-kraken/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 
 	// Jackson (JSON)
 	api group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
+	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
 	// Twitch4J Modules
 	api project(':' + rootProject.name + '-common')

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -478,7 +478,7 @@ public interface TwitchKraken {
      * @return {@link KrakenVideo}, the updated video
      */
     @RequestLine(
-        value = "POST /videos/{video_id}?description={description}&game={game}&language={language}&tag_list={tag_list}&title={title}",
+        value = "PUT /videos/{video_id}?description={description}&game={game}&language={language}&tag_list={tag_list}&title={title}",
         collectionFormat = CollectionFormat.CSV
     )
     @Headers({

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -9,7 +9,10 @@ import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 
+import java.net.URI;
+import java.time.Instant;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Twitch - Kraken API
@@ -17,6 +20,80 @@ import java.util.List;
  * Kraken is already deprecated, so we only offer methods which haven't been added to the new helix api yet. Please use the helix api if available.
  */
 public interface TwitchKraken {
+
+    /**
+     * The default baseUrl to pass to {@link TwitchKraken#uploadVideoPart(URI, String, String, int, byte[])} and {@link TwitchKraken#completeVideoUpload(URI, String, String)}
+     */
+    URI UPLOADS_BASE_URL = ((Supplier<URI>) () -> {
+        // Not pretty but needed for "Overriding the Request Line" - see: https://github.com/OpenFeign/feign/blob/master/README.md#interface-annotations
+        try {
+            return new URI("https://uploads.twitch.tv");
+        } catch (Exception e) {
+            return null;
+        }
+    }).get();
+
+    /**
+     * Get Channel Editors
+     * <p>
+     * Gets a list of users who are editors for a specified channel.
+     *
+     * @param authToken User Access Token (scope: channel_read)
+     * @param channelId The ID of the channel to retrieve editors from
+     * @return {@link KrakenUserList}
+     */
+    @RequestLine("GET /channels/{channelId}/editors")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenUserList> getChannelEditors(
+        @Param("token") String authToken,
+        @Param("channelId") String channelId
+    );
+
+    /**
+     * Get Channel Followers
+     * <p>
+     * Gets a list of users who follow a specified channel, sorted by the date when they started following the channel (newest first, unless specified otherwise).
+     *
+     * @param channelId Channel Id
+     * @param limit     Maximum number of objects to return. Default: 25. Maximum: 100.
+     * @param offset    Object offset for pagination of results. Default: 0.
+     * @param cursor    Tells the server where to start fetching the next set of results, in a multi-page response.
+     * @param direction Direction of sorting. Valid values: asc, desc (newest first). Default: desc.
+     * @return {@link KrakenFollowList}
+     */
+    @RequestLine("GET /channels/{channelId}/follows?limit={limit}&offset={offset}&cursor={cursor}&direction={direction}")
+    @Headers({
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenFollowList> getChannelFollowers(
+        @Param("channelId") String channelId,
+        @Param("limit") Integer limit,
+        @Param("offset") Integer offset,
+        @Param("cursor") String cursor,
+        @Param("direction") String direction
+    );
+
+    /**
+     * Reset Channel Stream Key
+     * <p>
+     * Deletes the stream key for a specified channel. Once it is deleted, the stream key is automatically reset.
+     *
+     * @param authToken User Access Token (scope: channel_stream)
+     * @param channelId Channel Id
+     * @return {@link KrakenChannel}
+     */
+    @RequestLine("DELETE /channels/{channelId}/stream_key")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenChannel> resetChannelStreamKey(
+        @Param("token") String authToken,
+        @Param("channelId") String channelId
+    );
 
     /**
      * Get Channel Subscribers
@@ -88,6 +165,107 @@ public interface TwitchKraken {
     );
 
     /**
+     * Get Clip
+     * <p>
+     * Gets details about a specified clip.
+     *
+     * @param slug The globally unique string to reference the clip
+     * @return {@link KrakenClip}
+     */
+    @RequestLine("GET /clips/{slug}")
+    @Headers({
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenClip> getClip(
+        @Param("slug") String slug
+    );
+
+    /**
+     * Get User Block List
+     * <p>
+     * Gets a specified user’s block list. List sorted by recency, newest first.
+     *
+     * @param authToken User Access Token (scope: user_blocks_read)
+     * @param userId    The user ID associated with the token
+     * @param limit     Maximum number of objects in array. Default: 25. Maximum: 100.
+     * @param offset    Object offset for pagination. Default: 0.
+     * @return {@link KrakenBlockList}
+     */
+    @RequestLine("GET /users/{user}/blocks?limit={limit}&offset={offset}")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenBlockList> getUserBlockList(
+        @Param("token") String authToken,
+        @Param("user") String userId,
+        @Param("limit") Integer limit,
+        @Param("offset") Integer offset
+    );
+
+    /**
+     * Block User
+     * <p>
+     * Blocks a user; that is, adds a specified target user to the blocks list of a specified source user.
+     *
+     * @param authToken    User Access Token (scope: user_blocks_edit)
+     * @param sourceUserId The ID of the user that is doing the blocking.
+     * @param targetUserId The ID of the user that is getting blocked by the source.
+     * @return {@link KrakenBlockTransaction}
+     */
+    @RequestLine("PUT /users/{from_id}/blocks/{to_id}")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenBlockTransaction> blockUser(
+        @Param("token") String authToken,
+        @Param("from_id") String sourceUserId,
+        @Param("to_id") String targetUserId
+    );
+
+    /**
+     * Unblock User
+     * <p>
+     * Unblocks a user; that is, deletes a specified target user from the blocks list of a specified source user.
+     *
+     * @param authToken    User Access Token (scope: user_blocks_edit)
+     * @param sourceUserId The ID of the user that is doing the unblocking.
+     * @param targetUserId The ID of the user that is getting unblocked by the source.
+     * @return 204 No Content upon a successful request
+     */
+    @RequestLine("DELETE /users/{from_id}/blocks/{to_id}")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<Void> unblockUser(
+        @Param("token") String authToken,
+        @Param("from_id") String sourceUserId,
+        @Param("to_id") String targetUserId
+    );
+
+    /**
+     * Get User Emotes
+     * <p>
+     * Gets a list of the emojis and emoticons that the specified user can use in chat.
+     * These are both the globally available ones and the channel-specific ones (which can be accessed by any user subscribed to the channel).
+     *
+     * @param authToken User Access Token (scope: user_subscriptions)
+     * @param userId    The user ID associated with the token
+     * @return {@link KrakenEmoticonSetList}
+     */
+    @RequestLine("GET /users/{user}/emotes")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenEmoticonSetList> getUserEmotes(
+        @Param("token") String authToken,
+        @Param("user") String userId
+    );
+
+    /**
      * Follow Channel
      * <p>
      * Adds a specified user to the followers of a specified channel.
@@ -96,7 +274,9 @@ public interface TwitchKraken {
      * @param userId       User Id
      * @param targetUserId Target User Id (the Channel the user will follow)
      * @return Object
+     * @deprecated in favor of TwitchHelix#createFollow
      */
+    @Deprecated
     @RequestLine("PUT /users/{user}/follows/channels/{targetUser}")
     @Headers({
         "Authorization: OAuth {token}",
@@ -173,9 +353,10 @@ public interface TwitchKraken {
      * @param authToken    Auth Token
      * @param channelId    Channel Id
      * @param title        New stream title
-     *
      * @return Object
+     * @deprecated in favor of TwitchHelix#updateChannelInformation
      */
+    @Deprecated
     @Headers({
         "Authorization: OAuth {token}",
         "Accept: application/vnd.twitchtv.v5+json",
@@ -185,6 +366,152 @@ public interface TwitchKraken {
         @Param("token") String authToken,
         @Param("channelId") String channelId,
         @Param("title") String title
+    );
+
+    /**
+     * Create Video
+     * <p>
+     * Creates a new video in a specified channel.
+     * Videos with the following formats can be uploaded:
+     * <ul>
+     * <li>MP4, MOV, AVI and FLV file formats</li>
+     * <li>AAC audio</li>
+     * <li>h264 codec</li>
+     * <li>Up to 10Mbps bitrate</li>
+     * <li>Up to 1080p/60FPS</li>
+     * </ul>
+     * There is a rate limit of 5 simultaneous uploads per user, with a maximum of 100 uploads in 24 hours.
+     *
+     * @param authToken   Auth Token (scope: channel_editor)
+     * @param channelId   Channel Id (Required)
+     * @param title       Title of the video. Maximum 100 characters. (Required)
+     * @param description Short description of the video. (Optional)
+     * @param game        Name of the game in the video. (Optional)
+     * @param language    Language of the video (for example, en). (Optional)
+     * @param tags        Tags describing the video. Maximum: 100 characters per tag, 500 characters for the entire list. (Optional)
+     * @param viewable    Specifies who can view the video. Valid values: public (the video is viewable by everyone) or private (the video is viewable only by the owner and channel editors).
+     *                    Default: public. (Optional)
+     * @param viewableAt  Date when the video will become public. This takes effect only if viewable=private. (Optional)
+     * @return {@link KrakenCreatedVideo}
+     */
+    @RequestLine(
+        value = "POST /videos?channel_id={channel_id}&title={title}&description={description}&game={game}&language={language}&tag_list={tag_list}&viewable={viewable}&viewable_at={viewable_at}",
+        collectionFormat = CollectionFormat.CSV
+    )
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenCreatedVideo> createVideo(
+        @Param("token") String authToken,
+        @Param("channel_id") String channelId,
+        @Param("title") String title,
+        @Param("description") String description,
+        @Param("game") String game,
+        @Param("language") String language,
+        @Param("tag_list") List<String> tags,
+        @Param("viewable") String viewable,
+        @Param("viewable_at") Instant viewableAt
+    );
+
+    @RequestLine("PUT /upload/{video_id}?part={part}&upload_token={upload_token}")
+    @Headers({
+        "Accept: application/vnd.twitchtv.v5+json",
+        "Content-Type: application/x-www-form-urlencoded"
+    })
+    HystrixCommand<Void> uploadVideoPart(
+        URI baseUrl,
+        @Param("video_id") String videoId,
+        @Param("upload_token") String uploadToken,
+        @Param("part") int partIndex,
+        byte[] videoPart
+    );
+
+    /**
+     * Upload Video Part
+     * <p>
+     * Uploads part of a video. Each part of a video is uploaded with a separate request.
+     *
+     * @param videoId     The video id returned by {@link TwitchKraken#createVideo(String, String, String, String, String, String, List, String, Instant)}. (Required)
+     * @param uploadToken The upload token returned by {@link TwitchKraken#createVideo(String, String, String, String, String, String, List, String, Instant)}. (Required)
+     * @param partIndex   The location of the video part in the complete video. The value of this is 1-based. (Required)
+     * @param videoPart   The body of the request is a byte[] that contains the video data. (Required)
+     * @return 200 OK upon a successful part upload
+     */
+    default HystrixCommand<Void> uploadVideoPart(String videoId, String uploadToken, int partIndex, byte[] videoPart) {
+        return uploadVideoPart(UPLOADS_BASE_URL, videoId, uploadToken, partIndex, videoPart);
+    }
+
+    @RequestLine("POST /upload/{video_id}/complete?upload_token={upload_token}")
+    @Headers("Accept: application/vnd.twitchtv.v5+json")
+    HystrixCommand<Void> completeVideoUpload(
+        URI baseUrl,
+        @Param("video_id") String videoId,
+        @Param("upload_token") String uploadToken
+    );
+
+    /**
+     * Complete Video Upload
+     * <p>
+     * After you upload all the parts of a video, you complete the upload process with this endpoint.
+     *
+     * @param videoId     The video id returned by {@link TwitchKraken#createVideo(String, String, String, String, String, String, List, String, Instant)}. (Required)
+     * @param uploadToken The upload token returned by {@link TwitchKraken#createVideo(String, String, String, String, String, String, List, String, Instant)}. (Required)
+     * @return 200 OK upon a successful POST
+     */
+    default HystrixCommand<Void> completeVideoUpload(String videoId, String uploadToken) {
+        return completeVideoUpload(UPLOADS_BASE_URL, videoId, uploadToken);
+    }
+
+    /**
+     * Update Video
+     * <p>
+     * Updates information about a specified video that was already created.
+     *
+     * @param authToken   Auth Token. (scope: channel_editor)
+     * @param videoId     Video ID. (Required)
+     * @param description Short description of the video. (Optional)
+     * @param game        Name of the game in the video.
+     * @param language    Language of the video (for example, en).
+     * @param tags        Tags describing the video. Maximum: 100 characters per tag, 500 characters for the entire list.
+     * @param title       tags describing the video (for example, “airplanes,scary”). Maximum: 100 characters per tag, 500 characters for the entire list.
+     * @return {@link KrakenVideo}, the updated video
+     */
+    @RequestLine(
+        value = "POST /videos/{video_id}?description={description}&game={game}&language={language}&tag_list={tag_list}&title={title}",
+        collectionFormat = CollectionFormat.CSV
+    )
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<KrakenVideo> updateVideo(
+        @Param("token") String authToken,
+        @Param("video_id") String videoId,
+        @Param("description") String description,
+        @Param("game") String game,
+        @Param("language") String language,
+        @Param("tag_list") List<String> tags,
+        @Param("title") String title
+    );
+
+    /**
+     * Delete Video
+     * <p>
+     * Deletes a specified video (can be a VOD, highlight, or upload).
+     *
+     * @param authToken Auth Token. (scope: channel_editor)
+     * @param videoId   Video ID. (Required)
+     * @return 200 OK upon a successful call
+     */
+    @RequestLine("DELETE /videos/{video_id}")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json"
+    })
+    HystrixCommand<Void> deleteVideo(
+        @Param("token") String authToken,
+        @Param("video_id") String videoId
     );
 
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.kraken;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.feign.interceptor.TwitchClientIdInterceptor;
@@ -86,6 +87,11 @@ public class TwitchKrakenBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Jackson ObjectMapper
+        ObjectMapper mapper = new ObjectMapper();
+        // - Modules
+        mapper.findAndRegisterModules();
+
         // Create HttpClient with proxy
         okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();
         if (proxyConfig != null)
@@ -94,8 +100,8 @@ public class TwitchKrakenBuilder {
         // Build
         TwitchKraken client = HystrixFeign.builder()
             .client(new OkHttpClient(clientBuilder.build()))
-            .encoder(new JacksonEncoder())
-            .decoder(new JacksonDecoder())
+            .encoder(new JacksonEncoder(mapper))
+            .decoder(new JacksonDecoder(mapper))
             .logger(new Logger.ErrorLogger())
             .errorDecoder(new TwitchKrakenErrorDecoder(new JacksonDecoder()))
             .requestInterceptor(new TwitchClientIdInterceptor(this.clientId, this.userAgent))

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -58,6 +58,9 @@ public class TwitchKrakenBuilder {
     @With
     private Integer timeout = 5000;
 
+    @With
+    private Integer uploadTimeout = 4 * 60 * 1000;
+
     /**
      * ProxyConfiguration
      */
@@ -86,6 +89,9 @@ public class TwitchKrakenBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.requestCache.enabled", false);
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
+
+        // Hystrix: Timeout modification for file uploads
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.TwitchKraken#uploadVideoPart(URI,String,String,int,byte[]).execution.isolation.thread.timeoutInMilliseconds", uploadTimeout);
 
         // Jackson ObjectMapper
         ObjectMapper mapper = new ObjectMapper();

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlock.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlock.java
@@ -3,17 +3,11 @@ package com.github.twitch4j.kraken.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.Setter;
-import lombok.ToString;
-
-import java.util.List;
 
 @Data
-@ToString(callSuper = true)
 @Setter(AccessLevel.PRIVATE)
-@EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KrakenBlockList extends AbstractResultList {
-    private List<KrakenBlock> blocks;
+public class KrakenBlock {
+    private KrakenUser user;
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockList.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString(callSuper = true)
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenBlockList extends AbstractResultList {
+    private List<KrakenUser> blocks;
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockTransaction.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockTransaction.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenBlockTransaction {
+    @JsonProperty("_id")
+    private String id;
+
+    private Instant updatedAt;
+
+    @JsonProperty("user")
+    private KrakenUser blockedUser;
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenChannel.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenChannel.java
@@ -1,0 +1,40 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenChannel {
+    @JsonProperty("_id")
+    private String id;
+    private String broadcasterLanguage;
+    private String broadcasterType;
+    private Instant createdAt;
+    private String displayName;
+    private String email;
+    private Long followers;
+    private String game;
+    private String language;
+    private String logo;
+    private Boolean mature;
+    private String name;
+    private Boolean partner;
+    private String profileBanner;
+    private String profileBannerBackgroundColor;
+    private String status;
+    private String streamKey;
+    private Instant updatedAt;
+    private String url;
+    private String videoBanner;
+    private Long views;
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenClip.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenClip.java
@@ -1,0 +1,61 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenClip {
+    private String slug;
+    private String trackingId;
+    private String url;
+    private String embedUrl;
+    private String embedHtml;
+    private SimpleUser broadcaster;
+    private SimpleUser curator;
+    private VideoOnDemand vod;
+    private String game;
+    private String language;
+    private String title;
+    private Long views;
+    private Double duration;
+    private Instant createdAt;
+    private Thumbnail thumbnails;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class SimpleUser {
+        private String id;
+        private String name;
+        private String displayName;
+        private String channelUrl;
+        private String logo;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class VideoOnDemand {
+        private String id;
+        private String url;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Thumbnail {
+        private String medium;
+        private String small;
+        private String tiny;
+    }
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCreatedVideo.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCreatedVideo.java
@@ -1,0 +1,56 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenCreatedVideo {
+
+    /**
+     * Important information for future calls to upload video parts.
+     */
+    private Upload upload;
+
+    private KrakenVideo video;
+
+    public String getVideoId() {
+        // Twitch's documentation had some inconsistencies in their example response, so this includes some fallbacks
+        String url = upload.url;
+        int i;
+
+        // Fallback 1
+        if (url == null || (i = url.lastIndexOf('/')) < 25) {
+            url = this.video.getUrl();
+            i = url.lastIndexOf('/');
+        }
+
+        // Fallback 2
+        if (i < 15)
+            return video.getIdForApiCalls();
+
+        return url.substring(i + 1);
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Upload {
+        /**
+         * The URL where you will upload video parts.
+         */
+        private String url;
+
+        /**
+         * The token you will use to upload video parts.
+         * <p>
+         * Upload tokens expire after 1 day.
+         * If you lose the token or it expires, you must start a new upload and get a new token.
+         */
+        private String token;
+    }
+
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticon.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticon.java
@@ -1,0 +1,14 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenEmoticon {
+    private Integer id;
+    private String code;
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticonSetList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticonSetList.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.Map;
+import java.util.Set;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenEmoticonSetList {
+    private Map<String, Set<KrakenEmoticon>> emoticonSets;
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollow.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollow.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.kraken.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenFollow {
+
+    @JsonProperty("created_at")
+    private Instant followedAt;
+
+    private Boolean notifications;
+
+    private KrakenUser user;
+
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollowList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollowList.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString(callSuper = true)
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenFollowList extends AbstractResultList {
+    private List<KrakenFollow> follows;
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenSubscriptionList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenSubscriptionList.java
@@ -1,11 +1,13 @@
 package com.github.twitch4j.kraken.domain;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @Data
-public class KrakenSubscriptionList {
+@EqualsAndHashCode(callSuper = true)
+public class KrakenSubscriptionList extends AbstractResultList {
 
 	private List<KrakenSubscription> subscriptions;
 

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
@@ -1,11 +1,13 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.Date;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenUser {
 
 	@JsonProperty("_id")

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenVideo.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenVideo.java
@@ -1,0 +1,89 @@
+package com.github.twitch4j.kraken.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KrakenVideo {
+    @JsonProperty("_id")
+    private String id;
+    private String title;
+    private String description;
+    private String descriptionHtml;
+    private Integer broadcastId;
+    private String broadcastType;
+    private String status;
+    private String tagList;
+    private Long views;
+    private String url;
+    private String language;
+    private Instant createdAt;
+    private String viewable;
+    private Instant viewableAt;
+    private Instant publishedAt;
+    private Instant recordedAt;
+    private String game;
+    private Long length;
+    private Preview preview;
+    private String animatedPreviewUrl;
+    private Thumbnails thumbnails;
+    private Map<String, Double> fps;
+    private Map<String, String> resolutions;
+    private Channel channel;
+
+    public String getIdForApiCalls() {
+        // The id returned in this object has a `v` prefix, which is not desirable for further api calls
+        return this.id.charAt(0) == 'v' ? id.substring(1) : id;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Preview {
+        private String small;
+        private String medium;
+        private String large;
+        private String template;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Thumbnail {
+        private String type;
+        private String url;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Thumbnails {
+        private List<Thumbnail> small;
+        private List<Thumbnail> medium;
+        private List<Thumbnail> large;
+        private List<Thumbnail> template;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Channel {
+        @JsonProperty("_id")
+        private String id;
+        private String name;
+        private String displayName;
+    }
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenVideo.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenVideo.java
@@ -22,7 +22,7 @@ public class KrakenVideo {
     private String title;
     private String description;
     private String descriptionHtml;
-    private Integer broadcastId;
+    private Long broadcastId;
     private String broadcastType;
     private String status;
     private String tagList;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/util/KrakenVideoHelper.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/util/KrakenVideoHelper.java
@@ -19,15 +19,58 @@ import java.util.concurrent.CompletionException;
 public class KrakenVideoHelper {
 
     /**
-     * Max size of a video part byte array; avoids hitting 25MB. This is just under 24 MiB.
+     * Max size of a video part byte array; avoids hitting 25MB.
+     * <p>
+     * This is conservatively set to just over 18 MiB based on testing which values avoid peer connection resets.
      *
      * @see <a href="https://dev.twitch.tv/docs/v5/reference/videos/#upload-video-part">Official documentation</a>
      */
-    private final int MAX_PIECE_LENGTH = 25_000_000;
+    public final int MAX_PIECE_LENGTH = 19_000_000;
 
+    /**
+     * Minimum size of a video part byte array, 5 MiB.
+     *
+     * @see <a href="https://dev.twitch.tv/docs/v5/reference/videos/#upload-video-part">Official documentation</a>
+     */
+    public final int MIN_PIECE_LENGTH = 5_242_880;
+
+    /**
+     * Uploads a video to the channel of an affiliate or partner.
+     * <p>
+     * Helper function to automate the process of creating the video, uploading the parts, and marking the upload as complete.
+     * <p>
+     * Videos with the following formats can be uploaded:
+     * <ul>
+     * <li>MP4, MOV, AVI and FLV file formats</li>
+     * <li>AAC audio</li>
+     * <li>h264 codec</li>
+     * <li>Up to 10Mbps bitrate</li>
+     * <li>Up to 1080p/60FPS</li>
+     * </ul>
+     * There is a rate limit of 5 simultaneous uploads per user, with a maximum of 100 uploads in 24 hours.
+     *
+     * @param api                  Required: A {@link TwitchKraken} instance.
+     * @param authToken            Required: Auth Token (scope: channel_editor) that is authorized to upload to the specified channel.
+     * @param channelId            Optional: The id of the channel to upload to. If absent, it will use the user id associated with the auth token.
+     * @param title                Required: The title for the uploaded video (maximum 100 characters).
+     * @param description          Optional: A short description for the video.
+     * @param game                 Optional: The name of the game in the video.
+     * @param language             Optional: Language of the video (for example, en).
+     * @param tags                 Optional: Tags describing the video. Maximum: 100 characters per tag, 500 characters for the entire list.
+     * @param viewable             Optional: Specifies who can view the video. Valid values: public or private. Default: public.
+     * @param viewableAt           Optional: Date when the video will become public (if initially private).
+     * @param inputStream          Required: The stream of bytes containing the video. Must be encoded in a format supported by Twitch.
+     * @param pieceLength          Optional: The number of bytes of video for each video part to be uploaded. Invalid values will be clamped into the valid range.
+     * @param sleepBetweenRequests Optional: The time to sleep after each video part upload. Invalid values will be treated as zero.
+     * @return a future wrapper around the uploaded video
+     * @see TwitchKraken#createVideo(String, String, String, String, String, String, List, String, Instant)
+     * @see TwitchKraken#uploadVideoPart(String, String, int, byte[])
+     * @see TwitchKraken#completeVideoUpload(String, String)
+     */
     public CompletableFuture<KrakenVideo> uploadVideo(@NonNull TwitchKraken api, String authToken, String channelId,
                                                       @NonNull String title, String description, String game, String language, List<String> tags, String viewable, Instant viewableAt,
-                                                      @NonNull InputStream inputStream, long sleepBetweenRequests) {
+                                                      @NonNull InputStream inputStream, int pieceLength, long sleepBetweenRequests) {
+        final int length = Math.max(Math.min(pieceLength, MAX_PIECE_LENGTH), MIN_PIECE_LENGTH);
         return CompletableFuture
             .supplyAsync(() -> {
                 // Use authToken to find channelId if it was not given
@@ -43,12 +86,12 @@ public class KrakenVideoHelper {
             .thenApplyAsync(vid -> {
                 try {
                     try {
-                        final byte[] buffer = new byte[MAX_PIECE_LENGTH];
+                        final byte[] buffer = new byte[length];
                         int bytesRead;
                         int partIndex = 1;
                         while ((bytesRead = inputStream.read(buffer)) != -1) {
                             final byte[] videoPart;
-                            if (bytesRead < MAX_PIECE_LENGTH) {
+                            if (bytesRead < length) {
                                 videoPart = Arrays.copyOfRange(buffer, 0, bytesRead);
                             } else {
                                 videoPart = buffer;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/util/KrakenVideoHelper.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/util/KrakenVideoHelper.java
@@ -1,0 +1,73 @@
+package com.github.twitch4j.kraken.util;
+
+import com.github.philippheuer.credentialmanager.domain.Credential;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
+import com.github.twitch4j.kraken.TwitchKraken;
+import com.github.twitch4j.kraken.domain.KrakenVideo;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+@UtilityClass
+public class KrakenVideoHelper {
+
+    /**
+     * Max size of a video part byte array; avoids hitting 25MB. This is just under 24 MiB.
+     *
+     * @see <a href="https://dev.twitch.tv/docs/v5/reference/videos/#upload-video-part">Official documentation</a>
+     */
+    private final int MAX_PIECE_LENGTH = 25_000_000;
+
+    public CompletableFuture<KrakenVideo> uploadVideo(@NonNull TwitchKraken api, String authToken, String channelId,
+                                                      @NonNull String title, String description, String game, String language, List<String> tags, String viewable, Instant viewableAt,
+                                                      @NonNull InputStream inputStream, long sleepBetweenRequests) {
+        return CompletableFuture
+            .supplyAsync(() -> {
+                // Use authToken to find channelId if it was not given
+                if (channelId == null || channelId.isEmpty()) {
+                    return new TwitchIdentityProvider(null, null, null)
+                        .getAdditionalCredentialInformation(new OAuth2Credential("twitch", authToken))
+                        .map(Credential::getUserId)
+                        .orElse(null);
+                }
+                return channelId;
+            })
+            .thenApplyAsync(cId -> api.createVideo(authToken, cId, title, description, game, language, tags, viewable, viewableAt).execute())
+            .thenApplyAsync(vid -> {
+                try {
+                    try {
+                        final byte[] buffer = new byte[MAX_PIECE_LENGTH];
+                        int bytesRead;
+                        int partIndex = 1;
+                        while ((bytesRead = inputStream.read(buffer)) != -1) {
+                            final byte[] videoPart;
+                            if (bytesRead < MAX_PIECE_LENGTH) {
+                                videoPart = Arrays.copyOfRange(buffer, 0, bytesRead);
+                            } else {
+                                videoPart = buffer;
+                            }
+                            api.uploadVideoPart(vid.getVideoId(), vid.getUpload().getToken(), partIndex++, videoPart).execute();
+                            Thread.sleep(Math.max(sleepBetweenRequests, 0));
+                        }
+                    } finally {
+                        inputStream.close();
+                    }
+                } catch (Exception e) {
+                    throw new CompletionException(e);
+                }
+                return vid;
+            })
+            .thenApplyAsync(vid -> {
+                api.completeVideoUpload(vid.getVideoId(), vid.getUpload().getToken()).execute();
+                return vid.getVideo();
+            });
+    }
+
+}

--- a/rest-kraken/src/test/java/kraken/endpoints/ChannelServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/ChannelServiceTest.java
@@ -1,23 +1,57 @@
 package kraken.endpoints;
 
+import com.github.twitch4j.kraken.domain.KrakenChannel;
+import com.github.twitch4j.kraken.domain.KrakenFollow;
 import com.github.twitch4j.kraken.domain.KrakenSubscriptionList;
+import com.github.twitch4j.kraken.domain.KrakenUser;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @Tag("integration")
 public class ChannelServiceTest extends AbstractKrakenServiceTest {
 
+    private static final String TWITCH_CHANNEL_ID = "149223493";
+
+    @Test
+    @DisplayName("getEditors")
+    @Disabled
+    public void getEditors() {
+        List<KrakenUser> resultList = getTwitchKrakenClient().getChannelEditors(getCredential().getAccessToken(), TWITCH_CHANNEL_ID).execute().getUsers();
+        assertNotNull(resultList);
+        assertFalse(resultList.isEmpty(), "Didn't find any editors!");
+        System.out.println(resultList);
+    }
+
+    @Test
+    @DisplayName("getFollowers")
+    public void getFollowers() {
+        List<KrakenFollow> resultList = getTwitchKrakenClient().getChannelFollowers(TWITCH_CHANNEL_ID, null, null, null, null).execute().getFollows();
+        assertNotNull(resultList);
+    }
+
+    @Test
+    @DisplayName("resetStreamKey")
+    @Disabled
+    public void resetStreamKey() {
+        KrakenChannel result = getTwitchKrakenClient().resetChannelStreamKey(getCredential().getAccessToken(), TWITCH_CHANNEL_ID).execute();
+        assertNotNull(result);
+    }
+
     @Test
     @DisplayName("getSubscribers")
     @Disabled // test acc has no subs
     public void getSubscribers() {
-        KrakenSubscriptionList resultList = getTwitchKrakenClient().getChannelSubscribers(AbstractKrakenServiceTest.getCredential().getAccessToken(), "149223493l", null, null, null).execute();
+        KrakenSubscriptionList resultList = getTwitchKrakenClient().getChannelSubscribers(AbstractKrakenServiceTest.getCredential().getAccessToken(), TWITCH_CHANNEL_ID, null, null, null).execute();
 
         assertTrue(resultList.getSubscriptions().size() > 0, "Didn't find any subscriptions!");
     }

--- a/rest-kraken/src/test/java/kraken/endpoints/ClipsServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/ClipsServiceTest.java
@@ -1,0 +1,23 @@
+package kraken.endpoints;
+
+import com.github.twitch4j.kraken.domain.KrakenClip;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@Tag("integration")
+public class ClipsServiceTest extends AbstractKrakenServiceTest {
+
+    @Test
+    @DisplayName("getClip")
+    public void getClip() {
+        KrakenClip clip = getTwitchKrakenClient().getClip("AmazonianEncouragingLyrebirdAllenHuhu").execute();
+        assertNotNull(clip);
+    }
+
+}

--- a/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
@@ -1,5 +1,6 @@
 package kraken.endpoints;
 
+import com.github.twitch4j.kraken.domain.KrakenEmoticon;
 import com.github.twitch4j.kraken.domain.KrakenUser;
 import com.github.twitch4j.kraken.domain.KrakenUserList;
 import lombok.extern.slf4j.Slf4j;
@@ -9,8 +10,12 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -21,7 +26,7 @@ public class UsersServiceTest extends AbstractKrakenServiceTest {
     @DisplayName("getUsers")
     @Disabled
     public void getUsers() {
-    	KrakenUserList resultList = getTwitchKrakenClient().getUsersByLogin(Arrays.asList("twitch4j")).execute();
+        KrakenUserList resultList = getTwitchKrakenClient().getUsersByLogin(Arrays.asList("twitch4j")).execute();
         assertTrue(resultList.getUsers().size() == 1, "Number of found users was not 1!");
         KrakenUser user = resultList.getUsers().get(0);
         assertTrue(user.getId().equals("149223493"), "Twitch4J user id should be 149223493!");
@@ -31,4 +36,21 @@ public class UsersServiceTest extends AbstractKrakenServiceTest {
         assertEquals(user.getType(), "user", "Twitch4J user type should be user!");
         assertEquals(user.getCreatedAt().getTime(), 1488456578184L, "Twitch4J user creation date is invalid!");
     }
+
+    @Test
+    @DisplayName("getBlocks")
+    @Disabled
+    public void getBlocks() {
+        List<KrakenUser> resultList = getTwitchKrakenClient().getUserBlockList(getCredential().getAccessToken(), "149223493", null, null).execute().getBlocks();
+        assertNotNull(resultList);
+    }
+
+    @Test
+    @DisplayName("getUserEmotes")
+    @Disabled
+    public void getUserEmotes() {
+        Map<String, Set<KrakenEmoticon>> results = getTwitchKrakenClient().getUserEmotes(getCredential().getAccessToken(), "149223493").execute().getEmoticonSets();
+        assertNotNull(results);
+    }
+
 }

--- a/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
@@ -1,5 +1,7 @@
 package kraken.endpoints;
 
+import com.github.twitch4j.kraken.domain.KrakenBlock;
+import com.github.twitch4j.kraken.domain.KrakenBlockTransaction;
 import com.github.twitch4j.kraken.domain.KrakenEmoticon;
 import com.github.twitch4j.kraken.domain.KrakenUser;
 import com.github.twitch4j.kraken.domain.KrakenUserList;
@@ -41,8 +43,23 @@ public class UsersServiceTest extends AbstractKrakenServiceTest {
     @DisplayName("getBlocks")
     @Disabled
     public void getBlocks() {
-        List<KrakenUser> resultList = getTwitchKrakenClient().getUserBlockList(getCredential().getAccessToken(), "149223493", null, null).execute().getBlocks();
+        List<KrakenBlock> resultList = getTwitchKrakenClient().getUserBlockList(getCredential().getAccessToken(), "149223493", null, null).execute().getBlocks();
         assertNotNull(resultList);
+    }
+
+    @Test
+    @DisplayName("blockUser")
+    @Disabled
+    public void blockUser() {
+        KrakenBlockTransaction block = getTwitchKrakenClient().blockUser(getCredential().getAccessToken(), "149223493", "12427").execute();
+        assertNotNull(block);
+    }
+
+    @Test
+    @DisplayName("unblockUser")
+    @Disabled
+    public void unblockUser() {
+        getTwitchKrakenClient().unblockUser(getCredential().getAccessToken(), "149223493", "12427").execute();
     }
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add ability to set a higher timeout specifically for `TwitchKraken#uploadVideoPart`
* Add `getChannelEditors`
* Add `getChannelFollowers` (has some extra info compared to helix)
* Add `resetChannelStreamKey`
* Add `getClip` (has some extra info compared to helix)
* Add `getUserBlockList`
* Add `blockUser`
* Add `unblockUser`
* Add `getUserEmotes`
* Add `createVideo`
* Add `uploadVideoPart`
* Add `completeVideoUpload`
* Add `updateVideo`
* Add `deleteVideo`
* Add tests for a bunch of the new endpoints
* Create `KrakenVideoHelper` for simplifying the process of uploading videos
* Deprecate `addFollow` (available in helix now)
* Deprecate `updateTitle` (available in helix now)
* Fix java.time deserialization
* Include `total` field for `KrakenSubscriptionList`
