### PR TITLE
fix: deserialize retry_after in helix commercial properly

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Commercial.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Commercial.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +11,7 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Commercial {
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Apply `SnakeCaseStrategy` so jackson looks for `retry_after` instead of `retryAfter`

### Additional Information 
* On [6/18](https://discuss.dev.twitch.tv/t/announcing-the-latest-helix-endpoints-and-hype-train-api/26530), the "Start Commercial" endpoint was released (with the docs claiming this field name is `retryAfter`)
* On [6/19](https://github.com/twitch4j/twitch4j/pull/144), we implemented this endpoint as documented
* On [7/30](https://dev.twitch.tv/docs/change-log), twitch updated the documentation to change `retryAfter` to `retry_after`
