### PR TITLE
feat: improve utility of active extensions in helix

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ActiveExtension.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ActiveExtension.java
@@ -1,0 +1,53 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ActiveExtension {
+
+    /**
+     * Activation state of the extension, for each extension type (component, overlay, mobile, panel). If false, no other data is provided.
+     */
+    private Boolean active;
+
+    /**
+     * (Client) ID of the extension.
+     */
+    private String id;
+
+    /**
+     * Name of the extension.
+     */
+    private String name;
+
+    /**
+     * Version of the extension.
+     */
+    private String version;
+
+    /**
+     * (Video-component Extensions only) X-coordinate of the placement of the extension.
+     */
+    private Integer x;
+
+    /**
+     * (Video-component Extensions only) Y-coordinate of the placement of the extension.
+     */
+    private Integer y;
+
+    Extension asExtension() {
+        return new Extension(id, name, version, null, null);
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,6 +17,7 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@AllArgsConstructor
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Extension {

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionActiveList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionActiveList.java
@@ -1,15 +1,17 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Extension Active List
@@ -17,7 +19,7 @@ import java.util.Map;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionActiveList {
 
@@ -25,24 +27,56 @@ public class ExtensionActiveList {
     private ActiveExtensions data;
 
     @JsonProperty("pagination")
+    @Deprecated
     private HelixPagination pagination;
 
     @Data
     @Setter(AccessLevel.PRIVATE)
+    @Builder(toBuilder = true)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @AllArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ActiveExtensions {
 
+        /**
+         * Contains data for panel Extensions.
+         */
         @JsonProperty("panel")
-        private Map<String, Extension> panels;
+        private Map<String, ActiveExtension> activePanels;
 
+        /**
+         * Contains data for video-overlay Extensions.
+         */
         @JsonProperty("overlay")
-        private Map<String, Extension> overlays;
+        private Map<String, ActiveExtension> activeOverlays;
 
+        /**
+         * Contains data for video-component Extensions.
+         */
         @JsonProperty("component")
-        private Map<String, Extension> components;
+        private Map<String, ActiveExtension> activeComponents;
 
+        @JsonIgnore
+        @Deprecated
+        public Map<String, Extension> getPanels() {
+            return computeFallback(activePanels);
+        }
+
+        @JsonIgnore
+        @Deprecated
+        public Map<String, Extension> getOverlays() {
+            return computeFallback(activeOverlays);
+        }
+
+        @JsonIgnore
+        @Deprecated
+        public Map<String, Extension> getComponents() {
+            return computeFallback(activeComponents);
+        }
+
+        private static Map<String, Extension> computeFallback(Map<String, ActiveExtension> map) {
+            return map.keySet().stream().collect(Collectors.toMap(k -> k, k -> map.get(k).asExtension()));
+        }
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionList.java
@@ -2,8 +2,6 @@ package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,14 +15,13 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionList {
 
     @JsonProperty("data")
     private List<Extension> extensions;
 
-    @JsonProperty("pagination")
+    @Deprecated
     private HelixPagination pagination;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Create `ActiveExtension` object that is distinct from a regular `Extension`; fields are slightly different so `TwitchHelix#getUserActiveExtensions` yields more information now
* Ease creation of `ExtensionActiveList`/`ActiveExtensions`/`ActiveExtension`; this makes `TwitchHelix#updateUserExtensions` more powerful
* Deprecate pagination fields in helix extension lists; not relevant for these endpoints
* Remove some unnecessary annotations
