### PR TITLE
fix: register jackson modules despite exotic class loaders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Plugins
 plugins {
-    id 'com.jfrog.bintray' version '1.8.5' apply false
-    id 'com.jfrog.artifactory' version '4.13.0' apply false
+	id 'com.jfrog.bintray' version '1.8.5' apply false
+	id 'com.jfrog.artifactory' version '4.13.0' apply false
 }
 
 // Artifact Info
@@ -28,18 +28,18 @@ allprojects {
 
 // Subprojects
 subprojects {
-    apply plugin: 'java'
+	apply plugin: 'java'
 	apply plugin: 'java-library'
-    apply plugin: 'eclipse'
-    apply plugin: 'idea'
-    apply plugin: 'maven-publish'
+	apply plugin: 'eclipse'
+	apply plugin: 'idea'
+	apply plugin: 'maven-publish'
 	apply plugin: 'com.jfrog.bintray'
 	apply plugin: 'com.jfrog.artifactory'
 
-    // Source Compatiblity
-    sourceCompatibility = 1.8
+	// Source Compatibility
+	sourceCompatibility = 1.8
 
-    // Dependency Management for Subprojects
+	// Dependency Management for Subprojects
 	dependencies {
 		constraints {
 			// Logging
@@ -67,7 +67,7 @@ subprojects {
 			api group: 'com.github.vladimir-bukhtoyarov', name: 'bucket4j-core', version: '4.7.0'
 
 			// Caching
-			api group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.5'
+			api group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.6'
 
 			// Http Client
 			api group: 'io.github.openfeign', name: 'feign-okhttp', version: '11.0'
@@ -79,9 +79,9 @@ subprojects {
 			api group: 'com.netflix.hystrix', name: 'hystrix-core', version: '1.5.18'
 
 			// Jackson (JSON)
-			api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.1'
-			api group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: '2.11.1'
-			api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.1'
+			api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.3'
+			api group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: '2.11.3'
+			api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.3'
 
 			// WebSocket
 			api group: 'com.neovisionaries', name: 'nv-websocket-client', version: '2.10'
@@ -114,8 +114,8 @@ subprojects {
 			testImplementation group: 'ch.qos.logback', name: 'logback-classic'
 
 			// Test
-			testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.6.0'
-			testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.0'
+			testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.7.0')
+			testImplementation 'org.junit.jupiter:junit-jupiter'
 		}
 	}
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,6 +10,10 @@ dependencies {
 	compileOnly group: 'io.github.openfeign', name: 'feign-slf4j'
 	compileOnly group: 'io.github.openfeign', name: 'feign-hystrix'
 
+	// Jackson (JSON)
+	api group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names'
+	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+
 	// Websocket (for common proxy settings)
 	compileOnly group: 'com.neovisionaries', name: 'nv-websocket-client'
 

--- a/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
@@ -2,6 +2,8 @@ package com.github.twitch4j.common.util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import lombok.Getter;
 
 public class TypeConvert {
@@ -10,7 +12,9 @@ public class TypeConvert {
      * ObjectMapper
      */
     @Getter
-    private static final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new ParameterNamesModule())
+        .registerModule(new JavaTimeModule());
 
     public static String objectToJson(Object object) {
         try {

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.extensions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.extensions.util.TwitchExtensionsClientIdInterceptor;
 import com.github.twitch4j.extensions.util.TwitchExtensionsErrorDecoder;
 import com.netflix.config.ConfigurationManager;
@@ -90,9 +91,7 @@ public class TwitchExtensionsBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
         // Jackson ObjectMapper
-        ObjectMapper mapper = new ObjectMapper();
-        // - Modules
-        mapper.findAndRegisterModules();
+        ObjectMapper mapper = TypeConvert.getObjectMapper();
 
         // Create HttpClient with proxy
         okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();

--- a/rest-helix/build.gradle
+++ b/rest-helix/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 	// Jackson (JSON)
 	api group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-	api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
 	// Cache
 	api group: 'com.github.ben-manes.caffeine', name: 'caffeine'

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -367,17 +367,17 @@ public interface TwitchHelix {
      * @param broadcasterId User ID of the broadcaster (required)
      * @param limit Maximum number of objects to return. Maximum: 100. Default: 1. (optional)
      * @param id The id of the wanted event, if known. (optional)
-     * @param cursor Cursor for forward pagination (optional)
+     * @param after Cursor for forward pagination (optional)
      * @return HypeTrainEventList
      */
-    @RequestLine("GET /hypetrain/events?broadcaster_id={broadcaster_id}&first={first}&id={id}&cursor={cursor}")
+    @RequestLine("GET /hypetrain/events?broadcaster_id={broadcaster_id}&first={first}&id={id}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<HypeTrainEventList> getHypeTrainEvents(
         @Param("token") String authToken,
         @Param("broadcaster_id") String broadcasterId,
         @Param("first") Integer limit,
         @Param("id") String id,
-        @Param("cursor") String cursor
+        @Param("after") String after
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor;
 import com.netflix.config.ConfigurationManager;
 import feign.Logger;
@@ -105,9 +106,7 @@ public class TwitchHelixBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
         // Jackson ObjectMapper
-        ObjectMapper mapper = new ObjectMapper();
-        // - Modules
-        mapper.findAndRegisterModules();
+        ObjectMapper mapper = TypeConvert.getObjectMapper();
 
         // Create HttpClient with proxy
         okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.helix;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.exception.NotFoundException;
 import com.github.twitch4j.common.exception.UnauthorizedException;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.helix.domain.TwitchHelixError;
 import feign.Request;
 import feign.Response;
@@ -26,7 +27,7 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
     final ErrorDecoder defaultDecoder = new ErrorDecoder.Default();
 
     // ObjectMapper
-    final ObjectMapper objectMapper = new ObjectMapper();
+    final ObjectMapper objectMapper = TypeConvert.getObjectMapper();
 
     /**
      * Constructor

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CategorySearchList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CategorySearchList.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.Setter;
 
 import java.util.List;
@@ -19,7 +18,6 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CategorySearchList {
 
-    @NonNull
     @JsonProperty("data")
     private List<Game> results;
 

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.feign.interceptor.TwitchClientIdInterceptor;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.netflix.config.ConfigurationManager;
 import feign.Logger;
 import feign.Request;
@@ -101,9 +102,7 @@ public class TwitchKrakenBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.TwitchKraken#uploadVideoPart(URI,String,String,int,byte[]).execution.isolation.thread.timeoutInMilliseconds", uploadTimeout);
 
         // Jackson ObjectMapper
-        ObjectMapper mapper = new ObjectMapper();
-        // - Modules
-        mapper.findAndRegisterModules();
+        ObjectMapper mapper = TypeConvert.getObjectMapper();
 
         // Create HttpClient with proxy
         okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.kraken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.exception.NotFoundException;
 import com.github.twitch4j.common.exception.UnauthorizedException;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.kraken.domain.TwitchKrakenError;
 import feign.Request;
 import feign.Response;
@@ -26,7 +27,7 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
     final ErrorDecoder defaultDecoder = new Default();
 
     // ObjectMapper
-    final ObjectMapper objectMapper = new ObjectMapper();
+    final ObjectMapper objectMapper = TypeConvert.getObjectMapper();
 
     /**
      * Constructor

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.tmi;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.feign.interceptor.TwitchClientIdInterceptor;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.netflix.config.ConfigurationManager;
 import feign.Logger;
 import feign.Request;
@@ -101,11 +103,13 @@ public class TwitchMessagingInterfaceBuilder {
         if (proxyConfig != null)
             proxyConfig.apply(clientBuilder);
 
+        ObjectMapper mapper = TypeConvert.getObjectMapper();
+
         // Build
         TwitchMessagingInterface client = HystrixFeign.builder()
             .client(new OkHttpClient(clientBuilder.build()))
-            .encoder(new JacksonEncoder())
-            .decoder(new JacksonDecoder())
+            .encoder(new JacksonEncoder(mapper))
+            .decoder(new JacksonDecoder(mapper))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)
             .errorDecoder(new TwitchMessagingInterfaceErrorDecoder(new JacksonDecoder()))

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceErrorDecoder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceErrorDecoder.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.tmi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.twitch4j.common.exception.NotFoundException;
 import com.github.twitch4j.common.exception.UnauthorizedException;
+import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.tmi.domain.TMIError;
 import feign.Request;
 import feign.Response;
@@ -24,7 +25,7 @@ public class TwitchMessagingInterfaceErrorDecoder implements ErrorDecoder {
     final ErrorDecoder defaultDecoder = new ErrorDecoder.Default();
 
     // ObjectMapper
-    final ObjectMapper objectMapper = new ObjectMapper();
+    final ObjectMapper objectMapper = TypeConvert.getObjectMapper();
 
     /**
      * Constructor


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Folks using Twitch4J in minecraft server plugins would have issues when `Instant`s needed to be deserialized from JSON, despite properly shading their plugin jar to include jackson and the jsr310 module. The custom [PluginClassLoader](https://papermc.io/javadocs/paper/1.13/org/bukkit/plugin/java/PluginClassLoader.html) used in this context likely is not compatible with `ObjectMapper#findAndRegisterModules`

### Changes Proposed
#### Primary
* Explicitly register `ParameterNamesModule` and `JavaTimeModule` (so we are also shifting off of the deprecated `JSR310Module` with this PR) in `TypeConvert`, instead of relying upon `findAndRegisterModules`
* Use `TypeConvert`'s `ObjectMapper` wherever possible

#### Secondary
* Bump jackson version
* Bump caffeine version
* Bump JUnit version
* Fix typo in pagination of hype train events caused by Twitch's faulty docs
* Remove NonNull annotation on category search data due to [twitch inconsistency](https://github.com/twitchdev/issues/issues/238)
