### PR TITLE
feat: add kraken getChannelTeams + getUser + getUserById

### DIFF
--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -300,6 +300,18 @@ public interface TwitchKraken {
     HystrixCommand<KrakenIngestList> getIngestServers();
 
     /**
+     * Gets a list of teams to which a specified channel belongs.
+     *
+     * @param channelId Channel Id (Required)
+     * @return KrakenTeamList
+     */
+    @RequestLine("GET /channels/{channel_id}/teams")
+    @Headers("Accept: application/vnd.twitchtv.v5+json")
+    HystrixCommand<KrakenTeamList> getChannelTeams(
+        @Param("channel_id") String channelId
+    );
+
+    /**
      * Get All Teams
      * <p>
      * Gets all active teams.
@@ -327,6 +339,35 @@ public interface TwitchKraken {
     @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenTeam> getTeamByName(
         @Param("name") String name
+    );
+
+    /**
+     * Gets a user object based on the OAuth token provided.
+     * <p>
+     * Get User returns more data than Get User by ID, because Get User is privileged.
+     *
+     * @param authToken User access token with scope user_read (Required)
+     * @return KrakenUser
+     */
+    @RequestLine("GET /user")
+    @Headers({
+        "Authorization: OAuth {token}",
+        "Accept: application/vnd.twitchtv.v5+json",
+    })
+    HystrixCommand<KrakenUser> getUser(
+        @Param("token") String authToken
+    );
+
+    /**
+     * Gets a specified user object.
+     *
+     * @param userId The id of the user being queried
+     * @return KrakenUser
+     */
+    @RequestLine("GET /users/{user_id}")
+    @Headers("Accept: application/vnd.twitchtv.v5+json")
+    HystrixCommand<KrakenUser> getUserById(
+        @Param("user_id") String userId
     );
 
     /**

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
@@ -3,7 +3,9 @@ package com.github.twitch4j.kraken.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.util.Date;
@@ -25,6 +27,16 @@ public class KrakenUser {
     private String type;
 
     private String bio;
+
+    private String email;
+
+    private Boolean emailVerified;
+
+    private Notifications notifications;
+
+    private Boolean partnered;
+
+    private Boolean twitterConnected;
 
     @JsonProperty("updated_at")
     private Instant updatedAtInstant;
@@ -50,5 +62,13 @@ public class KrakenUser {
     @Deprecated
     public Date getUpdatedAt() {
         return Date.from(updatedAtInstant);
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Notifications {
+        private Boolean email;
+        private Boolean push;
     }
 }

--- a/rest-kraken/src/test/java/kraken/endpoints/ChannelServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/ChannelServiceTest.java
@@ -3,6 +3,7 @@ package kraken.endpoints;
 import com.github.twitch4j.kraken.domain.KrakenChannel;
 import com.github.twitch4j.kraken.domain.KrakenFollow;
 import com.github.twitch4j.kraken.domain.KrakenSubscriptionList;
+import com.github.twitch4j.kraken.domain.KrakenTeamList;
 import com.github.twitch4j.kraken.domain.KrakenUser;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -54,6 +55,15 @@ public class ChannelServiceTest extends AbstractKrakenServiceTest {
         KrakenSubscriptionList resultList = getTwitchKrakenClient().getChannelSubscribers(AbstractKrakenServiceTest.getCredential().getAccessToken(), TWITCH_CHANNEL_ID, null, null, null).execute();
 
         assertTrue(resultList.getSubscriptions().size() > 0, "Didn't find any subscriptions!");
+    }
+
+    @Test
+    @DisplayName("getTeams")
+    @Disabled // test acc is not on any team
+    public void getTeams() {
+        KrakenTeamList resultList = getTwitchKrakenClient().getChannelTeams(TWITCH_CHANNEL_ID).execute();
+
+        assertFalse(resultList.getTeams().isEmpty(), "Didn't find any teams!");
     }
 
 }

--- a/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/UsersServiceTest.java
@@ -25,6 +25,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class UsersServiceTest extends AbstractKrakenServiceTest {
 
     @Test
+    @DisplayName("getUser")
+    @Disabled
+    public void getUser() {
+        KrakenUser resultUser = getTwitchKrakenClient().getUser(getCredential().getAccessToken()).execute();
+        assertNotNull(resultUser);
+    }
+
+    @Test
+    @DisplayName("getUserById")
+    public void getUserById() {
+        KrakenUser resultUser = getTwitchKrakenClient().getUserById("149223493").execute();
+        assertNotNull(resultUser);
+        assertEquals(resultUser.getId(), "149223493");
+        assertEquals(resultUser.getName(), "twitch4j");
+    }
+
+    @Test
     @DisplayName("getUsers")
     @Disabled
     public void getUsers() {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `TwitchKraken#getChannelTeams(String)` - no analog in helix yet
* Add `TwitchKraken#getUser(String)` - has some fields not present in helix
* Add `TwitchKraken#getUserById(String)` - has some fields not present in helix
