### PR TITLE
feat: handle unban request pubsub topic for channels and users

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatedUnbanRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatedUnbanRequest.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.pubsub.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreatedUnbanRequest extends UnbanRequest {
+
+    private String channelId;
+
+    private String requesterMessage;
+
+    private String requesterProfileImage;
+
+    private Instant createdAt;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UnbanRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UnbanRequest.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnbanRequest {
+
+    private String id;
+
+    private String requesterId;
+
+    private String requesterLogin;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdatedUnbanRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdatedUnbanRequest.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpdatedUnbanRequest extends UnbanRequest {
+
+    private String resolverId;
+
+    private String resolverLogin;
+
+    private String resolverMessage;
+
+    private String status; // e.g. "CANCELED" or "APPROVED" or "DENIED"
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelUnbanRequestCreateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelUnbanRequestCreateEvent.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.CreatedUnbanRequest;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelUnbanRequestCreateEvent extends UnbanRequestEvent {
+
+    public ChannelUnbanRequestCreateEvent(String userId, String channelId, CreatedUnbanRequest unbanRequest) {
+        super(userId, channelId, unbanRequest);
+    }
+
+    @Override
+    public CreatedUnbanRequest getUnbanRequest() {
+        return (CreatedUnbanRequest) super.getUnbanRequest();
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelUnbanRequestUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelUnbanRequestUpdateEvent.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelUnbanRequestUpdateEvent extends UnbanRequestEvent {
+
+    public ChannelUnbanRequestUpdateEvent(String userId, String channelId, UpdatedUnbanRequest unbanRequest) {
+        super(userId, channelId, unbanRequest);
+    }
+
+    @Override
+    public UpdatedUnbanRequest getUnbanRequest() {
+        return (UpdatedUnbanRequest) super.getUnbanRequest();
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UnbanRequestEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UnbanRequestEvent.java
@@ -1,0 +1,14 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.UnbanRequest;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public abstract class UnbanRequestEvent extends TwitchEvent {
+    private final String userId;
+    private final String channelId;
+    private final UnbanRequest unbanRequest;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserUnbanRequestUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserUnbanRequestUpdateEvent.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class UserUnbanRequestUpdateEvent extends UnbanRequestEvent {
+
+    public UserUnbanRequestUpdateEvent(String userId, String channelId, UpdatedUnbanRequest unbanRequest) {
+        super(userId, channelId, unbanRequest);
+    }
+
+    @Override
+    public UpdatedUnbanRequest getUnbanRequest() {
+        return (UpdatedUnbanRequest) super.getUnbanRequest();
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Handle unofficial `channel-unban-requests.<user-id>.<channel-id>` pubsub topic (for mods to receive unban request creations and updates in real-time)
* Handle unofficial `user-unban-requests.<user-id>.<channel-id>` pubsub topic (for banned users to monitor the status of their unban request)
