### PR TITLE
fix: feign request + response logging

### DIFF
--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
@@ -13,11 +13,8 @@ import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.With;
+import feign.slf4j.Slf4jLogger;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.TimeUnit;
@@ -67,6 +64,12 @@ public class TwitchExtensionsBuilder {
     private int requestQueueSize = -1;
 
     /**
+     * you can overwrite the feign loglevel to print the full requests + responses if needed
+     */
+    @With
+    private Logger.Level logLevel = Logger.Level.NONE;
+
+    /**
      * Proxy Configuration
      */
     @With
@@ -101,7 +104,8 @@ public class TwitchExtensionsBuilder {
             .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder(mapper))
             .decoder(new JacksonDecoder(mapper))
-            .logger(new Logger.ErrorLogger())
+            .logger(new Slf4jLogger())
+            .logLevel(logLevel)
             .errorDecoder(new TwitchExtensionsErrorDecoder(mapper, new JacksonDecoder()))
             .requestInterceptor(new TwitchExtensionsClientIdInterceptor(this))
             .options(new Request.Options(timeout / 3, TimeUnit.MILLISECONDS, timeout, TimeUnit.MILLISECONDS, true))

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -13,6 +13,7 @@ import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
+import feign.slf4j.Slf4jLogger;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -69,6 +70,12 @@ public class TwitchHelixBuilder {
     private Integer timeout = 5000;
 
     /**
+     * you can overwrite the feign loglevel to print the full requests + responses if needed
+     */
+    @With
+    private Logger.Level logLevel = Logger.Level.NONE;
+
+    /**
      * Proxy Configuration
      */
     @With
@@ -112,7 +119,8 @@ public class TwitchHelixBuilder {
             .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder(mapper))
             .decoder(new JacksonDecoder(mapper))
-            .logger(new Logger.ErrorLogger())
+            .logger(new Slf4jLogger())
+            .logLevel(logLevel)
             .errorDecoder(new TwitchHelixErrorDecoder(new JacksonDecoder()))
             .requestInterceptor(new TwitchHelixClientIdInterceptor(this))
             .options(new Request.Options(timeout / 3, TimeUnit.MILLISECONDS, timeout, TimeUnit.MILLISECONDS, true))

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -12,6 +12,7 @@ import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
+import feign.slf4j.Slf4jLogger;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,6 +63,12 @@ public class TwitchKrakenBuilder {
     private Integer uploadTimeout = 4 * 60 * 1000;
 
     /**
+     * you can overwrite the feign loglevel to print the full requests + responses if needed
+     */
+    @With
+    private Logger.Level logLevel = Logger.Level.NONE;
+
+    /**
      * ProxyConfiguration
      */
     @With
@@ -108,7 +115,8 @@ public class TwitchKrakenBuilder {
             .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder(mapper))
             .decoder(new JacksonDecoder(mapper))
-            .logger(new Logger.ErrorLogger())
+            .logger(new Slf4jLogger())
+            .logLevel(logLevel)
             .errorDecoder(new TwitchKrakenErrorDecoder(new JacksonDecoder()))
             .requestInterceptor(new TwitchClientIdInterceptor(this.clientId, this.userAgent))
             .options(new Request.Options(timeout / 3, TimeUnit.MILLISECONDS, timeout, TimeUnit.MILLISECONDS, true))

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -11,6 +11,7 @@ import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
+import feign.slf4j.Slf4jLogger;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -61,6 +62,12 @@ public class TwitchMessagingInterfaceBuilder {
     private Integer timeout = 5000;
 
     /**
+     * you can overwrite the feign loglevel to print the full requests + responses if needed
+     */
+    @With
+    private Logger.Level logLevel = Logger.Level.NONE;
+
+    /**
      * Proxy Configuration
      */
     @With
@@ -99,9 +106,9 @@ public class TwitchMessagingInterfaceBuilder {
             .client(new OkHttpClient(clientBuilder.build()))
             .encoder(new JacksonEncoder())
             .decoder(new JacksonDecoder())
-            .logger(new Logger.ErrorLogger())
+            .logger(new Slf4jLogger())
+            .logLevel(logLevel)
             .errorDecoder(new TwitchMessagingInterfaceErrorDecoder(new JacksonDecoder()))
-            .logLevel(Logger.Level.BASIC)
             .requestInterceptor(new TwitchClientIdInterceptor(this.clientId, this.userAgent))
             .retryer(new Retryer.Default(1, 10000, 3))
             .options(new Request.Options(5000, TimeUnit.MILLISECONDS, 15000, TimeUnit.MILLISECONDS, true))


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* the tmi module had the loglevel forced to BASIC and wasn't using slf4j for logging

### Changes Proposed

* allow overwriting the loglevel in all feign builders
* set the default loglevel to `NONE`
* delegate all logging to slf4j
