### PR TITLE
feat: provide channel id + name in all events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -350,13 +350,13 @@ public class TwitchChat implements AutoCloseable {
                 if (event.getChannelId() != null) {
                     channelCacheLock.lock();
                     try {
+                        // store mapping info into channelIdToChannelName / channelNameToChannelId
                         event.getChannelName().map(String::toLowerCase).filter(currentChannels::contains).ifPresent(name -> {
-                            // remove old name -> id mapping if present (name-change)
-                            Optional.ofNullable(channelIdToChannelName.get(event.getChannelId())).ifPresent(oldName -> channelNameToChannelId.remove(oldName));
-
-                            // store mapping
-                            channelNameToChannelId.put(name, event.getChannelId());
-                            channelIdToChannelName.put(event.getChannelId(), name);
+                            String oldName = channelIdToChannelName.put(event.getChannelId(), name);
+                            if (!name.equals(oldName)) {
+                                if (oldName != null) channelNameToChannelId.remove(oldName, event.getChannelId());
+                                channelNameToChannelId.put(name, event.getChannelId());
+                            }
                         });
                     } finally {
                         channelCacheLock.unlock();

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -495,10 +495,10 @@ public class IRCEventHandler {
     }
 
     public void onChannelState(IRCMessageEvent event) {
-        if(event.getCommandType().equals("ROOMSTATE")) {
+        if (event.getCommandType().equals("ROOMSTATE")) {
             // getting Status on channel
             EventChannel channel = event.getChannel();
-            Map<ChannelStateEvent.ChannelState, Object> states = new HashMap<ChannelStateEvent.ChannelState, Object>();
+            Map<ChannelStateEvent.ChannelState, Object> states = new HashMap<>();
             if (event.getTags().size() > 2) {
                 event.getTags().forEach((k, v) -> {
                     switch (k) {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* will ensure that channel id + name are present in all events
* adds 2 maps to store the mapping (channel id -> name, channel name -> id) for all joined channels)