### PR TITLE
feat: fire specialized roomstate events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.events.channel.*;
+import com.github.twitch4j.chat.events.roomstate.*;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -499,22 +500,34 @@ public class IRCEventHandler {
                 event.getTags().forEach((k, v) -> {
                     switch (k) {
                         case "broadcaster-lang":
-                            states.put(ChannelStateEvent.ChannelState.BROADCAST_LANG, (v != null) ? Locale.forLanguageTag(v) : v);
+                            Locale locale = v != null ? Locale.forLanguageTag(v) : null;
+                            states.put(ChannelStateEvent.ChannelState.BROADCAST_LANG, locale);
+                            eventManager.publish(new BroadcasterLanguageEvent(channel, locale));
                             break;
                         case "emote-only":
-                            states.put(ChannelStateEvent.ChannelState.EMOTE, v.equals("1"));
+                            boolean eoActive = "1".equals(v);
+                            states.put(ChannelStateEvent.ChannelState.EMOTE, eoActive);
+                            eventManager.publish(new EmoteOnlyEvent(channel, eoActive));
                             break;
                         case "followers-only":
-                            states.put(ChannelStateEvent.ChannelState.FOLLOWERS, Long.parseLong(v));
+                            long followDelay = Long.parseLong(v);
+                            states.put(ChannelStateEvent.ChannelState.FOLLOWERS, followDelay);
+                            eventManager.publish(new FollowersOnlyEvent(channel, followDelay));
                             break;
                         case "r9k":
-                            states.put(ChannelStateEvent.ChannelState.R9K, v.equals("1"));
+                            boolean uniqActive = "1".equals(v);
+                            states.put(ChannelStateEvent.ChannelState.R9K, uniqActive);
+                            eventManager.publish(new Robot9000Event(channel, uniqActive));
                             break;
                         case "slow":
-                            states.put(ChannelStateEvent.ChannelState.SLOW, Long.parseLong(v));
+                            long slowDelay = Long.parseLong(v);
+                            states.put(ChannelStateEvent.ChannelState.SLOW, slowDelay);
+                            eventManager.publish(new SlowModeEvent(channel, slowDelay));
                             break;
                         case "subs-only":
-                            states.put(ChannelStateEvent.ChannelState.SUBSCRIBERS, v.equals("1"));
+                            boolean subActive = "1".equals(v);
+                            states.put(ChannelStateEvent.ChannelState.SUBSCRIBERS, subActive);
+                            eventManager.publish(new SubscribersOnlyEvent(channel, subActive));
                             break;
                         default:
                             break;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/BroadcasterLanguageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/BroadcasterLanguageEvent.java
@@ -2,7 +2,7 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 import java.util.Locale;
@@ -11,14 +11,15 @@ import java.util.Locale;
  * Broadcaster Language Event
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Deprecated
 public class BroadcasterLanguageEvent extends ChannelStatesEvent {
 
     /**
      * Language
      */
-	private final Locale language;
+    Locale language;
 
     /**
      * Constructor

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/ChannelStatesEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/ChannelStatesEvent.java
@@ -2,16 +2,16 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Abstract Channel State Event
  */
-@Data
 @Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class ChannelStatesEvent extends AbstractChannelEvent {
 
 	private final boolean active;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/EmoteOnlyEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/EmoteOnlyEvent.java
@@ -2,16 +2,16 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 /**
  * Emote Only State Event
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
-public class EmoteOnlyEvent extends ChannelStatesEvent{
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class EmoteOnlyEvent extends ChannelStatesEvent {
 
     /**
      * Constructor

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/FollowersOnlyEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/FollowersOnlyEvent.java
@@ -2,7 +2,7 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 import java.util.concurrent.TimeUnit;
@@ -11,11 +11,14 @@ import java.util.concurrent.TimeUnit;
  * Followers Only State Event
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
-public class FollowersOnlyEvent extends ChannelStatesEvent{
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class FollowersOnlyEvent extends ChannelStatesEvent {
 
-	private final long time;
+    /**
+     * Time in  seconds
+     */
+    long time;
 
 	public FollowersOnlyEvent(EventChannel channel, long time, TimeUnit timeUnit) {
 		super(channel, time > -1);

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/Robot9000Event.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/Robot9000Event.java
@@ -2,16 +2,16 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 /**
  * R9K State Event
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
-public class Robot9000Event extends ChannelStatesEvent{
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class Robot9000Event extends ChannelStatesEvent {
 
     /**
      * Constructor

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/SlowModeEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/SlowModeEvent.java
@@ -2,20 +2,20 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 /**
  * Slow Mode State Event
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class SlowModeEvent extends ChannelStatesEvent {
 	/**
-	 * time in seconds
+	 * Time in seconds
 	 */
-	private final long time;
+    long time;
 
     /**
      * Constructor

--- a/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/SubscribersOnlyEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/roomstate/SubscribersOnlyEvent.java
@@ -2,16 +2,16 @@ package com.github.twitch4j.chat.events.roomstate;
 
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 /**
  * Subscribers Only State Event
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
-public class SubscribersOnlyEvent extends ChannelStatesEvent{
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class SubscribersOnlyEvent extends ChannelStatesEvent {
 
     /**
      * Constructor


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Fixes #170

### Changes Proposed
* Fire the events from IRCEventHandler#onChannelState
* Fix up the event classes

### Additional Information 
On [2019-03-08](https://dev.twitch.tv/docs/change-log), `broadcaster-lang` was removed from the `ROOMSTATE` docs, so I marked the event as deprecated.
