### PR TITLE
feat: add more host and chatter info to tmi

### DIFF
--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Chatters.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Chatters.java
@@ -27,12 +27,18 @@ public class Chatters {
     @JsonIgnore
     private List<String> vips;
 
+    /** Broadcaster */
+    @JsonIgnore
+    private List<String> broadcaster;
+
     /** Staff */
     @JsonIgnore
+    @Deprecated
     private List<String> staff;
 
     /** Admins */
     @JsonIgnore
+    @Deprecated
     private List<String> admins;
 
     /** Moderators */
@@ -45,6 +51,7 @@ public class Chatters {
 
     @JsonProperty("chatters")
     private void unpackMessage(Map<String, List<String>> chatters) {
+        broadcaster = chatters.get("broadcaster");
         vips = chatters.get("vips");
         moderators = chatters.get("moderators");
         staff = chatters.get("staff");
@@ -58,7 +65,8 @@ public class Chatters {
      * @return all viewers (name)
      */
     public List<String> getAllViewers() {
-        List<String> newList = new ArrayList<String>();
+        List<String> newList = new ArrayList<>(viewerCount);
+        newList.addAll(broadcaster);
         newList.addAll(vips);
         newList.addAll(moderators);
         newList.addAll(staff);

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Host.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Host.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.tmi.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
@@ -15,17 +14,19 @@ import lombok.Setter;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Host {
-	
-	@JsonProperty("host_id")
-	private String hostId;
-	
-	@JsonProperty("host_login")
-	private String hostLogin;
-	
-	@JsonProperty("target_id")
-	private String targetId;
-	
-	@JsonProperty("target_login")
-	private String targetLogin;
-	
+
+    private String hostId;
+
+    private String hostLogin;
+
+    private String hostDisplayName;
+
+    private String targetId;
+
+    private String targetLogin;
+
+    private String targetDisplayName;
+
+    private Boolean hostPartnered;
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `host_partnered` field to `Host` (can appear when doing `getHostsOf`)
* Add `display_name` fields to `Host` (always present in  `getHosts`, only present for the person hosting when doing `getHostsOf`)
* Add `broadcaster` field to `Chatters` - indicates whether the broadcaster is in chat or not
* Deprecate staff-related fields in `Chatters` - twitch decided to stop sending this info (it's always an empty array now)
