### PR TITLE
feat: allow to overwrite the default event handler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ subprojects {
 			api group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
 
 			// Event Dispatcher
-			api group: 'com.github.philippheuer.events4j', name: 'events4j-core', version: '0.9.1'
-			api group: 'com.github.philippheuer.events4j', name: 'events4j-handler-simple', version: '0.9.1'
+			api group: 'com.github.philippheuer.events4j', name: 'events4j-core', version: '0.9.2'
+			api group: 'com.github.philippheuer.events4j', name: 'events4j-handler-simple', version: '0.9.2'
 
 			// Credential Manager
 			api group: 'com.github.philippheuer.credentialmanager', name: 'credentialmanager', version: '0.1.1'

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -326,7 +326,7 @@ public class TwitchChat implements AutoCloseable {
         log.debug("Registering the following command triggers: " + commandPrefixes.toString());
 
         // register event handler
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(ChannelMessageEvent.class, this::onChannelMessage);
+        eventManager.onEvent(ChannelMessageEvent.class, this::onChannelMessage);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.chat;
 import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.CredentialManagerBuilder;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
@@ -54,6 +55,12 @@ public class TwitchChatBuilder {
      */
     @With
     private EventManager eventManager;
+
+    /**
+     * EventManager
+     */
+    @With
+    private Class<? extends IEventHandler> defaultEventHandler = null;
 
     /**
      * Credential Manager
@@ -154,6 +161,9 @@ public class TwitchChatBuilder {
         if (eventManager == null) {
             eventManager = new EventManager();
             eventManager.autoDiscovery();
+        }
+        if (defaultEventHandler != null) {
+            eventManager.setDefaultEventHandler(defaultEventHandler);
         }
 
         log.debug("TwitchChat: Initializing Module ...");

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -49,26 +49,26 @@ public class IRCEventHandler {
         this.eventManager = twitchChat.getEventManager();
 
         // register event handlers
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannelMessage);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onWhisper);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onBitsBadgeTier);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannelCheer);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannelSubscription);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onClearChat);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannnelClientJoinEvent);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannnelClientLeaveEvent);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannelModChange);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onNoticeEvent);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onHostOnEvent);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onHostOffEvent);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onChannelState);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onGiftReceived);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onPayForward);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onRaid);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onUnraid);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onRewardGift);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onRitual);
-        eventManager.getEventHandler(SimpleEventHandler.class).onEvent(IRCMessageEvent.class, this::onMessageDeleteResponse);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannelMessage);
+        eventManager.onEvent(IRCMessageEvent.class, this::onWhisper);
+        eventManager.onEvent(IRCMessageEvent.class, this::onBitsBadgeTier);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannelCheer);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannelSubscription);
+        eventManager.onEvent(IRCMessageEvent.class, this::onClearChat);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannnelClientJoinEvent);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannnelClientLeaveEvent);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannelModChange);
+        eventManager.onEvent(IRCMessageEvent.class, this::onNoticeEvent);
+        eventManager.onEvent(IRCMessageEvent.class, this::onHostOnEvent);
+        eventManager.onEvent(IRCMessageEvent.class, this::onHostOffEvent);
+        eventManager.onEvent(IRCMessageEvent.class, this::onChannelState);
+        eventManager.onEvent(IRCMessageEvent.class, this::onGiftReceived);
+        eventManager.onEvent(IRCMessageEvent.class, this::onPayForward);
+        eventManager.onEvent(IRCMessageEvent.class, this::onRaid);
+        eventManager.onEvent(IRCMessageEvent.class, this::onUnraid);
+        eventManager.onEvent(IRCMessageEvent.class, this::onRewardGift);
+        eventManager.onEvent(IRCMessageEvent.class, this::onRitual);
+        eventManager.onEvent(IRCMessageEvent.class, this::onMessageDeleteResponse);
     }
 
     /**

--- a/chat/src/test/java/com/github/twitch4j/chat/TwitchChatTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/TwitchChatTest.java
@@ -50,7 +50,7 @@ public class TwitchChatTest {
         // listen for events in channel
         List<ChannelMessageEvent> channelMessages = new ArrayList<>();
         twitchChat.joinChannel("twitch4j");
-        twitchChat.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChannelMessageEvent.class, event -> {
+        twitchChat.getEventManager().onEvent(ChannelMessageEvent.class, event -> {
             channelMessages.add(event);
             log.debug(event.toString());
         });
@@ -72,11 +72,11 @@ public class TwitchChatTest {
         // listen for events in channel
         List<ChannelMessageEvent> channelMessages = new ArrayList<>();
         twitchChat.joinChannel("twitch4j");
-        twitchChat.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChannelMessageEvent.class, event -> {
+        twitchChat.getEventManager().onEvent(ChannelMessageEvent.class, event -> {
             log.debug(event.toString());
         });
 
-        twitchChat.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(CommandEvent.class, event -> {
+        twitchChat.getEventManager().onEvent(CommandEvent.class, event -> {
             log.debug(event.toString());
         });
 

--- a/docs/content/events/_index.md
+++ b/docs/content/events/_index.md
@@ -21,13 +21,38 @@ eventManager.publish(object);
 
 ## Handle / Process Events
 
-By default Twitch4J uses the `SimpleHandler` which works on all platforms.
+Twitch4J uses the `SimpleHandler` by default which works on all platforms.
 
 Handlers:
 
 - SimpleHandler
 - ReactorHandler
 - SpringHandler
+
+You can register listeners directly on the eventManager, the call is forwarded and registered on the current `defaultEventHandler` set in the eventManager instance.
+
+##### Switch the default event handler
+
+If you want all your events to be processed by a specific eventHandler, then check out the following pages on all available eventHandlers:
+
+* [SimpleEventHandler (Default)](./ceventhandler-simple)
+* [ReactorEventHandler](./ceventhandler-reactor)
+
+##### Register your event listeners in a generic way
+
+Only the consumers registered with `eventManager.onEvent` will use the `defaultEventHandler`.
+
+```java
+// register handler
+IDisposable handlerReg = twitchClient.getEventManager().onEvent(ChannelMessageEvent.class, event -> {
+	System.out.println("[" + event.getChannel().getName() + "]["+event.getPermissions().toString()+"] " + event.getUser().getName() + ": " + event.getMessage());
+});
+
+// cancel handler (don't call the method for new events of the required type anymore)
+handlerReg.dispose();
+```
+
+This is the recommended method to register listeners, as you can switch between the different EventHandlers by chaning a single line of code.
 
 ### Simple Handler
 

--- a/docs/content/events/eventhandler-reactor.md
+++ b/docs/content/events/eventhandler-reactor.md
@@ -1,0 +1,38 @@
++++
+title="EventHandler - Reactor"
+weight = 202
++++
+
+# EventHandler - Reactor
+
+## Description
+
+The ReactorEventHandler will process all events asynchronous in a threadpool with at least 4 threads.
+
+Check out the following class if you want to customize the parameters used when building a ReactorEventHandler instance:
+
+- [ReactorEventHandler.java](https://github.com/PhilippHeuer/events4j/blob/master/handler-reactor/src/main/java/com/github/philippheuer/events4j/reactor/ReactorEventHandler.java)
+
+## Dependencies
+
+Gradle:
+
+`api group: 'com.github.philippheuer.events4j', name: 'events4j-handler-reactor', version: '0.9.2'`
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.github.philippheuer.events4j</groupId>
+    <artifactId>events4j-handler-reactor</artifactId>
+    <version>0.9.2</version>
+</dependency>
+```
+
+## Set as default in Twitch4J and for eventManager.onEvent
+
+```java
+TwitchClient twitchClient = TwitchClientBuilder.builder()
+    .withDefaultEventHandler(ReactorEventHandler.class)
+    .build();
+```

--- a/docs/content/events/eventhandler-simple.md
+++ b/docs/content/events/eventhandler-simple.md
@@ -1,0 +1,34 @@
++++
+title="EventHandler - Simple"
+weight = 201
++++
+
+# EventHandler - Simple
+
+## Description
+
+The SimpleEventHandler will process all events synchronous in the current thread.
+
+## Dependencies
+
+Gradle:
+
+`api group: 'com.github.philippheuer.events4j', name: 'events4j-handler-simple', version: '0.9.2'`
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.github.philippheuer.events4j</groupId>
+    <artifactId>events4j-handler-simple</artifactId>
+    <version>0.9.2</version>
+</dependency>
+```
+
+## Set as default in Twitch4J and for eventManager.onEvent
+
+```java
+TwitchClient twitchClient = TwitchClientBuilder.builder()
+    .withDefaultEventHandler(SimpleEventHandler.class)
+    .build();
+```

--- a/docs/content/pubsub/topic-bits-events.md
+++ b/docs/content/pubsub/topic-bits-events.md
@@ -29,5 +29,5 @@ Subscribe to all cheers to user twitch4j and register a listener that prints all
 ```java
 twitchClient.getPubSub().listenForCheerEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChannelBitsEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ChannelBitsEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-channel-points-events.md
+++ b/docs/content/pubsub/topic-channel-points-events.md
@@ -29,8 +29,6 @@ None
 
 ```java
 twitchClient.getPubSub().listenForChannelPointsRedemptionEvents(credential, "149223493");
-
-SimpleEventHandler eventHandler = twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class);
 ```
 
 ### Listen for Custom Reward Redemptions
@@ -38,7 +36,7 @@ SimpleEventHandler eventHandler = twitchClient.getEventManager().getEventHandler
 Fired when a _custom_ reward is redeemed in the channel.
 
 ```java
-eventHandler.onEvent(RewardRedeemedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(RewardRedeemedEvent.class, System.out::println);
 ```
 
 ### Listen for Redemption Status Updates
@@ -50,7 +48,7 @@ Fired when the status of a redemption changes (e.g. completed or rejected).
 Note that, at the time of writing, the status is `ACTION_TAKEN` whether the reward was completed or rejected, rather than `FULFILLED` or `UNFULFILLED`.
 
 ```java
-eventHandler.onEvent(RedemptionStatusUpdateEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(RedemptionStatusUpdateEvent.class, System.out::println);
 ```
 
 ### Listen for Reward Creations
@@ -60,7 +58,7 @@ Not documented by Twitch.
 Fired when a _custom_ reward is **created**.
 
 ```java
-eventHandler.onEvent(CustomRewardCreatedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(CustomRewardCreatedEvent.class, System.out::println);
 ```
 
 ### Listen for Reward Updates
@@ -70,7 +68,7 @@ Not documented by Twitch.
 Fired when a _custom_ reward is **updated**.
 
 ```java
-eventHandler.onEvent(CustomRewardUpdatedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(CustomRewardUpdatedEvent.class, System.out::println);
 ```
 
 ### Listen for Reward Deletions
@@ -80,7 +78,7 @@ Not documented by Twitch.
 Fired when _custom_ reward is **deleted**.
 
 ```java
-eventHandler.onEvent(CustomRewardDeletedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(CustomRewardDeletedEvent.class, System.out::println);
 ```
 
 ### Listen for Update Redemption Status Progress
@@ -90,7 +88,7 @@ Not documented by Twitch.
 Fired when there is an update to the redemption progress.
 
 ```java
-eventHandler.onEvent(UpdateRedemptionProgressEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(UpdateRedemptionProgressEvent.class, System.out::println);
 ```
 
 ### Listen for Update Redemption Status Completion
@@ -100,5 +98,5 @@ Not documented by Twitch.
 Fired when the redemption progress has completed.
 
 ```java
-eventHandler.onEvent(UpdateRedemptionFinishedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(UpdateRedemptionFinishedEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-commerce-events.md
+++ b/docs/content/pubsub/topic-commerce-events.md
@@ -29,5 +29,5 @@ Subscribe to all commerce purchases in the twitch4j channel and register a liste
 ```java
 twitchClient.getPubSub().listenForCommerceEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChannelCommerceEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ChannelCommerceEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-following-events.md
+++ b/docs/content/pubsub/topic-following-events.md
@@ -28,5 +28,5 @@ Subscribe to new follower events for user twitch4j and register a listener that 
 ```java
 twitchClient.getPubSub().listenForFollowingEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(FollowingEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(FollowingEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-friendship-events.md
+++ b/docs/content/pubsub/topic-friendship-events.md
@@ -32,5 +32,5 @@ Subscribe to friendship events for user twitch4j and register a listener that pr
 ```java
 twitchClient.getPubSub().listenForFriendshipEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(FriendshipEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(FriendshipEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-hype-train-events.md
+++ b/docs/content/pubsub/topic-hype-train-events.md
@@ -24,42 +24,40 @@ With all undocumented topics, use at your own risk.
 
 ```java
 twitchClient.getPubSub().listenForHypeTrainEvents(credential, "149223493");
-
-SimpleEventHandler eventHandler = twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class);
 ```
 
 ### Listen for Hype Train Starts
 
 ```java
-eventHandler.onEvent(HypeTrainStartEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainStartEvent.class, System.out::println);
 ```
 
 ### Listen for Hype Train Progression
 
 ```java
-eventHandler.onEvent(HypeTrainProgressionEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainProgressionEvent.class, System.out::println);
 ```
 
 ### Listen for Hype Train Level Ups
 
 ```java
-eventHandler.onEvent(HypeTrainLevelUpEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainLevelUpEvent.class, System.out::println);
 ```
 
 ### Listen for Hype Train Ends
 
 ```java
-eventHandler.onEvent(HypeTrainEndEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainEndEvent.class, System.out::println);
 ```
 
 ### Listen for Conductor Updates
 
 ```java
-eventHandler.onEvent(HypeTrainConductorUpdateEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainConductorUpdateEvent.class, System.out::println);
 ```
 
 ### Listen for Cooldown Expiration
 
 ```java
-eventHandler.onEvent(HypeTrainCooldownExpirationEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainCooldownExpirationEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-hype-train-rewards.md
+++ b/docs/content/pubsub/topic-hype-train-rewards.md
@@ -25,5 +25,5 @@ Subscribe to hype train rewards for channel `twitch4j` and register a listener t
 ```java
 twitchClient.getPubSub().listenForHypeTrainRewardEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(HypeTrainRewardsEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(HypeTrainRewardsEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-leaderboard-events.md
+++ b/docs/content/pubsub/topic-leaderboard-events.md
@@ -45,11 +45,11 @@ twitchClient.getPubSub().listenForLeaderboardMonthlyEvents(credential, "14922349
 ### Listen: Bits Leaderboard Update
 
 ```java
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(BitsLeaderboardEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(BitsLeaderboardEvent.class, System.out::println);
 ```
 
 ### Listen: Sub Gifts Leaderboard Update
 
 ```java
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(SubLeaderboardEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(SubLeaderboardEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-moderation-events.md
+++ b/docs/content/pubsub/topic-moderation-events.md
@@ -31,7 +31,7 @@ Subscribe to all moderation events in the twitch4j channel and register a listen
 ```java
 twitchClient.getPubSub().listenForModerationEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChatModerationEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ChatModerationEvent.class, System.out::println);
 ```
 
 ### Unofficial

--- a/docs/content/pubsub/topic-onsite-notifications.md
+++ b/docs/content/pubsub/topic-onsite-notifications.md
@@ -29,10 +29,10 @@ Subscribe to all onsite notifications for user `twitch4j` and register listeners
 twitchClient.getPubSub().listenForOnsiteNotificationEvents(credential, "149223493");
 
 // Listen to notification creations
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(OnsiteNotificationCreationEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(OnsiteNotificationCreationEvent.class, System.out::println);
 
 // Listen for notification summary updates
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(UpdateOnsiteNotificationSummaryEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(UpdateOnsiteNotificationSummaryEvent.class, System.out::println);
 ```
 
 ### Example: Live status monitoring
@@ -55,7 +55,7 @@ interestedChannelIds.add("142621956");
 twitchClient.getPubSub().listenForOnsiteNotificationEvents(credential, userId);
 
 // Listen to notification creations
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(OnsiteNotificationCreationEvent.class, e -> {
+twitchClient.getEventManager().onEvent(OnsiteNotificationCreationEvent.class, e -> {
 	OnsiteNotification notification = e.getData().getNotification();
 	if ("streamup".equalsIgnoreCase(notification.getType())) {
 		List<OnsiteNotification.Creator> creators = notification.getCreators();

--- a/docs/content/pubsub/topic-poll-events.md
+++ b/docs/content/pubsub/topic-poll-events.md
@@ -32,5 +32,5 @@ Subscribe to all poll events in channel `twitch4j` and register a listener that 
 ```java
 twitchClient.getPubSub().listenForPollEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(PollsEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(PollsEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-presence-events.md
+++ b/docs/content/pubsub/topic-presence-events.md
@@ -39,10 +39,10 @@ Subscribe to presence events for user `twitch4j` and register a listener that pr
 twitchClient.getPubSub().listenForPresenceEvents(credential, "149223493");
 
 // Listen for presence updates
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(UserPresenceEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(UserPresenceEvent.class, System.out::println);
 
 // Listen for updates to the user's presence settings
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(PresenceSettingsEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(PresenceSettingsEvent.class, System.out::println);
 ```
 
 ### Example: Live status monitoring
@@ -54,7 +54,7 @@ Note: these events tend to be fired significantly faster than the documented ana
 Disclaimer: do not solely rely upon this code; fallback mechanisms should be employed as well.
 
 ```java
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(UserPresenceEvent.class, e -> {
+twitchClient.getEventManager().onEvent(UserPresenceEvent.class, e -> {
 	boolean wentLive = e.getData().getActivities().stream().anyMatch(a -> "broadcasting".equalsIgnoreCase(a.getType()));
 	if (wentLive) {
 		System.out.println(e); // Handle Go Live

--- a/docs/content/pubsub/topic-public-cheer-events.md
+++ b/docs/content/pubsub/topic-public-cheer-events.md
@@ -25,5 +25,5 @@ Subscribe to all cheerbombs in channel `twitch4j` and register a listener that p
 ```java
 twitchClient.getPubSub().listenForPublicCheerEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(CheerbombEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(CheerbombEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-raid-events.md
+++ b/docs/content/pubsub/topic-raid-events.md
@@ -27,11 +27,11 @@ Subscribe to all raid events in channel `twitch4j` and register a listener that 
 twitchClient.getPubSub().listenForRaidEvents(credential, "149223493");
 
 // Listen for the channel executing a raid
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(RaidGoEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(RaidGoEvent.class, System.out::println);
 
 // Listen for raid progress (counting down until the raid can go through)
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(RaidUpdateEvent.class, System.out::println);
+twitchClient.getEventManager()onEvent(RaidUpdateEvent.class, System.out::println);
 
 // Listen for raid cancellations
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(RaidCancelEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(RaidCancelEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-sub-gift-events.md
+++ b/docs/content/pubsub/topic-sub-gift-events.md
@@ -28,5 +28,5 @@ Subscribe to all sub gift events in channel `twitch4j` and register a listener t
 ```java
 twitchClient.getPubSub().listenForChannelSubGiftsEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChannelSubGiftEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ChannelSubGiftEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-subscribe-events.md
+++ b/docs/content/pubsub/topic-subscribe-events.md
@@ -29,5 +29,5 @@ Subscribe to all subscription events to the twitch4j channel and register a list
 ```java
 twitchClient.getPubSub().listenForSubscriptionEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(ChannelSubscribeEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ChannelSubscribeEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-user-community-points-events.md
+++ b/docs/content/pubsub/topic-user-community-points-events.md
@@ -29,10 +29,9 @@ Subscribe to all user community points events for `twitch4j` and register a list
 twitchClient.getPubSub().listenForUserChannelPointsEvents(credential, "149223493");
 
 // Register event listeners
-SimpleEventHandler eventHandler = twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class);
-eventHandler.onEvent(PointsEarnedEvent.class, System.out::println);
-eventHandler.onEvent(ClaimAvailableEvent.class, System.out::println);
-eventHandler.onEvent(ClaimClaimedEvent.class, System.out::println);
-eventHandler.onEvent(PointsSpentEvent.class, System.out::println);
-eventHandler.onEvent(RewardRedeemedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(PointsEarnedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ClaimAvailableEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(ClaimClaimedEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(PointsSpentEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(RewardRedeemedEvent.class, System.out::println);
 ```

--- a/docs/content/pubsub/topic-video-playback-events.md
+++ b/docs/content/pubsub/topic-video-playback-events.md
@@ -60,10 +60,10 @@ twitchClient.getPubSub().listenForVideoPlaybackByNameEvents(credential, "twitch4
 
 ```java
 // Handle all subtypes
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(VideoPlaybackEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(VideoPlaybackEvent.class, System.out::println);
 
 // Alternatively, only consider a specific subtype
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(VideoPlaybackEvent.class, e -> {
+twitchClient.getEventManager().onEvent(VideoPlaybackEvent.class, e -> {
 	if (e.getData().getType() == VideoPlaybackData.Type.STREAM_UP) {
 		System.out.println(e); // Handle Go Live
 	}

--- a/docs/content/pubsub/topic-whispers.md
+++ b/docs/content/pubsub/topic-whispers.md
@@ -31,5 +31,5 @@ Subscribe to all whispers to user twitch4j and register a listener that prints a
 ```java
 twitchClient.getPubSub().listenForWhisperEvents(credential, "149223493");
 
-twitchClient.getEventManager().getEventHandler(SimpleEventHandler.class).onEvent(PrivateMessageEvent.class, System.out::println);
+twitchClient.getEventManager().onEvent(PrivateMessageEvent.class, System.out::println);
 ```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.graphql;
 
+import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.common.config.ProxyConfig;
 import lombok.*;
@@ -19,6 +20,12 @@ public class TwitchGraphQLBuilder {
      */
     @With
     private EventManager eventManager = new EventManager();
+
+    /**
+     * EventManager
+     */
+    @With
+    private Class<? extends IEventHandler> defaultEventHandler = null;
 
     /**
      * Proxy Configuration
@@ -66,6 +73,14 @@ public class TwitchGraphQLBuilder {
         log.debug("GraphQL: Initializing Module ...");
         log.warn("GraphQL: GraphQL is a experimental module, please take care as some features might break unannounced.");
         TwitchGraphQL client = new TwitchGraphQL(eventManager, clientId, clientSecret, proxyConfig);
+
+        if (eventManager == null) {
+            eventManager = new EventManager();
+            eventManager.autoDiscovery();
+        }
+        if (defaultEventHandler != null) {
+            eventManager.setDefaultEventHandler(defaultEventHandler);
+        }
 
         // register with serviceMediator
         this.eventManager.getServiceMediator().addService("twitch4j-graphql", client);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub;
 
+import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.ThreadUtils;
@@ -26,6 +27,12 @@ public class TwitchPubSubBuilder {
      */
     @With
     private EventManager eventManager = null;
+
+    /**
+     * EventManager
+     */
+    @With
+    private Class<? extends IEventHandler> defaultEventHandler = null;
 
     /**
      * Scheduler Thread Pool Executor
@@ -68,6 +75,9 @@ public class TwitchPubSubBuilder {
         if (eventManager == null) {
             eventManager = new EventManager();
             eventManager.autoDiscovery();
+        }
+        if (defaultEventHandler != null) {
+            eventManager.setDefaultEventHandler(defaultEventHandler);
         }
 
         return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds);

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -3,7 +3,9 @@ package com.github.twitch4j;
 import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.CredentialManagerBuilder;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
+import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.auth.TwitchAuth;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.TwitchChatBuilder;
@@ -138,6 +140,12 @@ public class TwitchClientBuilder {
     private EventManager eventManager = null;
 
     /**
+     * EventManager
+     */
+    @With
+    private Class<? extends IEventHandler> defaultEventHandler = null;
+
+    /**
      * Size of the ChatQueue
      */
     @With
@@ -239,6 +247,9 @@ public class TwitchClientBuilder {
         if (eventManager == null) {
             eventManager = new EventManager();
             eventManager.autoDiscovery();
+        }
+        if (defaultEventHandler != null) {
+            eventManager.setDefaultEventHandler(defaultEventHandler);
         }
 
         // Determinate required threadPool size


### PR DESCRIPTION
# Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* allows to overwrite the default EventHandler in events4j, so that ie. the ReactorEventHandler can also used for internal events based on library user choice

Related to this: https://github.com/PhilippHeuer/events4j/commit/4d3e2344fa273c64c5e9f270f1607a180f8044a0