### PR TITLE
fix: allow multiple languages to be specified in helix getStreams

### DIFF
--- a/docs/content/rest-helix/streams-get.md
+++ b/docs/content/rest-helix/streams-get.md
@@ -14,34 +14,35 @@ The response has a JSON payload with a data field containing an array of stream 
 ## Method Definition
 
 ```java
-@RequestLine("GET /streams?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+@RequestLine("GET /streams?after={after}&before={before}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
 @Headers("Authorization: Bearer {token}")
 HystrixCommand<StreamList> getStreams(
     @Param("token") String authToken,
-	@Param("after") String after,
-	@Param("before") String before,
-	@Param("first") Integer limit,
-	@Param("community_id") List<UUID> communityId,
-	@Param("game_id") List<Long> gameIds,
-	@Param("language") String language,
-	@Param("user_id") List<String> userIds,
-	@Param("user_login") List<String> userLogins
+    @Param("after") String after,
+    @Param("before") String before,
+    @Param("first") Integer limit,
+    @Param("game_id") List<String> gameIds,
+    @Param("language") List<String> language,
+    @Param("user_id") List<String> userIds,
+    @Param("user_login") List<String> userLogins
 );
 ```
 
 *Required Parameters*
 
-None
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| authToken     | string    | User or App Access Token |
+
+As with all Helix endpoints, twitch requires an oauth token. If when using `TwitchHelixBuilder`, a valid client id/secret pair or defaultAuthToken was specified, then this can be set to null.
 
 *Optional Parameters*
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| authToken     | string    | User Auth Token |
 | after | string | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
 | before | string | Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
-| limit | string | Maximum number of objects to return. Maximum: 100. Default: 20. |
-| community_id | string | Returns streams in a specified community ID. You can specify up to 100 IDs. |
+| limit | integer | Maximum number of objects to return. Maximum: 100. Default: 20. |
 | game_id | string |  	Returns streams broadcasting a specified game ID. You can specify up to 100 IDs. |
 | language | string | Stream language. You can specify up to 100 languages. |
 | user_id | string | Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs. |
@@ -52,7 +53,7 @@ None
 
 ### get the top 5 streams
 ```java
-StreamList resultList = twitchClient.getHelix().getStreams("", "", null, 5, null, null, null, null).execute();
+StreamList resultList = twitchClient.getHelix().getStreams(null, null, null, 5, null, null, null, null).execute();
 resultList.getStreams().forEach(stream -> {
     System.out.println("ID: " + stream.getId() + " - Title: " + stream.getTitle());
 });

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -7,6 +7,7 @@ import com.netflix.hystrix.HystrixCommand;
 import feign.*;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -494,33 +495,63 @@ public interface TwitchHelix {
     );
 
     /**
-     * Gets information about active streams. Streams are returned sorted by number of current viewers, in descending order. Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams.
-     * Using user-token or app-token to increase rate limits.
+     * Gets information about active streams.
+     * <p>
+     * Streams are returned sorted by number of current viewers, in descending order.
+     * Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams.
      *
-     * @param authToken User or App auth Token, for increased rate-limits
-     * @param after       Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
-     * @param before      Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
-     * @param limit       Maximum number of objects to return. Maximum: 100. Default: 20.
-     * @param communityId Returns streams in a specified community ID. You can specify up to 100 IDs.
-     * @param gameIds     Returns streams broadcasting a specified game ID. You can specify up to 100 IDs.
-     * @param language    Stream language. You can specify up to 100 languages.
-     * @param userIds     Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
-     * @param userLogins  Returns streams broadcast by one or more specified user login names. You can specify up to 100 names.
+     * @param authToken  User or App Access Token
+     * @param after      Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param before     Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit      Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @param gameIds    Returns streams broadcasting a specified game ID. You can specify up to 100 IDs.
+     * @param language   Stream language. You can specify up to 100 languages.
+     * @param userIds    Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
+     * @param userLogins Returns streams broadcast by one or more specified user login names. You can specify up to 100 names.
      * @return StreamList
      */
-    @RequestLine("GET /streams?after={after}&before={before}&community_id={community_id}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
+    @RequestLine("GET /streams?after={after}&before={before}&first={first}&game_id={game_id}&language={language}&user_id={user_id}&user_login={user_login}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<StreamList> getStreams(
         @Param("token") String authToken,
         @Param("after") String after,
         @Param("before") String before,
         @Param("first") Integer limit,
-        @Param("community_id") List<UUID> communityId,
+        @Param("game_id") List<String> gameIds,
+        @Param("language") List<String> language,
+        @Param("user_id") List<String> userIds,
+        @Param("user_login") List<String> userLogins
+    );
+
+    /**
+     * Gets information about active streams.
+     *
+     * @param authToken   User or App Access Token
+     * @param after       Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param before      Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit       Maximum number of objects to return. Maximum: 100. Default: 20.
+     * @param communityId Returns streams in a specified community ID. You can specify up to 100 IDs. No longer supported by twitch.
+     * @param gameIds     Returns streams broadcasting a specified game ID. You can specify up to 100 IDs.
+     * @param language    Stream language. You can specify up to 100 languages.
+     * @param userIds     Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
+     * @param userLogins  Returns streams broadcast by one or more specified user login names. You can specify up to 100 names.
+     * @return StreamList
+     * @deprecated in favor of getStreams(String, String, String, Integer, List, List, List, List); simply remove the argument for communityId to migrate
+     */
+    @Deprecated
+    default HystrixCommand<StreamList> getStreams(
+        @Param("token") String authToken,
+        @Param("after") String after,
+        @Param("before") String before,
+        @Param("first") Integer limit,
+        @Param("community_id") List<UUID> communityId, // Now unsupported by twitch
         @Param("game_id") List<String> gameIds,
         @Param("language") String language,
         @Param("user_id") List<String> userIds,
         @Param("user_login") List<String> userLogins
-    );
+    ) {
+        return getStreams(authToken, after, before, limit, gameIds, Collections.singletonList(language), userIds, userLogins);
+    }
 
     /**
      * Gets the channel stream key for a user

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -42,7 +42,7 @@ public class Stream {
     private String gameId;
 
     /** Array of community IDs. */
-    @NonNull
+    @Deprecated
     private List<UUID> communityIds;
 
     /** Stream type: "live" or "" (in case of error). */

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
@@ -37,7 +37,7 @@ public class StreamsServiceTest extends AbstractEndpointTest {
     @DisplayName("Fetch information about current live streams")
     public void getStreams() {
         // TestCase
-        StreamList resultList = testUtils.getTwitchHelixClient().getStreams(null, "", "", 5, null, null, null, null, null).execute();
+        StreamList resultList = testUtils.getTwitchHelixClient().getStreams(null, "", "", 5, null, null, null, null).execute();
 
         // Test
         assertTrue(resultList.getStreams().size() > 0, "Should at least find one result from the streams method!");

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -128,7 +128,7 @@ public class TwitchClientHelper implements AutoCloseable {
         // Threads
         this.streamStatusEventTask = channels -> {
             // check go live / stream events
-            HystrixCommand<StreamList> hystrixGetAllStreams = twitchClient.getHelix().getStreams(null, null, null, channels.size(), null, null, null, channels, null);
+            HystrixCommand<StreamList> hystrixGetAllStreams = twitchClient.getHelix().getStreams(null, null, null, channels.size(), null, null, channels, null);
             try {
                 Map<String, Stream> streams = new HashMap<>();
                 channels.forEach(id -> streams.put(id, null));


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Could only previously request a single language because the field was a `String` instead of `List<String>` and the query parms need to be repeated (since feign will not allow `;` to be used in a single string to split up the languages as it must encode it to `%3B`)

### Changes Proposed
* Create new getStreams method that changes `String language` to `List<String> language` (also we remove `communityId` as it is no longer supported by twitch)
* Deprecate old getStreams method (and point it to the new one)

### Additional Information 
Endpoint: https://dev.twitch.tv/docs/api/reference#get-streams
Changelog: https://dev.twitch.tv/docs/change-log
> 9/10/2019: Removed communities-related data fields from Get Streams and Get Streams Metadata endpoints. These fields are no longer supported.
