### PR TITLE
feat: handle unofficial radio events pubsub topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -536,6 +536,8 @@ public class TwitchPubSub implements AutoCloseable {
                                 } else {
                                     log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
                                 }
+                            } else if (topic.startsWith("radio-events-v1")) {
+                                eventManager.publish(new RadioEvent(TypeConvert.jsonToObject(rawMessage, RadioData.class)));
                             } else if (topic.startsWith("channel-sub-gifts-v1")) {
                                 eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(rawMessage, SubGiftData.class)));
                             } else if (topic.startsWith("channel-cheer-events-public-v1")) {
@@ -1043,6 +1045,11 @@ public class TwitchPubSub implements AutoCloseable {
     @Unofficial
     public PubSubSubscription listenForPresenceEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "presence." + userId);
+    }
+
+    @Unofficial
+    public PubSubSubscription listenForRadioEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "radio-events-v1." + channelId);
     }
 
     @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioData.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.twitch4j.common.util.NanoInstantDeserializer;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RadioData {
+
+    @JsonProperty("userID")
+    private String channelId;
+
+    private String asin;
+
+    private String type; // e.g. "RADIO_PLAYING"
+
+    @JsonDeserialize(using = NanoInstantDeserializer.class)
+    private Instant updatedAt;
+
+    private RadioTrack track;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioTrack.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioTrack.java
@@ -1,0 +1,44 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RadioTrack {
+
+    private String asin;
+
+    private Integer duration; // in seconds
+
+    private String title;
+
+    private List<Artist> artists;
+
+    private AlbumInfo album;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Artist {
+        private String asin;
+        private String name;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AlbumInfo {
+        private String asin;
+        private String name;
+        @JsonProperty("imageURL")
+        private String imageUrl;
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RadioEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RadioEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.RadioData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RadioEvent extends TwitchEvent {
+    RadioData data;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Handle `radio-events-v1.<channel-id>` unofficial pubsub topic

### Additional Information
Related announcement: https://blog.twitch.tv/en/2020/09/30/introducing-soundtrack-by-twitch-rights-cleared-music-for-all-twitch-creators/
