### PR TITLE
feat: add unofficial get extension information endpoint

### DIFF
--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
@@ -1,9 +1,11 @@
 package com.github.twitch4j.extensions;
 
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.extensions.domain.ChannelList;
 import com.github.twitch4j.extensions.domain.ConfigurationSegment;
 import com.github.twitch4j.extensions.domain.ConfigurationSegmentType;
 import com.github.twitch4j.extensions.domain.ExtensionConfigurationSegment;
+import com.github.twitch4j.extensions.domain.ExtensionInformation;
 import com.github.twitch4j.extensions.domain.ExtensionSecretList;
 import com.github.twitch4j.common.feign.JsonStringExpander;
 import com.netflix.hystrix.HystrixCommand;
@@ -261,6 +263,20 @@ public interface TwitchExtensions {
         @Param("extension_version") String extensionVersion,
         @Param("channel_id") String channelId,
         @Param(value = "text", expander = JsonStringExpander.class) String text
+    );
+
+    /**
+     * Get Extension Information
+     *
+     * @param clientId The client ID value assigned to the extension when it is created.
+     * @return ExtensionInformation
+     * @see Unofficial
+     */
+    @Unofficial
+    @RequestLine("GET /{client_id}")
+    @Headers("Client-Id: {client_id}")
+    HystrixCommand<ExtensionInformation> getExtensionInformation(
+        @Param("client_id") String clientId
     );
 
 }

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
@@ -273,7 +273,7 @@ public interface TwitchExtensions {
      * @see Unofficial
      */
     @Unofficial
-    @RequestLine("GET /{client_id}")
+    @RequestLine("GET /{client_id}/") // Trailing slash allows for the interceptor to inject a missing client id
     @Headers("Client-Id: {client_id}")
     HystrixCommand<ExtensionInformation> getExtensionInformation(
         @Param("client_id") String clientId

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionInformation.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionInformation.java
@@ -1,0 +1,58 @@
+package com.github.twitch4j.extensions.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Unofficial
+public class ExtensionInformation {
+
+    private String anchor;
+    private List<String> assetUrls;
+    private String authorName;
+    private Boolean bitsEnabled;
+    private Boolean canInstall;
+    private String configUrl;
+    private String configurationLocation;
+    private String description;
+    private String eulaTosUrl;
+    private Boolean hasChatSupport;
+    private String iconUrl;
+    private Map<String, String> iconUrls;
+    private String id;
+    private Integer installationCount; // always -42
+    private String liveConfigUrl;
+    private String name;
+    private Integer panelHeight;
+    private String privacyPolicyUrl;
+    private Boolean requestIdentityLink;
+    private List<Object> requiredBroadcasterAbilities;
+    private List<String> screenshotUrls;
+    private String sku;
+    private String state;
+    private String subscriptionsSupportLevel;
+    private String summary;
+    private String supportEmail;
+    private String vendorCode;
+    private String version;
+    private String viewerSummary;
+    private String viewerUrl;
+    private Map<String, String> viewerUrls;
+    private Map<String, Object> views;
+    private List<String> whitelistedConfigUrls;
+    private List<String> whitelistedPanelUrls;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* Continuing #171

### Changes Proposed
* Add `TwitchExtensions#getExtensionInformation(String)`
