### PR TITLE
chore: update jackson to 2.11.1 and remove unused datatype module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,10 +77,9 @@ subprojects {
 			api group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.5.18'
 
 			// Jackson (JSON)
-			api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0'
-			api group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: '2.11.0'
-			api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: '2.11.0'
-			api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.0'
+			api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.1'
+			api group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: '2.11.1'
+			api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.1'
 
 			// WebSocket
 			api group: 'com.neovisionaries', name: 'nv-websocket-client', version: '2.9'

--- a/rest-helix/build.gradle
+++ b/rest-helix/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 	// Jackson (JSON)
 	api group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
 	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
 	// Cache

--- a/rest-kraken/build.gradle
+++ b/rest-kraken/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 	// Jackson (JSON)
 	api group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
 	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
 	// Twitch4J Modules


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Maven shading problem due to overlapping resource: `META-INF/services/com.fasterxml.jackson.databind.Module`

### Changes Proposed
* Update jackson dependencies to latest patch version
* Remove `jackson-datatype-jdk8`

### Additional Information
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.11.1
