### PR TITLE
refactor: modernize timestamps, rename fields, improve javadocs

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/TimeUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TimeUtils.java
@@ -1,6 +1,10 @@
 package com.github.twitch4j.common.util;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 public class TimeUtils {
 
@@ -11,6 +15,14 @@ public class TimeUtils {
      */
     public static long getCurrentTimeInMillis() {
         return Calendar.getInstance().getTimeInMillis();
+    }
+
+    /**
+     * @param time an {@link Instant}
+     * @return a {@link Calendar} instance for the instant, in the system default zone
+     */
+    public static Calendar fromInstant(Instant time) {
+        return GregorianCalendar.from(ZonedDateTime.ofInstant(time, ZoneId.systemDefault()));
     }
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -30,13 +30,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -391,21 +387,15 @@ public class TwitchPubSub implements AutoCloseable {
                             } else if (topic.startsWith("community-points-channel-v1")) {
                                 String timestampText = msgData.path("timestamp").asText();
                                 Instant instant = Instant.parse(timestampText);
-                                Calendar timestamp = GregorianCalendar.from(
-                                    ZonedDateTime.ofInstant(
-                                        instant,
-                                        ZoneId.systemDefault()
-                                    )
-                                );
 
                                 switch (type) {
                                     case "reward-redeemed":
                                         ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                                        eventManager.publish(new RewardRedeemedEvent(timestamp, redemption));
+                                        eventManager.publish(new RewardRedeemedEvent(instant, redemption));
                                         break;
                                     case "redemption-status-update":
                                         ChannelPointsRedemption updatedRedemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                                        eventManager.publish(new RedemptionStatusUpdateEvent(timestamp, updatedRedemption));
+                                        eventManager.publish(new RedemptionStatusUpdateEvent(instant, updatedRedemption));
                                         break;
                                     case "custom-reward-created":
                                         ChannelPointsReward newReward = TypeConvert.convertValue(msgData.path("new_reward"), ChannelPointsReward.class);
@@ -507,9 +497,8 @@ public class TwitchPubSub implements AutoCloseable {
                                         eventManager.publish(new PointsSpentEvent(pointsSpent));
                                         break;
                                     case "reward-redeemed":
-                                        final Calendar timestamp = GregorianCalendar.from(ZonedDateTime.ofInstant(Instant.parse(msgData.path("timestamp").asText()), ZoneId.systemDefault()));
                                         final ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                                        eventManager.publish(new RewardRedeemedEvent(timestamp, redemption));
+                                        eventManager.publish(new RewardRedeemedEvent(Instant.parse(msgData.path("timestamp").asText()), redemption));
                                         break;
                                     case "global-last-viewed-content-updated":
                                     case "channel-last-viewed-content-updated":

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelPointsRedemptionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelPointsRedemptionEvent.java
@@ -1,10 +1,12 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.util.TimeUtils;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.time.Instant;
 import java.util.Calendar;
 
 @Data
@@ -14,11 +16,19 @@ public class ChannelPointsRedemptionEvent extends TwitchEvent {
     /**
      * The time the pubsub message was sent
      */
-    private final Calendar timestamp;
+    private final Instant time;
 
     /**
      * Data about the redemption, includes unique id and user that redeemed it
      */
     private final ChannelPointsRedemption redemption;
 
+    /**
+     * @return the timestamp for this event, in the system default zone
+     * @deprecated in favor of getTime()
+     */
+    @Deprecated
+    public Calendar getTimestamp() {
+        return TimeUtils.fromInstant(time);
+    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RedemptionStatusUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RedemptionStatusUpdateEvent.java
@@ -4,14 +4,14 @@ import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.util.Calendar;
+import java.time.Instant;
 
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class RedemptionStatusUpdateEvent extends ChannelPointsRedemptionEvent {
 
-	public RedemptionStatusUpdateEvent(Calendar timestamp, ChannelPointsRedemption redemption) {
-		super(timestamp, redemption);
-	}
+    public RedemptionStatusUpdateEvent(Instant timestamp, ChannelPointsRedemption redemption) {
+        super(timestamp, redemption);
+    }
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RewardRedeemedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RewardRedeemedEvent.java
@@ -4,14 +4,14 @@ import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.util.Calendar;
+import java.time.Instant;
 
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class RewardRedeemedEvent extends ChannelPointsRedemptionEvent {
 
-	public RewardRedeemedEvent(Calendar timestamp, ChannelPointsRedemption redemption) {
-		super(timestamp, redemption);
-	}
+    public RewardRedeemedEvent(Instant timestamp, ChannelPointsRedemption redemption) {
+        super(timestamp, redemption);
+    }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -6,7 +6,7 @@ import com.github.twitch4j.helix.webhooks.domain.WebhookRequest;
 import com.netflix.hystrix.HystrixCommand;
 import feign.*;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -289,8 +289,8 @@ public interface TwitchHelix {
         @Param("after") String after,
         @Param("before") String before,
         @Param("first") Integer limit,
-        @Param("started_at") Date startedAt,
-        @Param("ended_at") Date endedAt
+        @Param("started_at") Instant startedAt,
+        @Param("ended_at") Instant endedAt
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AnaylticsDateRange.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AnaylticsDateRange.java
@@ -1,13 +1,14 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -16,13 +17,34 @@ import java.util.Date;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AnaylticsDateRange {
 
     /** Starting date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z. */
-    private Date startedAt;
+    @JsonProperty("started_at")
+    private Instant startedAtInstant;
 
     /** Ending date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z. */
-    private Date endedAt;
+    @JsonProperty("ended_at")
+    private Instant endedAtInstant;
+
+    /**
+     * @return the starting timestamp for returned reports
+     * @deprecated in favor of getStartedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getStartedAt() {
+        return Date.from(startedAtInstant);
+    }
+
+    /**
+     * @return the ending timestamp for returned reports
+     * @deprecated in favor of getEndedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getEndedAt() {
+        return Date.from(endedAtInstant);
+    }
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
@@ -8,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -51,8 +54,19 @@ public class Clip {
     private Integer viewCount;
 
     /** Date when the clip was created. */
-    private Date createdAt;
+    @JsonProperty("created_at")
+    private Instant createdAtInstant;
 
     /** URL of the clip thumbnail. */
     private String thumbnailUrl;
+
+    /**
+     * @return the timestamp for the clip's creation
+     * @deprecated in favor of getCreatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getCreatedAt() {
+        return Date.from(createdAtInstant);
+    }
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Follow.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Follow.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
@@ -8,7 +10,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * Follow
@@ -33,6 +37,17 @@ public class Follow {
     private String toName;
 
     /** Date and time when the from_id user followed the to_id user. */
-    private LocalDateTime followedAt;
+    @JsonProperty("followed_at")
+    private Instant followedAtInstant;
+
+    /**
+     * @return the date and time when the from_id user followed the to_id user.
+     * @deprecated in favor of getFollowedAtInstant
+     */
+    @JsonIgnore
+    @Deprecated
+    public LocalDateTime getFollowedAt() {
+        return LocalDateTime.ofInstant(followedAtInstant, ZoneOffset.UTC);
+    }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Moderator.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Moderator.java
@@ -12,11 +12,11 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Moderator {
 
-    /** ID of the subscribed user. */
+    /** ID of the moderator. */
     @NonNull
     private String userId;
 
-    /** Login name of the subscribed user. */
+    /** Display name of the moderator. */
     @NonNull
     private String userName;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEvent.java
@@ -1,11 +1,15 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -14,20 +18,46 @@ import java.time.LocalDateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ModeratorEvent {
 
+    /**
+     * Event ID
+     */
     @NonNull
     private String id;
 
+    /**
+     * Displays "moderation.user.ban" or "moderation.user.unban".
+     */
     @NonNull
     private String eventType;
 
+    /**
+     * RFC3339 formatted timestamp for events.
+     */
     @NonNull
-    private LocalDateTime eventTimestamp;
+    @JsonProperty("event_timestamp")
+    private Instant timestamp;
 
+    /**
+     * Returns the version of the endpoint.
+     */
     @NonNull
     private String version;
 
+    /**
+     * @see ModeratorEventData
+     */
     @NonNull
     private ModeratorEventData eventData;
+
+    /**
+     * @return the timestamp of when the event took place
+     * @deprecated in favor of getTimestamp
+     */
+    @JsonIgnore
+    @Deprecated
+    public LocalDateTime getEventTimestamp() {
+        return LocalDateTime.ofInstant(timestamp, ZoneOffset.UTC);
+    }
 
     @Data
     @Setter(AccessLevel.PRIVATE)
@@ -36,15 +66,27 @@ public class ModeratorEvent {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ModeratorEventData {
 
+        /**
+         * The ID of the channel where the event took place
+         */
         @NonNull
         private String broadcasterId;
 
+        /**
+         * The (display) name of the channel where the event took place
+         */
         @NonNull
         private String broadcasterName;
 
+        /**
+         * The User ID of the moderator being added/removed
+         */
         @NonNull
         private String userId;
 
+        /**
+         * The (display) name of the moderator being added/removed
+         */
         @NonNull
         private String userName;
     }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEventList.java
@@ -14,10 +14,17 @@ import java.util.List;
 public class ModeratorEventList {
 
     @JsonProperty("data")
-    private List<ModeratorEvent> subscriptions;
+    private List<ModeratorEvent> events;
 
     @JsonProperty("pagination")
     private HelixPagination pagination;
 
+    /**
+     * @return the moderator events from this query
+     * @deprecated in favor of getEvents()
+     */
+    @Deprecated
+    public List<ModeratorEvent> getSubscriptions() {
+        return this.events;
+    }
 }
-

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorList.java
@@ -14,10 +14,17 @@ import java.util.List;
 public class ModeratorList {
 
     @JsonProperty("data")
-    private List<Moderator> subscriptions;
+    private List<Moderator> moderators;
 
     @JsonProperty("pagination")
     private HelixPagination pagination;
 
+    /**
+     * @return the moderators from this query
+     * @deprecated in favor of getModerators()
+     */
+    @Deprecated
+    public List<Moderator> getSubscriptions() {
+        return this.moderators;
+    }
 }
-

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -1,11 +1,15 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.util.TimeUtils;
 import lombok.*;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -55,7 +59,8 @@ public class Stream {
 
     /** UTC timestamp on when the stream started */
     @NonNull
-    private Calendar startedAt;
+    @JsonProperty("started_at")
+    private Instant startedAtInstant;
 
     /** Ids of active tags on the stream */
     private List<UUID> tagIds = new ArrayList<>();
@@ -74,8 +79,7 @@ public class Stream {
      * @return The stream uptime.
      */
     public Duration getUptime() {
-        Duration uptime = Duration.between(startedAt.toInstant(), Calendar.getInstance().toInstant());
-        return uptime;
+        return Duration.between(startedAtInstant, Instant.now());
     }
 
     /**
@@ -87,5 +91,15 @@ public class Stream {
      */
     public String getThumbnailUrl(Integer width, Integer height) {
         return thumbnailUrl.replaceAll(Pattern.quote("{width}"), width.toString()).replaceAll(Pattern.quote("{height}"), height.toString());
+    }
+
+    /**
+     * @return the timestamp on when the stream started, in the system default zone
+     * @deprecated in favor of getStartedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Calendar getStartedAt() {
+        return TimeUtils.fromInstant(startedAtInstant);
     }
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
@@ -8,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -36,10 +39,12 @@ public class Video {
     private String description;
 
     /** Date when the video was created. */
-    private Date createdAt;
+    @JsonProperty("created_at")
+    private Instant createdAtInstant;
 
     /** Date when the video was published. */
-    private Date publishedAt;
+    @JsonProperty("published_at")
+    private Instant publishedAtInstant;
 
     /** URL of the video. */
     private String url;
@@ -62,4 +67,23 @@ public class Video {
     /** Length of the video. */
     private String duration;
 
+    /**
+     * @return the timestamp when the video was created
+     * @deprecated in favor of getCreatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getCreatedAt() {
+        return Date.from(createdAtInstant);
+    }
+
+    /**
+     * @return the timestamp when the video was published
+     * @deprecated in favor of getPublishedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getPublishedAt() {
+        return Date.from(publishedAtInstant);
+    }
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarker.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarker.java
@@ -1,10 +1,14 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.util.TimeUtils;
 import lombok.*;
 
+import java.time.Instant;
 import java.util.Calendar;
 
 /**
@@ -25,7 +29,8 @@ public class VideoMarker {
 
     /** RFC3339 timestamp of the marker. */
     @NonNull
-    private Calendar createdAt;
+    @JsonProperty("created_at")
+    private Instant createdAtInstant;
 
     /** Description of the marker. */
     @NonNull
@@ -38,4 +43,13 @@ public class VideoMarker {
     /** A link to the stream with a query parameter that is a timestamp of the marker’s location. */
     private String url;
 
+    /**
+     * @return the timestamp of the marker, in the system default zone
+     * @deprecated in favor of getCreatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Calendar getCreatedAt() {
+        return TimeUtils.fromInstant(createdAtInstant);
+    }
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeam.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeam.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
@@ -12,27 +14,47 @@ import java.util.List;
 @Data
 public class KrakenTeam {
 
-	@JsonProperty("_id")
-	private long id;
+    @JsonProperty("_id")
+    private long id;
 
-	private String name;
+    private String name;
 
-	@JsonProperty("display_name")
-	private String displayName;
+    @JsonProperty("display_name")
+    private String displayName;
 
-	private String info;
+    private String info;
 
-	private String logo;
+    private String logo;
 
-	private String background;
+    private String background;
 
-	private String banner;
+    private String banner;
 
-  @JsonProperty("created_at")
-  private Date createdAt;
+    @JsonProperty("created_at")
+    private Instant createdAtInstant;
 
-  @JsonProperty("updated_at")
-  private Date updatedAt;
+    @JsonProperty("updated_at")
+    private Instant updatedAtInstant;
 
-	private List<KrakenTeamUser> users;
+    private List<KrakenTeamUser> users;
+
+    /**
+     * @return the timestamp of when the team was created
+     * @deprecated in favor of getCreatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getCreatedAt() {
+        return Date.from(createdAtInstant);
+    }
+
+    /**
+     * @return the timestamp of when the team was last updated
+     * @deprecated in favor of getUpdatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getUpdatedAt() {
+        return Date.from(updatedAtInstant);
+    }
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamUser.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -19,7 +21,7 @@ public class KrakenTeamUser {
     private String broadcasterLanguage;
 
     @JsonProperty("created_at")
-    private Date createdAt;
+    private Instant createdAtInstant;
 
     @JsonProperty("display_name")
     private String displayName;
@@ -47,7 +49,7 @@ public class KrakenTeamUser {
     private String status;
 
     @JsonProperty("updated_at")
-    private Date updatedAt;
+    private Instant updatedAtInstant;
 
     private String url;
 
@@ -55,4 +57,24 @@ public class KrakenTeamUser {
     private Object videoBanner;
 
     private long views;
+
+    /**
+     * @return creation timestamp
+     * @deprecated in favor of getCreatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getCreatedAt() {
+        return Date.from(createdAtInstant);
+    }
+
+    /**
+     * @return updated timestamp
+     * @deprecated in favor of getUpdatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getUpdatedAt() {
+        return Date.from(updatedAtInstant);
+    }
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
@@ -1,33 +1,54 @@
 package com.github.twitch4j.kraken.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.time.Instant;
 import java.util.Date;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenUser {
 
-	@JsonProperty("_id")
-	private String id;
+    @JsonProperty("_id")
+    private String id;
 
-	private String name;
+    private String name;
 
     @JsonProperty("display_name")
-	private String displayName;
+    private String displayName;
 
-	private String logo;
+    private String logo;
 
-	private String type;
+    private String type;
 
-	private String bio;
+    private String bio;
 
     @JsonProperty("updated_at")
-	private Date updatedAt;
+    private Instant updatedAtInstant;
 
     @JsonProperty("created_at")
-	private Date createdAt;
+    private Instant createdAtInstant;
 
+    /**
+     * @return the timestamp the account was created
+     * @deprecated in favor of getCreatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getCreatedAt() {
+        return Date.from(createdAtInstant);
+    }
+
+    /**
+     * @return the timestamp the account was updated
+     * @deprecated in favor of getUpdatedAtInstant()
+     */
+    @JsonIgnore
+    @Deprecated
+    public Date getUpdatedAt() {
+        return Date.from(updatedAtInstant);
+    }
 }

--- a/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
@@ -36,7 +36,7 @@ public class UsersServiceTest extends AbstractKrakenServiceTest {
         assertEquals(user.getName(), "twitch4j", "Twitch4J user name should be twitch4j!");
         assertEquals(user.getDisplayName(), "twitch4j", "Twitch4J user display name should be twitch4j!");
         assertEquals(user.getType(), "user", "Twitch4J user type should be user!");
-        assertEquals(user.getCreatedAt().getTime(), 1488456578184L, "Twitch4J user creation date is invalid!");
+        assertEquals(user.getCreatedAtInstant().toEpochMilli(), 1488456578184L, "Twitch4J user creation date is invalid!");
     }
 
     @Test

--- a/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * Channel Cache
@@ -39,5 +39,5 @@ public class ChannelCache {
     /**
      * Last Follow Check
      */
-    private LocalDateTime lastFollowCheck;
+    private Instant lastFollowCheck;
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Work towards #61
* `TwitchHelix#getClips`: passing a `Date` (for `startedAt` or `endedAt`) would always result in failure due to its `toString` method not yielding a RFC 3339 compliant format

### Changes Proposed
* `LocalDateTime`, `Date`, `Calendar` => `Instant`
* Improve documentation of `Moderator` and `ModeratorEvent`
* Rename `subscriptions` field in `ModeratorList` and `ModeratorEventList`
