### PR TITLE
feat: add sub months/tier getter to more chat events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -135,9 +135,11 @@ public class IRCEventHandler {
                 EventUser user = event.getUser();
                 String message = event.getMessage().orElse("");
                 Integer bits = Integer.parseInt(event.getTags().get("bits"));
+                int subMonths = event.getSubscriberMonths().orElse(0);
+                int subTier = event.getSubscriptionTier().orElse(0);
 
                 // Dispatch Event
-                eventManager.publish(new CheerEvent(channel, user != null ? user : ANONYMOUS_CHEERER, message, bits, event.getFlags()));
+                eventManager.publish(new CheerEvent(channel, user != null ? user : ANONYMOUS_CHEERER, message, bits, subMonths, subTier, event.getFlags()));
             }
         }
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
@@ -41,6 +41,16 @@ public class ChannelMessageActionEvent extends AbstractChannelEvent {
 	 */
 	private Set<CommandPermission> permissions;
 
+    /**
+     * The exact number of months the user has been a subscriber, or zero if not subscribed
+     */
+    private int subscriberMonths;
+
+    /**
+     * The tier at which the user is subscribed (prime is treated as 1), or zero if not subscribed
+     */
+    private int subscriptionTier;
+
 	/**
 	 * Event Constructor
 	 *
@@ -56,6 +66,8 @@ public class ChannelMessageActionEvent extends AbstractChannelEvent {
 		this.user = user;
 		this.message = message;
 		this.permissions = permissions;
+        this.subscriberMonths = messageEvent.getSubscriberMonths().orElse(0);
+        this.subscriptionTier = messageEvent.getSubscriptionTier().orElse(0);
 	}
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -41,6 +41,16 @@ public class ChannelMessageEvent extends AbstractChannelEvent {
 	 */
 	private Set<CommandPermission> permissions;
 
+    /**
+     * The exact number of months the user has been a subscriber, or zero if not subscribed
+     */
+	private int subscriberMonths;
+
+    /**
+     * The tier at which the user is subscribed (prime is treated as 1), or zero if not subscribed
+     */
+	private int subscriptionTier;
+
 	/**
 	 * Event Constructor
 	 *
@@ -56,6 +66,8 @@ public class ChannelMessageEvent extends AbstractChannelEvent {
 		this.user = user;
 		this.message = message;
 		this.permissions = permissions;
+		this.subscriberMonths = messageEvent.getSubscriberMonths().orElse(0);
+		this.subscriptionTier = messageEvent.getSubscriptionTier().orElse(0);
 	}
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
@@ -35,6 +35,16 @@ public class CheerEvent extends AbstractChannelEvent {
 	private Integer bits;
 
     /**
+     * The exact number of months the user has been a subscriber, or zero if not subscribed
+     */
+    private int subscriberMonths;
+
+    /**
+     * The tier at which the user is subscribed (prime is treated as 1), or zero if not subscribed
+     */
+    private int subscriptionTier;
+
+    /**
      * Regions of {@link #getMessage()} that were flagged by AutoMod (Unofficial)
      */
     @Unofficial
@@ -42,18 +52,22 @@ public class CheerEvent extends AbstractChannelEvent {
 
 	/**
 	 * Event Constructor
-	 *
-	 * @param channel The channel that this event originates from.
-	 * @param user The donating user.
-	 * @param message The donation message.
-	 * @param bits The amount of bits.
-	 * @param flags The regions of the message that were flagged by AutoMod.
-	 */
-	public CheerEvent(EventChannel channel, EventUser user, String message, Integer bits, List<AutoModFlag> flags) {
+     *
+     * @param channel The channel that this event originates from.
+     * @param user The donating user.
+     * @param message The donation message.
+     * @param bits The amount of bits.
+     * @param subscriberMonths The exact number of months the user has been a subscriber.
+     * @param subscriptionTier The tier at which the user is subscribed.
+     * @param flags The regions of the message that were flagged by AutoMod.
+     */
+	public CheerEvent(EventChannel channel, EventUser user, String message, Integer bits, int subscriberMonths, int subscriptionTier, List<AutoModFlag> flags) {
 		super(channel);
 		this.user = user;
 		this.message = message;
 		this.bits = bits;
-		this.flags = flags;
+        this.subscriberMonths = subscriberMonths;
+        this.subscriptionTier = subscriptionTier;
+        this.flags = flags;
 	}
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
Add fields (and automatic getters) for:
* `ChannelMessageEvent` (convenience)
* `ChannelMessageActionEvent` (convenience)
* `CheerEvent` (necessity)

### Additional Information 
Extension of #163 
