### PR TITLE
feat: allow owner designation via builder and CommandPermission

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -150,6 +151,11 @@ public class TwitchChat implements AutoCloseable {
     protected volatile Boolean stopQueueThread = false;
 
     /**
+     * Bot Owner IDs
+     */
+    protected final Collection<String> botOwnerIds;
+
+    /**
      * IRC Command Handlers
      */
     protected final List<String> commandPrefixes;
@@ -203,14 +209,16 @@ public class TwitchChat implements AutoCloseable {
      * @param taskExecutor ScheduledThreadPoolExecutor
      * @param chatQueueTimeout Timeout to wait for events in Chat Queue
      * @param proxyConfig Proxy Configuration
+     * @param botOwnerIds Bot Owner IDs
      */
-    public TwitchChat(EventManager eventManager, CredentialManager credentialManager, OAuth2Credential chatCredential, String baseUrl, boolean sendCredentialToThirdPartyHost, List<String> commandPrefixes, Integer chatQueueSize, Bandwidth chatRateLimit, Bandwidth[] whisperRateLimit, ScheduledThreadPoolExecutor taskExecutor, long chatQueueTimeout, ProxyConfig proxyConfig) {
+    public TwitchChat(EventManager eventManager, CredentialManager credentialManager, OAuth2Credential chatCredential, String baseUrl, boolean sendCredentialToThirdPartyHost, List<String> commandPrefixes, Integer chatQueueSize, Bandwidth chatRateLimit, Bandwidth[] whisperRateLimit, ScheduledThreadPoolExecutor taskExecutor, long chatQueueTimeout, ProxyConfig proxyConfig, Collection<String> botOwnerIds) {
         this.eventManager = eventManager;
         this.credentialManager = credentialManager;
         this.chatCredential = chatCredential;
         this.baseUrl = baseUrl;
         this.sendCredentialToThirdPartyHost = sendCredentialToThirdPartyHost;
         this.commandPrefixes = commandPrefixes;
+        this.botOwnerIds = botOwnerIds;
         this.ircCommandQueue = new ArrayBlockingQueue<>(chatQueueSize, true);
         this.whisperCommandQueue = new LinkedBlockingQueue<>();
         this.chatRateLimit = chatRateLimit;
@@ -462,7 +470,7 @@ public class TwitchChat implements AutoCloseable {
                                 else
                                 {
                                     try {
-                                        IRCMessageEvent event = new IRCMessageEvent(message);
+                                        IRCMessageEvent event = new IRCMessageEvent(message, botOwnerIds);
 
                                         if(event.isValid()) {
                                             eventManager.publish(event);

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -9,12 +9,14 @@ import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.util.ThreadUtils;
 import io.github.bucket4j.Bandwidth;
 import lombok.*;
+import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -80,6 +82,13 @@ public class TwitchChatBuilder {
      */
     @With
     private boolean sendCredentialToThirdPartyHost = false;
+
+    /**
+     * User IDs of Bot Owners for applying {@link com.github.twitch4j.common.enums.CommandPermission#OWNER}
+     */
+    @Setter
+    @Accessors(chain = true)
+    protected Collection<String> botOwnerIds = new HashSet<>();
 
     /**
      * IRC Command Handlers
@@ -148,7 +157,7 @@ public class TwitchChatBuilder {
         }
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.chatRateLimit, this.whisperRateLimit, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.botOwnerIds);
     }
 
     /**
@@ -170,6 +179,28 @@ public class TwitchChatBuilder {
      */
     public TwitchChatBuilder withCommandTriggers(Collection<String> commandTrigger) {
         this.commandPrefixes.addAll(commandTrigger);
+        return this;
+    }
+
+    /**
+     * With a Bot Owner's User ID
+     *
+     * @param userId the user id
+     * @return TwitchChatBuilder
+     */
+    public TwitchChatBuilder withBotOwnerId(String userId) {
+        this.botOwnerIds.add(userId);
+        return this;
+    }
+
+    /**
+     * With multiple Bot Owner User IDs
+     *
+     * @param botOwnerIds the user ids
+     * @return TwitchChatBuilder
+     */
+    public TwitchChatBuilder withBotOwnerIds(Collection<String> botOwnerIds) {
+        this.botOwnerIds.addAll(botOwnerIds);
         return this;
     }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -90,18 +90,28 @@ public class IRCMessageEvent extends TwitchEvent {
 	 */
 	private final String rawMessage;
 
-	/**
-	 * Event Constructor
-	 *
-	 * @param rawMessage      The raw message.
-	 */
-	public IRCMessageEvent(String rawMessage) {
+    /**
+     * Event Constructor
+     *
+     * @param rawMessage The raw message.
+     */
+    public IRCMessageEvent(String rawMessage) {
+        this(rawMessage, null);
+    }
+
+    /**
+     * Event Constructor
+     *
+     * @param rawMessage  The raw message.
+     * @param botOwnerIds The bot owner ids.
+     */
+	public IRCMessageEvent(String rawMessage, Collection<String> botOwnerIds) {
 		this.rawMessage = rawMessage;
 
 		this.parseRawMessage();
 
         // permissions and badges
-		getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges));
+		getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds));
 		getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
 	}
 

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -26,6 +26,10 @@ public class TwitchUtils {
     }
 
     public static Set<CommandPermission> getPermissionsFromTags(@NonNull Map<String, Object> tags, @NonNull Map<String, String> badges) {
+        return getPermissionsFromTags(tags, badges, null, null);
+    }
+
+    public static Set<CommandPermission> getPermissionsFromTags(@NonNull Map<String, Object> tags, @NonNull Map<String, String> badges, String userId, Collection<String> botOwnerIds) {
         Set<CommandPermission> permissionSet = EnumSet.of(CommandPermission.EVERYONE);
 
         // Check for Permissions
@@ -94,6 +98,9 @@ public class TwitchUtils {
                 */
             }
         }
+
+        if (userId != null && botOwnerIds != null && botOwnerIds.contains(userId))
+            permissionSet.add(CommandPermission.OWNER);
 
         return permissionSet;
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -34,8 +34,10 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,6 +137,11 @@ public class TwitchPubSub implements AutoCloseable {
     protected final ScheduledExecutorService taskExecutor;
 
     /**
+     * Bot Owner IDs
+     */
+    private final Collection<String> botOwnerIds;
+
+    /**
      * WebSocket Factory
      */
     protected final WebSocketFactory webSocketFactory;
@@ -171,9 +178,11 @@ public class TwitchPubSub implements AutoCloseable {
      * @param eventManager EventManager
      * @param taskExecutor ScheduledThreadPoolExecutor
      * @param proxyConfig  ProxyConfig
+     * @param botOwnerIds  Bot Owner IDs
      */
-    public TwitchPubSub(EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig) {
+    public TwitchPubSub(EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds) {
         this.taskExecutor = taskExecutor;
+        this.botOwnerIds = botOwnerIds;
         this.eventManager = eventManager;
         // register with serviceMediator
         this.eventManager.getServiceMediator().addService("twitch4j-pubsub", this);
@@ -374,7 +383,7 @@ public class TwitchPubSub implements AutoCloseable {
 
                                 String body = msgDataParsed.get("body").asText();
 
-                                Set<CommandPermission> permissions = TwitchUtils.getPermissionsFromTags(tags);
+                                Set<CommandPermission> permissions = TwitchUtils.getPermissionsFromTags(tags, new HashMap<>(), fromId, botOwnerIds);
 
                                 PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(eventUser, body, permissions);
                                 eventManager.publish(privateMessageEvent);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -4,9 +4,12 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.ThreadUtils;
 import lombok.*;
+import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 /**
@@ -37,6 +40,13 @@ public class TwitchPubSubBuilder {
     private ProxyConfig proxyConfig = null;
 
     /**
+     * User IDs of Bot Owners for applying {@link com.github.twitch4j.common.enums.CommandPermission#OWNER}
+     */
+    @Setter
+    @Accessors(chain = true)
+    private Collection<String> botOwnerIds = new HashSet<>();
+
+    /**
      * Initialize the builder
      *
      * @return Twitch PubSub Builder
@@ -60,7 +70,28 @@ public class TwitchPubSubBuilder {
             eventManager.autoDiscovery();
         }
 
-        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig);
+        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds);
     }
 
+    /**
+     * With a Bot Owner's User ID
+     *
+     * @param userId the user id
+     * @return TwitchPubSubBuilder
+     */
+    public TwitchPubSubBuilder withBotOwnerId(String userId) {
+        this.botOwnerIds.add(userId);
+        return this;
+    }
+
+    /**
+     * With multiple Bot Owner User IDs
+     *
+     * @param botOwnerIds the user ids
+     * @return TwitchPubSubBuilder
+     */
+    public TwitchPubSubBuilder withBotOwnerIds(Collection<String> botOwnerIds) {
+        this.botOwnerIds.addAll(botOwnerIds);
+        return this;
+    }
 }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -22,10 +22,12 @@ import com.github.twitch4j.tmi.TwitchMessagingInterface;
 import com.github.twitch4j.tmi.TwitchMessagingInterfaceBuilder;
 import io.github.bucket4j.Bandwidth;
 import lombok.*;
+import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -98,6 +100,13 @@ public class TwitchClientBuilder {
      */
     @With
     private Boolean enableChat = false;
+
+    /**
+     * User IDs of Bot Owners for applying {@link com.github.twitch4j.common.enums.CommandPermission#OWNER}
+     */
+    @Setter
+    @Accessors(chain = true)
+    protected Collection<String> botOwnerIds = new HashSet<>();
 
     /**
      * IRC Command Handlers
@@ -183,6 +192,17 @@ public class TwitchClientBuilder {
      */
     @With
     private ProxyConfig proxyConfig = null;
+
+    /**
+     * With a Bot Owner's User ID
+     *
+     * @param userId the user id
+     * @return TwitchClientBuilder
+     */
+    public TwitchClientBuilder withBotOwnerId(String userId) {
+        this.botOwnerIds.add(userId);
+        return this;
+    }
 
     /**
      * With a CommandTrigger
@@ -290,6 +310,7 @@ public class TwitchClientBuilder {
                 .withChatQueueTimeout(chatQueueTimeout)
                 .withCommandTriggers(commandPrefixes)
                 .withProxyConfig(proxyConfig)
+                .setBotOwnerIds(botOwnerIds)
                 .build();
         }
 
@@ -300,6 +321,7 @@ public class TwitchClientBuilder {
                 .withEventManager(eventManager)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withProxyConfig(proxyConfig)
+                .setBotOwnerIds(botOwnerIds)
                 .build();
         }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 

* Fixes #169 <sup>(nice)</sup>


### Changes Proposed

* Allow bot owner id's to be specified in `TwitchClientBuilder`, `TwitchChatBuilder`, `TwitchPubSubBuilder`
* Update `TwitchUtils` to consider user id's
* Chat: `IRCMessageEvent`'s `commandPermissions` will contain `CommandPermission.OWNER` when appropriate
* PubSub: `PrivateMessageEvent`'s `permissions` will contain `CommandPermission.OWNER` when appropriate
