### PR TITLE
fix: deprecated helix.getStreams issue with language param

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -550,7 +550,7 @@ public interface TwitchHelix {
         @Param("user_id") List<String> userIds,
         @Param("user_login") List<String> userLogins
     ) {
-        return getStreams(authToken, after, before, limit, gameIds, Collections.singletonList(language), userIds, userLogins);
+        return getStreams(authToken, after, before, limit, gameIds, language != null ? Collections.singletonList(language) : null, userIds, userLogins);
     }
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -23,6 +23,7 @@ import com.github.twitch4j.pubsub.TwitchPubSub;
 import com.github.twitch4j.pubsub.TwitchPubSubBuilder;
 import com.github.twitch4j.tmi.TwitchMessagingInterface;
 import com.github.twitch4j.tmi.TwitchMessagingInterfaceBuilder;
+import feign.Logger;
 import io.github.bucket4j.Bandwidth;
 import lombok.*;
 import lombok.experimental.Accessors;
@@ -209,6 +210,12 @@ public class TwitchClientBuilder {
     private ProxyConfig proxyConfig = null;
 
     /**
+     * you can overwrite the feign loglevel to print the full requests + responses if needed
+     */
+    @With
+    private Logger.Level feignLogLevel = Logger.Level.NONE;
+
+    /**
      * With a Bot Owner's User ID
      *
      * @param userId the user id
@@ -299,6 +306,7 @@ public class TwitchClientBuilder {
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
                 .withProxyConfig(proxyConfig)
+                .withLogLevel(feignLogLevel)
                 .build();
         }
 
@@ -313,6 +321,7 @@ public class TwitchClientBuilder {
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
                 .withProxyConfig(proxyConfig)
+                .withLogLevel(feignLogLevel)
                 .build();
         }
 
@@ -326,6 +335,7 @@ public class TwitchClientBuilder {
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
                 .withProxyConfig(proxyConfig)
+                .withLogLevel(feignLogLevel)
                 .build();
         }
 
@@ -339,6 +349,7 @@ public class TwitchClientBuilder {
                 .withRequestQueueSize(requestQueueSize)
                 .withTimeout(timeout)
                 .withProxyConfig(proxyConfig)
+                .withLogLevel(feignLogLevel)
                 .build();
         }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* makes sure the language param is omitted in the deprecated helix.getStreams request if its not set

### Changes Proposed
* allows setting the feignLogLevel globally in the twitchClientBuilder