### PR TITLE
docs: improve clarity of channel ids in pubsub

### DIFF
--- a/docs/content/pubsub/topic-bits-badge-unlocks.md
+++ b/docs/content/pubsub/topic-bits-badge-unlocks.md
@@ -15,8 +15,8 @@ This topic can be used to monitor whenever a new bits badge tier is unlocked by 
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| credential | OAuth2Credential | User Auth Token for the target user id, with the scope `bits:read` |
-| userId | String | Target User Id |
+| credential | OAuth2Credential | User Auth Token for the target channel id, with the scope `bits:read` |
+| channelId | String | Target Channel Id |
 
 *Optional Parameters*
 

--- a/docs/content/pubsub/topic-bits-events.md
+++ b/docs/content/pubsub/topic-bits-events.md
@@ -15,8 +15,8 @@ This topic can be used to monitor whenever bits are cheered in a specified chann
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| credential | OAuth2Credential | User Auth Token for the target user id, with the scope `bits:read` |
-| userId | String | Target User Id |
+| credential | OAuth2Credential | User Auth Token for the target channel id, with the scope `bits:read` |
+| channelId | String | Target Channel Id |
 
 *Optional Parameters*
 

--- a/docs/content/pubsub/topic-commerce-events.md
+++ b/docs/content/pubsub/topic-commerce-events.md
@@ -15,8 +15,8 @@ This topic is deprecated by Twitch, but it could be used to monitor purchases in
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| credential | OAuth2Credential | User Auth Token for the target user id, with any scope |
-| userId | String | Target User Id |
+| credential | OAuth2Credential | User Auth Token for the target channel id, with any scope |
+| channelId | String | Target Channel Id |
 
 *Optional Parameters*
 

--- a/docs/content/pubsub/topic-moderation-events.md
+++ b/docs/content/pubsub/topic-moderation-events.md
@@ -44,5 +44,7 @@ As this is not officially documented by Twitch, it may break at any time (howeve
 Example: User `hexafice` subscribes to moderation events in channel `twitch4j`
 
 ```java
-twitchClient.getPubSub().listenForModerationEvents(credential, "149223493", "142621956");
+String broadcasterId = "149223493"; // channel id of twitch4j
+String userId = "142621956"; // user id of hexafice
+twitchClient.getPubSub().listenForModerationEvents(credential, broadcasterId, userId);
 ```

--- a/docs/content/pubsub/topic-subscribe-events.md
+++ b/docs/content/pubsub/topic-subscribe-events.md
@@ -15,8 +15,8 @@ This topic can be used to monitor whenever a specified channel receives a new su
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| credential | OAuth2Credential | User Auth Token for the target user id, with the scope `channel_subscriptions` |
-| userId | String | Target User Id |
+| credential | OAuth2Credential | User Auth Token for the target channel id, with the scope `channel_subscriptions` |
+| channelId | String | Target Channel Id |
 
 *Optional Parameters*
 

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -384,7 +384,7 @@ public class TwitchPubSub implements AutoCloseable {
                                 PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(eventUser, body, permissions);
                                 eventManager.publish(privateMessageEvent);
 
-                            } else if (topic.startsWith("community-points-channel-v1")) {
+                            } else if (topic.startsWith("community-points-channel-v1") || topic.startsWith("channel-points-channel-v1")) {
                                 String timestampText = msgData.path("timestamp").asText();
                                 Instant instant = Instant.parse(timestampText);
 
@@ -660,7 +660,7 @@ public class TwitchPubSub implements AutoCloseable {
     public PubSubSubscription listenOnTopic(PubSubType type, OAuth2Credential credential, List<String> topics) {
         PubSubRequest request = new PubSubRequest();
         request.setType(type);
-        request.setNonce(CryptoUtils.generateNonce(32));
+        request.setNonce(CryptoUtils.generateNonce(30));
         request.getData().put("auth_token", credential != null ? credential.getAccessToken() : "");
         request.getData().put("topics", topics);
 
@@ -709,46 +709,46 @@ public class TwitchPubSub implements AutoCloseable {
     /**
      * Event Listener: User earned a new Bits badge and shared the notification with chat
      *
-     * @param credential Credential (for target user id, scope: bits:read)
-     * @param userId     Target User Id
+     * @param credential Credential (for target channel id, scope: bits:read)
+     * @param channelId  Target Channel Id
      * @return PubSubSubscription
      */
-    public PubSubSubscription listenForBitsBadgeEvents(OAuth2Credential credential, String userId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "channel-bits-badge-unlocks." + userId);
+    public PubSubSubscription listenForBitsBadgeEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-bits-badge-unlocks." + channelId);
     }
 
     /**
      * Event Listener: Anyone cheers on a specified channel.
      *
-     * @param credential Credential (for target user id, scope: bits:read)
-     * @param userId     Target User Id
+     * @param credential Credential (for target channel id, scope: bits:read)
+     * @param channelId  Target Channel Id
      * @return PubSubSubscription
      */
-    public PubSubSubscription listenForCheerEvents(OAuth2Credential credential, String userId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "channel-bits-events-v2." + userId);
+    public PubSubSubscription listenForCheerEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-bits-events-v2." + channelId);
     }
 
     /**
      * Event Listener: Anyone subscribes (first month), resubscribes (subsequent months), or gifts a subscription to a channel.
      *
-     * @param credential Credential (for targetUserId, scope: channel_subscriptions)
-     * @param userId     Target User Id
+     * @param credential Credential (for targetChannelId, scope: channel_subscriptions)
+     * @param channelId  Target Channel Id
      * @return PubSubSubscription
      */
-    public PubSubSubscription listenForSubscriptionEvents(OAuth2Credential credential, String userId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "channel-subscribe-events-v1." + userId);
+    public PubSubSubscription listenForSubscriptionEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-subscribe-events-v1." + channelId);
     }
 
     /**
      * Event Listener: Anyone makes a purchase on a channel.
      *
      * @param credential Credential (any)
-     * @param userId     Target User Id
+     * @param channelId  Target Channel Id
      * @return PubSubSubscription
      */
     @Deprecated
-    public PubSubSubscription listenForCommerceEvents(OAuth2Credential credential, String userId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "channel-commerce-events-v1." + userId);
+    public PubSubSubscription listenForCommerceEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-commerce-events-v1." + channelId);
     }
 
     /**
@@ -777,18 +777,19 @@ public class TwitchPubSub implements AutoCloseable {
      * Event Listener: A moderator performs an action in the channel
      *
      * @param credential Credential (for userId, scope: channel:moderate)
+     * @param channelId  The user id associated with the target channel
      * @param userId     The user id associated with the credential
-     * @param roomId     The user id associated with the target channel
      * @return PubSubSubscription
      */
-    public PubSubSubscription listenForModerationEvents(OAuth2Credential credential, String userId, String roomId) {
-        return listenForModerationEvents(credential, userId + "." + roomId);
+    @Unofficial
+    public PubSubSubscription listenForModerationEvents(OAuth2Credential credential, String channelId, String userId) {
+        return listenForModerationEvents(credential, channelId + "." + userId);
     }
 
     /**
      * Event Listener: Anyone makes a channel points redemption on a channel.
      *
-     * @param credential Credential (any)
+     * @param credential Credential (with the channel:read:redemptions scope for maximum information)
      * @param channelId  Target Channel Id
      * @return PubSubSubscription
      */
@@ -802,14 +803,14 @@ public class TwitchPubSub implements AutoCloseable {
 
     @Unofficial
     @Deprecated
-    public PubSubSubscription listenForAdsEvents(OAuth2Credential credential, String userId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "ads." + userId);
+    public PubSubSubscription listenForAdsEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "ads." + channelId);
     }
 
     @Unofficial
     @Deprecated
-    public PubSubSubscription listenForAdPropertyRefreshEvents(OAuth2Credential credential, String userId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "ad-property-refresh." + userId);
+    public PubSubSubscription listenForAdPropertyRefreshEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "ad-property-refresh." + channelId);
     }
 
     @Unofficial
@@ -986,6 +987,12 @@ public class TwitchPubSub implements AutoCloseable {
     @Deprecated
     public PubSubSubscription listenForUserCampaignEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "user-campaign-events." + userId);
+    }
+
+    @Unofficial
+    @Deprecated
+    public PubSubSubscription listenForUserDropEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "user-drop-events." + userId);
     }
 
     @Unofficial


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Confusion regarding argument ordering of `TwitchPubSub#listenForModerationEvents(OAuth2Credential, String, String)`

### Changes Proposed
* Change "user id" to "channel id" where appropriate in javadocs
* Reflect above changes in markdown docs as well
* Extraneous: change nonce length to 30 instead of 32 to match twitch's first-party clients
* Extraneous: add listen method for unofficial `user-drop-events` topic & mark it deprecated (as there is no implementation provided yet)
