### PR TITLE
fix: deserialize pagination in extension transaction list

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransaction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransaction.java
@@ -15,111 +15,108 @@ import lombok.Setter;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionTransaction {
-	
-	/**
-	 * Unique identifier of the Bits in Extensions Transaction.
-	 */
-	private String id;
-	
-	/**
+
+    /**
+     * Unique identifier of the Bits in Extensions Transaction.
+     */
+    private String id;
+
+    /**
      * UTC timestamp when this transaction occurred.
-	 */
-	private String timestamp;
-	
-	/**
+     */
+    private String timestamp;
+
+    /**
      * Twitch User ID of the channel the transaction occurred on.
-	 */
-	private String broadcasterId;
-	
-	/**
+     */
+    private String broadcasterId;
+
+    /**
      * Twitch Display Name of the broadcaster.
-	 */
-	private String broadcasterName;
-	
-	/**
+     */
+    private String broadcasterName;
+
+    /**
      * Twitch User ID of the user who generated the transaction.
-	 */
-	private String userId;
-	
-	/**
+     */
+    private String userId;
+
+    /**
      * Twitch Display Name of the user who generated the transaction.
-	 */
-	private String userName;
-	
-	/**
+     */
+    private String userName;
+
+    /**
      * Enum of the product type. Currently only BITS_IN_EXTENSION.
-	 */
-	private String productType;
-	
-	/**
-	 * Known "product_type" enum values.
-	 */
-	public static class ProductType {
-		// "Currently" only valid product type
-		public static String BITS_IN_EXTENSION = "BITS_IN_EXTENSION";
-	}
-	
-	/**
+     */
+    private String productType;
+
+    /**
+     * Known "product_type" enum values.
+     */
+    public static class ProductType {
+        // "Currently" only valid product type
+        public static String BITS_IN_EXTENSION = "BITS_IN_EXTENSION";
+    }
+
+    /**
      * JSON Object representing the product acquired, as it looked at the time of the transaction.
-	 */
-	private ProductData productData;
-	
-	@Data
-	@Setter(AccessLevel.PRIVATE)
-	@NoArgsConstructor
-	@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class ProductData {
-		
-		/**
+     */
+    private ProductData productData;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ProductData {
+
+        /**
          * Unique identifier for the product across the extension.
-		 */
-		private String sku;
-		
-		/**
+         */
+        private String sku;
+
+        /**
          * JSON Object representing the cost to acquire the product.
-		 */
-		private Cost cost;
-		
-		/**
+         */
+        private Cost cost;
+
+        /**
          * Display Name of the product.
-		 */
-		@JsonProperty("displayName")
-		private String displayName;
-		
-		/**
+         */
+        @JsonProperty("displayName")
+        private String displayName;
+
+        /**
          * Flag used to indicate if the product is in development. Either true or false.
-		 */
-		@JsonProperty("inDevelopment")
-		private Boolean inDevelopment;
-		
-		@Data
-		@Setter(AccessLevel.PRIVATE)
-		@NoArgsConstructor
-		@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-		@JsonIgnoreProperties(ignoreUnknown = true)
-		public static class Cost {
-			
-			/**
-			 * Number of Bits required to acquire the product.
-			 */
-			private Integer amount;
-			
-			/**
-			 * Always the string “Bits”.
-			 */
-			private String type;
-			
-			/**
-			 * Known "type" enum values
-			 */
-			public static class CostType {
-				// "Currently" only valid cost type.
-				public static final String BITS = "bits";
-			}
-		}
-		
-		
-	}
-	
+         */
+        @JsonProperty("inDevelopment")
+        private Boolean inDevelopment;
+
+        @Data
+        @Setter(AccessLevel.PRIVATE)
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Cost {
+
+            /**
+             * Number of Bits required to acquire the product.
+             */
+            private Integer amount;
+
+            /**
+             * Always the string “bits”.
+             */
+            private String type;
+
+            /**
+             * Known "type" enum values
+             */
+            public static class CostType {
+                // "Currently" only valid cost type.
+                public static final String BITS = "bits";
+            }
+        }
+
+    }
+
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransactionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransactionList.java
@@ -2,8 +2,6 @@ package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,20 +12,18 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionTransactionList {
-	
-	/**
+
+    /**
      * Array of requested transactions.
-	 */
-	@JsonProperty("data")
-	private List<ExtensionTransaction> transactions;
-	
-	/**
+     */
+    @JsonProperty("data")
+    private List<ExtensionTransaction> transactions;
+
+    /**
      * If provided, is the key used to fetch the next page of data. If not provided, the current response is the last page of data available.
-	 */
-	@JsonProperty("pagination")
-	private String pagination;
-	
+     */
+    private HelixPagination pagination;
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
`ExtensionTransactionList`: Deserialization of `pagination` field would fail due to expecting a `String` while encountering a json object

### Changes Proposed
* Change type of `pagination` field to `HelixPagination`
* Tabs => 4 spaces

### Additional Information 
https://dev.twitch.tv/docs/api/reference#get-extension-transactions