### PR TITLE
feat: add nonce and reply support to chat

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -15,6 +15,7 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.ChatReply;
 import com.github.twitch4j.common.util.CryptoUtils;
+import com.github.twitch4j.common.util.EscapeUtils;
 import com.github.twitch4j.common.util.ExponentialBackoffStrategy;
 import com.neovisionaries.ws.client.WebSocket;
 import com.neovisionaries.ws.client.WebSocketAdapter;
@@ -607,7 +608,7 @@ public class TwitchChat implements AutoCloseable {
         StringBuilder sb = new StringBuilder();
         if (tags != null && !tags.isEmpty()) {
             sb.append('@');
-            tags.forEach((k, v) -> sb.append(k).append('=').append(escapeTagValue(v)).append(';'));
+            tags.forEach((k, v) -> sb.append(k).append('=').append(EscapeUtils.escapeTagValue(v)).append(';'));
             sb.setCharAt(sb.length() - 1, ' '); // replace last semi-colon with space
         }
         sb.append("PRIVMSG #").append(channel.toLowerCase()).append(" :").append(message);
@@ -734,41 +735,4 @@ public class TwitchChat implements AutoCloseable {
     public List<String> getCurrentChannels() {
         return Collections.unmodifiableList(new ArrayList<>(channelCache));
     }
-
-    /**
-     * Escapes a value for use in an IRC message tag.
-     *
-     * @param value the unescaped message tag value
-     * @return the escaped tag value
-     * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Offical spec</a>
-     */
-    private static String escapeTagValue(Object value) {
-        if (value == null) return "";
-        char[] unescaped = value.toString().toCharArray();
-        StringBuilder sb = new StringBuilder(unescaped.length);
-        for (char c : unescaped) {
-            switch (c) {
-                case ';':
-                    sb.append("\\:");
-                    break;
-                case ' ':
-                    sb.append("\\s");
-                    break;
-                case '\\':
-                    sb.append("\\\\");
-                    break;
-                case '\r':
-                    sb.append("\\r");
-                    break;
-                case '\n':
-                    sb.append("\\n");
-                    break;
-                default:
-                    sb.append(c);
-                    break;
-            }
-        }
-        return sb.toString();
-    }
-
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -607,9 +607,8 @@ public class TwitchChat implements AutoCloseable {
         StringBuilder sb = new StringBuilder();
         if (tags != null && !tags.isEmpty()) {
             sb.append('@');
-            tags.forEach((k, v) -> sb.append(k).append('=').append(v).append(';'));
-            sb.setLength(sb.length() - 1); // remove last semi-colon
-            sb.append(' ');
+            tags.forEach((k, v) -> sb.append(k).append('=').append(escapeTagValue(v)).append(';'));
+            sb.setCharAt(sb.length() - 1, ' '); // replace last semi-colon with space
         }
         sb.append("PRIVMSG #").append(channel.toLowerCase()).append(" :").append(message);
 
@@ -735,4 +734,41 @@ public class TwitchChat implements AutoCloseable {
     public List<String> getCurrentChannels() {
         return Collections.unmodifiableList(new ArrayList<>(channelCache));
     }
+
+    /**
+     * Escapes a value for use in an IRC message tag.
+     *
+     * @param value the unescaped message tag value
+     * @return the escaped tag value
+     * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Offical spec</a>
+     */
+    private static String escapeTagValue(Object value) {
+        if (value == null) return "";
+        char[] unescaped = value.toString().toCharArray();
+        StringBuilder sb = new StringBuilder(unescaped.length);
+        for (char c : unescaped) {
+            switch (c) {
+                case ';':
+                    sb.append("\\:");
+                    break;
+                case ' ':
+                    sb.append("\\s");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -6,6 +6,7 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
+import com.github.twitch4j.common.util.ChatReply;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
@@ -50,6 +51,20 @@ public class ChannelMessageEvent extends AbstractChannelEvent {
      * The tier at which the user is subscribed (prime is treated as 1), or zero if not subscribed
      */
 	private int subscriptionTier;
+
+    /**
+     * Nonce
+     */
+    @Unofficial
+    @Getter(lazy = true)
+    private String nonce = getMessageEvent().getNonce().orElse(null);
+
+    /**
+     * Information regarding the parent message being replied to, if applicable.
+     */
+    @Unofficial
+    @Getter(lazy = true)
+    private ChatReply replyInfo = ChatReply.parse(getMessageEvent().getTags());
 
 	/**
 	 * Event Constructor

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -7,6 +7,7 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
+import com.github.twitch4j.common.util.EscapeUtils;
 import com.github.twitch4j.common.util.TwitchUtils;
 import lombok.*;
 import org.apache.commons.lang3.StringUtils;
@@ -297,7 +298,7 @@ public class IRCMessageEvent extends TwitchEvent {
 	public Optional<String> getTagValue(String tagName) {
 	    return Optional.ofNullable(getTags().get(tagName))
             .filter(StringUtils::isNotBlank)
-            .map(s -> s.replaceAll("\\\\s", " "));
+            .map(EscapeUtils::unescapeTagValue);
 	}
 
 	/**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -24,6 +24,9 @@ import java.util.regex.Pattern;
 @EqualsAndHashCode(callSuper = false)
 public class IRCMessageEvent extends TwitchEvent {
 
+    @Unofficial
+    public static final String NONCE_TAG_NAME = "client-nonce";
+
 	/**
 	 * Tags
 	 */
@@ -236,6 +239,23 @@ public class IRCMessageEvent extends TwitchEvent {
         }
 
         return null;
+    }
+
+    /**
+     * The message UUID that is used for deletion by a moderator or a chat reply (from Tags)
+     *
+     * @return the unique ID for the message
+     */
+    public Optional<String> getMessageId() {
+        return getTagValue("id");
+    }
+
+    /**
+     * @return the client nonce for the message.
+     */
+    @Unofficial
+    public Optional<String> getNonce() {
+        return getTagValue(NONCE_TAG_NAME);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/MessageDeleteError.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/MessageDeleteError.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.Value;
+
+/**
+ * Failed to delete a message
+ */
+@Value
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class MessageDeleteError extends AbstractChannelEvent {
+
+    /**
+     * Event Constructor
+     *
+     * @param channel       The channel that this event originates from.
+     */
+    public MessageDeleteError(EventChannel channel) {
+        super(channel);
+    }
+
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/MessageDeleteSuccess.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/MessageDeleteSuccess.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.Value;
+
+/**
+ * Successfully deleted a message
+ */
+@Value
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class MessageDeleteSuccess extends AbstractChannelEvent {
+
+	/**
+	 * Event Constructor
+	 *
+	 * @param channel       The channel that this event originates from.
+	 */
+	public MessageDeleteSuccess(EventChannel channel) {
+		super(channel);
+	}
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
@@ -1,0 +1,63 @@
+package com.github.twitch4j.common.util;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.Map;
+
+/**
+ * Meta-info regarding the <i>parent</i> message being replied to.
+ */
+@Value
+@Unofficial
+public class ChatReply {
+
+    public static final String REPLY_MSG_ID_TAG_NAME = "reply-parent-msg-id";
+
+    /**
+     * The msgId of the original message being replied to.
+     */
+    @NonNull
+    String messageId;
+
+    /**
+     * The text of the original message being replied to.
+     */
+    String messageBody;
+
+    /**
+     * The id of the user who originally sent the message being replied to.
+     */
+    String userId;
+
+    /**
+     * The login name of the user who originally sent the message being replied to.
+     */
+    String userLogin;
+
+    /**
+     * The display name of the user who originally sent the message being replied to.
+     */
+    String displayName;
+
+    /**
+     * Attempts to parse a {@link ChatReply} instance from chat tags.
+     *
+     * @param tags the message tags associated with a reply.
+     * @return the parsed {@link ChatReply}, or null if unsuccessful
+     */
+    public static ChatReply parse(final Map<String, String> tags) {
+        final String msgId;
+        if (tags == null || (msgId = tags.get(REPLY_MSG_ID_TAG_NAME)) == null || msgId.isEmpty())
+            return null;
+
+        return new ChatReply(
+            msgId,
+            tags.get("reply-parent-msg-body"),
+            tags.get("reply-parent-user-id"),
+            tags.get("reply-parent-user-login"),
+            tags.get("reply-parent-display-name")
+        );
+    }
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
@@ -6,6 +6,8 @@ import lombok.Value;
 
 import java.util.Map;
 
+import static com.github.twitch4j.common.util.EscapeUtils.unescapeTagValue;
+
 /**
  * Meta-info regarding the <i>parent</i> message being replied to.
  */
@@ -54,10 +56,10 @@ public class ChatReply {
 
         return new ChatReply(
             msgId,
-            tags.get("reply-parent-msg-body"),
+            unescapeTagValue(tags.get("reply-parent-msg-body")),
             tags.get("reply-parent-user-id"),
             tags.get("reply-parent-user-login"),
-            tags.get("reply-parent-display-name")
+            unescapeTagValue(tags.get("reply-parent-display-name"))
         );
     }
 }

--- a/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
@@ -12,10 +12,30 @@ public class EscapeUtils {
      * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Offical spec</a>
      */
     public static String escapeTagValue(Object value) {
-        if (value == null) return "";
-        char[] unescaped = value.toString().toCharArray();
-        StringBuilder sb = new StringBuilder(unescaped.length);
-        for (char c : unescaped) {
+        final String unescapedString;
+        if (value == null || (unescapedString = value.toString()) == null) return "";
+
+        final char[] unescaped = unescapedString.toCharArray();
+        final int n = unescaped.length;
+
+        // Determine the index of the first replacement needed in the string
+        int firstReplacement = -1;
+        for (int i = 0; i < n; i++) {
+            char c = unescaped[i];
+            if (c == ';' || c == ' ' || c == '\\' || c == '\r' || c == '\n') {
+                firstReplacement = i;
+                break;
+            }
+        }
+
+        // When no replacements are needed, skip allocating the StringBuilder and copying over the chars
+        if (firstReplacement < 0) return unescapedString;
+
+        // Otherwise: replacement(s) are needed
+        final StringBuilder sb = new StringBuilder(n + 1); // Set capacity to length of string plus one replacement
+        sb.append(unescaped, 0, firstReplacement); // Copy over the region of the string that requires no replacements
+        for (int i = firstReplacement; i < n; i++) { // Perform replacements on the rest of the string as needed
+            char c = unescaped[i];
             switch (c) {
                 case ';':
                     sb.append("\\:");

--- a/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
@@ -1,0 +1,70 @@
+package com.github.twitch4j.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class EscapeUtils {
+
+    /**
+     * Escapes a value for use in an IRCv3 message tag.
+     *
+     * @param value the unescaped message tag value
+     * @return the escaped tag value
+     * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Offical spec</a>
+     */
+    public static String escapeTagValue(Object value) {
+        if (value == null) return "";
+        char[] unescaped = value.toString().toCharArray();
+        StringBuilder sb = new StringBuilder(unescaped.length);
+        for (char c : unescaped) {
+            switch (c) {
+                case ';':
+                    sb.append("\\:");
+                    break;
+                case ' ':
+                    sb.append("\\s");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Unescapes a value used in a IRCv3 message tag.
+     *
+     * @param value the escaped message tag value
+     * @return the unescaped value
+     * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Offical spec</a>
+     */
+    public static String unescapeTagValue(String value) {
+        return StringUtils.replaceEach(
+            value,
+            new String[] {
+                "\\:",
+                "\\s",
+                "\\\\",
+                "\\r",
+                "\\n"
+            },
+            new String[] {
+                ";",
+                " ",
+                "\\",
+                "\r",
+                "\n"
+            }
+        );
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Fixes #173

### Changes Proposed
* Add methods to `TwitchChat` to send messages with nonce/reply msg id/other arbitrary tags
* Add nonce & reply info to `ChannelMessageEvent` (currently not applicable to other events)
* Add convenient id & nonce getters to `IRCMessageEvent`
* Add `TwitchChat#delete(String, String)`
