### PR TITLE
docs: add missing TMI docs and rename get-viewers

### DIFF
--- a/docs/content/rest-tmi/_index.md
+++ b/docs/content/rest-tmi/_index.md
@@ -32,4 +32,6 @@ TwitchHelix client = TwitchMessagingInterfaceBuilder.builder()
 
 ## API Methods
 
-- [TMI -> Get Viewers](./get-viewers)
+- [TMI -> Get Chatters](./get-chatters)
+- [TMI -> Get Hosts](./get-hosts)
+- [TMI -> Get Hosts Of](./get-hosts-of)

--- a/docs/content/rest-tmi/get-chatters.md
+++ b/docs/content/rest-tmi/get-chatters.md
@@ -1,9 +1,9 @@
 +++
-title="TMI - Get Viewers"
+title="TMI - Get Chatters"
 weight = 10
 +++
 
-# Get Viewers
+# Get Chatters
 
 ## Description
 
@@ -37,6 +37,7 @@ None
 ```java
 Chatters chatters = twitchClient.getMessagingInterface().getChatters("lirik").execute();
 
+System.out.println("Broadcaster: " + chatters.getBroadcaster());
 System.out.println("VIPs: " + chatters.getVips());
 System.out.println("Mods: " + chatters.getModerators());
 System.out.println("Admins: " + chatters.getAdmins());

--- a/docs/content/rest-tmi/get-hosts-of.md
+++ b/docs/content/rest-tmi/get-hosts-of.md
@@ -1,0 +1,43 @@
++++
+title="TMI - Get Hosts of target channel"
+weight = 12
++++
+
+# Get Hosts of target channel
+
+## Description
+
+This endpoint returns a "host" record for each channel hosting the channel with the provided targetId. It does not 
+return the login of the target, only of the hosts. Therefore getTargetLogin will return null for each Host in 
+HostList.getHosts().
+
+## Method Definition
+
+```java
+@RequestLine("GET /hosts?include_logins=1&target={id}")
+HystrixCommand<HostList> getHostsOf(
+    @Param("id") String targetId
+);
+```
+
+*Required Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| targetId | text | The user ID of the channel for which to get host information. |
+
+*Optional Parameters*
+
+None
+
+## Code-Snippets
+
+### print who is hosting a channel
+
+```java
+HostList hosts = twitchClient.getMessagingInterface().getHostsOf("29829912").execute();
+
+hosts.getHosts().forEach(host -> {
+    System.out.println(host.getHostDisplayName());
+});
+```

--- a/docs/content/rest-tmi/get-hosts.md
+++ b/docs/content/rest-tmi/get-hosts.md
@@ -1,0 +1,42 @@
++++
+title="TMI - Get Hosts"
+weight = 11
++++
+
+# Get Hosts
+
+## Description
+
+This endpoint returns a "host" record for each channel ID provided. If the channel is not hosting anyone, the target_id 
+and target_login fields will not be present.
+
+## Method Definition
+
+```java
+@RequestLine("GET /hosts?include_logins=1&host={id}")
+HystrixCommand<HostList> getHosts(
+    @Param("id") List<String> channelIds
+);
+```
+
+*Required Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| channelIds | text | A list containing a user ID for each channel to check. |
+
+*Optional Parameters*
+
+None
+
+## Code-Snippets
+
+### print who a channel is hosting
+
+```java
+HostList hosts = twitchClient.getMessagingInterface().getHosts(List.of("29829912")).execute();
+
+hosts.getHosts().forEach(host -> {
+    System.out.println(host.getHostDisplayName() + " hosting " + host.getTargetDisplayName());
+});
+```


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* [Issue #205]

### Additional Information 
Added markdown docs for get-hosts and get-hosts-of, renamed get-viewers, and added `Chatters#getBroadcaster` example.