### PR TITLE
feat: add get drops entitlements endpoint to helix

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -138,6 +138,38 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets a list of entitlements for a given organization that have been granted to a game, user, or both.
+     * <p>
+     * Valid combinations of requests are:
+     * <ul>
+     *     <li>No fields - All entitlements with benefits owned by your organization.</li>
+     *     <li>Only userId - All entitlements for a user with benefits owned by your organization.</li>
+     *     <li>Only gameId - All entitlements for all users for a game. Your organization must own the game.</li>
+     *     <li>Both userId and gameId - All entitlements for the game granted to a user. Your organization must own the game.</li>
+     * </ul>
+     * <p>
+     * Pagination support: Forward only
+     *
+     * @param authToken Required: App Access OAuth Token. OAuth Token Client ID must have ownership of Game: Client ID {@literal >} RBAC Organization ID {@literal >} Game ID.
+     * @param id        Optional: Unique Identifier of the entitlement.
+     * @param userId    Optional: A Twitch User ID.
+     * @param gameId    Optional: A Twitch Game ID.
+     * @param after     Optional: The cursor used to fetch the next page of data.
+     * @param limit     Optional: Maximum number of entitlements to return. Default: 20. Max: 100.
+     * @return DropsEntitlementList
+     */
+    @RequestLine("GET /entitlements/drops?id={id}&user_id={user_id}&game_id={game_id}&after={after}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<DropsEntitlementList> getDropsEntitlements(
+        @Param("token") String authToken,
+        @Param("id") String id,
+        @Param("user_id") String userId,
+        @Param("game_id") String gameId,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    );
+
+    /**
      * Get Extension Transactions allows extension back end servers to fetch a list of transactions that have occurred for their extension across all of Twitch.
      *
      * @param authToken App Access  OAuth Token

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlement.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlement.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * An entitlement is the link between a User and a Benefit.
+ */
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DropsEntitlement {
+
+    /**
+     * Unique Identifier of the entitlement
+     */
+    private String id;
+
+    /**
+     * Identifier of the Benefit
+     */
+    private String benefitId;
+
+    /**
+     * UTC timestamp in ISO format when this entitlement was granted on Twitch.
+     */
+    private Instant timestamp;
+
+    /**
+     * Twitch User ID of the user who was granted the entitlement.
+     */
+    private String userId;
+
+    /**
+     * Twitch Game ID of the game that was being played when this benefit was entitled.
+     */
+    private String gameId;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.helix.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -22,13 +23,13 @@ public class DropsEntitlementList {
      */
     private List<DropsEntitlement> data;
 
-    /**
-     * If provided, is the key used to fetch the next page of data.
-     * If not provided, the current response is the last page of data available.
-     */
+    @Getter(AccessLevel.PRIVATE)
     private Object pagination;
 
     /**
+     * If present, is the key used to fetch the next page of data.
+     * If absent, the current response is the last page of data available.
+     *
      * @return the cursor from the pagination object, in an optional wrapper
      */
     public Optional<String> getPaginationCursor() {

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.helix.domain;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class DropsEntitlementList {
+
+    /**
+     * The entitlements
+     */
+    private List<DropsEntitlement> data;
+
+    /**
+     * If provided, is the key used to fetch the next page of data.
+     * If not provided, the current response is the last page of data available.
+     */
+    private Object pagination;
+
+    /**
+     * @return the cursor from the pagination object, in an optional wrapper
+     */
+    public Optional<String> getPaginationCursor() {
+        // The example response contained in the official documentation claims that the pagination field in the JSON
+        // is simply a string, deviating from the rest of the helix endpoints which use an object that contains a string.
+        // Since this may be an error that we are unable to test, we provide this code to be agnostic to both approaches.
+        return Optional.ofNullable(pagination instanceof Map ? ((Map<?, ?>) pagination).get("cursor") : pagination)
+            .filter(c -> c instanceof String)
+            .map(c -> (String) c)
+            .filter(StringUtils::isNotBlank);
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
@@ -1,11 +1,20 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DropsEntitlementList {
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement `TwitchHelix#getDropsEntitlements(String, String, String, String, String, Integer)`

### Additional Information 
https://dev.twitch.tv/docs/api/reference#get-drops-entitlements (was added under a month ago to the API)
