### PR TITLE
fix: ignore missing properties in kraken result lists

### DIFF
--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenIngestList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenIngestList.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.List;
  * Model representing a list of ingest servers.
  */
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenIngestList {
 	/**
 	 * Data

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenSubscriptionList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenSubscriptionList.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -7,6 +8,7 @@ import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenSubscriptionList extends AbstractResultList {
 
 	private List<KrakenSubscription> subscriptions;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamList.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.List;
  * Model representing teams.
  */
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenTeamList {
 	/**
 	 * Data

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUserList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUserList.java
@@ -1,10 +1,12 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenUserList {
 	/**
 	 * Data


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
Running into `com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "_total" (class com.github.twitch4j.kraken.domain.KrakenUserList), not marked as ignorable (one known property: "users"])` after updating to `1.1.1` - I would guess that [switching to our own ObjectMapper](https://github.com/twitch4j/twitch4j/commit/dc2d3773b678a293d35eba7b58db2009ca19232c#diff-74d77f21f2c1932bbe4611b84d52acfaR97) had a different default configuration than what was used by feign.

### Changes Proposed

Add `JsonIgnoreProperties` to a few classes to avoid this error
