### PR TITLE
docs: add moderators and getStreamKey Helix docs

### DIFF
--- a/docs/content/rest-helix/_index.md
+++ b/docs/content/rest-helix/_index.md
@@ -69,9 +69,15 @@ Games:
 - [Games -> Search](./games-get)
 - [Games -> Top Games](./games-top)
 
+Moderators:
+
+- [Moderators -> Get](./moderators-get)
+- [Moderators -> Get Events](./moderators-get-events)
+
 Streams:
 
 - [Streams -> Search](./streams-get)
+- [Streams -> Get Key](./streams-get-key)
 - Create Stream Marker
 - [Streams -> Get Markers](./streams-markers-get)
 

--- a/docs/content/rest-helix/_index.md
+++ b/docs/content/rest-helix/_index.md
@@ -69,7 +69,7 @@ Games:
 - [Games -> Search](./games-get)
 - [Games -> Top Games](./games-top)
 
-Moderators:
+Moderation:
 
 - [Moderators -> Get](./moderators-get)
 - [Moderators -> Get Events](./moderators-get-events)

--- a/docs/content/rest-helix/moderators-get-events.md
+++ b/docs/content/rest-helix/moderators-get-events.md
@@ -26,7 +26,7 @@ HystrixCommand<ModeratorEventList> getModeratorEvents(
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| authToken     | string    | User Token for the broadcaster |
+| authToken     | string    | User Token for the broadcaster (scope: moderation:read) |
 | broadcasterId | string    | Provided broadcaster_id must match the user_id in the auth token. |
 
 *Optional Parameters*

--- a/docs/content/rest-helix/moderators-get-events.md
+++ b/docs/content/rest-helix/moderators-get-events.md
@@ -1,0 +1,48 @@
++++
+title="Moderators - Get Events"
+weight = 46
++++
+
+# Get Moderator Events
+
+## Description
+
+Returns a list of moderators or users added and removed as moderators from a channel.
+
+## Method Definition
+
+```java
+@RequestLine(value = "GET /moderation/moderators/events?broadcaster_id={broadcaster_id}&user_id={user_id}&after={after}", collectionFormat = CollectionFormat.CSV)
+@Headers("Authorization: Bearer {token}")
+HystrixCommand<ModeratorEventList> getModeratorEvents(
+    @Param("token") String authToken,
+    @Param("broadcaster_id") String broadcasterId,
+    @Param("user_id") List<String> userIds,
+    @Param("after") String after
+);
+```
+
+*Required Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| authToken     | string    | User Token for the broadcaster |
+| broadcasterId | string    | Provided broadcaster_id must match the user_id in the auth token. |
+
+*Optional Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| userIds       | string    | Filters the results and only returns a status object for users who are moderators in this channel and have a matching user_id. |
+| after         | string    | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
+
+## Code-Snippets
+
+### print list of moderator events
+
+```java
+ModeratorEventList resultList = twitchClient.getHelix().getModeratorEvents(authToken, broadcasterId, null, null).execute();
+resultList.getEvents().forEach(event -> {
+    System.out.println(event);
+});
+```

--- a/docs/content/rest-helix/moderators-get.md
+++ b/docs/content/rest-helix/moderators-get.md
@@ -1,0 +1,48 @@
++++
+title="Moderators - Get"
+weight = 45
++++
+
+# Get Moderators
+
+## Description
+
+Returns all moderators in a channel.
+
+## Method Definition
+
+```java
+@RequestLine(value = "GET /moderation/moderators?broadcaster_id={broadcaster_id}&user_id={user_id}&after={after}", collectionFormat = CollectionFormat.CSV)
+@Headers("Authorization: Bearer {token}")
+HystrixCommand<ModeratorList> getModerators(
+    @Param("token") String authToken,
+    @Param("broadcaster_id") String broadcasterId,
+    @Param("user_id") List<String> userIds,
+    @Param("after") String after
+);
+```
+
+*Required Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| authToken     | string    | User Token for the broadcaster |
+| broadcasterId | string    | Provided broadcaster_id must match the user_id in the auth token. |
+
+*Optional Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| userIds       | string    | Filters the results and only returns a status object for users who are moderators in this channel and have a matching user_id. |
+| after         | string    | Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query. |
+
+## Code-Snippets
+
+### print list of moderators
+
+```java
+ModeratorList resultList = twitchClient.getHelix().getModerators(authToken, broadcasterId, null, null).execute();
+resultList.getModerators().forEach(moderator -> {
+    System.out.println(moderator);
+});
+```

--- a/docs/content/rest-helix/moderators-get.md
+++ b/docs/content/rest-helix/moderators-get.md
@@ -26,7 +26,7 @@ HystrixCommand<ModeratorList> getModerators(
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| authToken     | string    | User Token for the broadcaster |
+| authToken     | string    | User Token for the broadcaster (scope: moderation:read) |
 | broadcasterId | string    | Provided broadcaster_id must match the user_id in the auth token. |
 
 *Optional Parameters*

--- a/docs/content/rest-helix/streams-get-key.md
+++ b/docs/content/rest-helix/streams-get-key.md
@@ -24,7 +24,7 @@ HystrixCommand<StreamKeyList> getStreamKey(
 
 | Name          | Type      | Description  |
 | ------------- |:---------:| -----------------:|
-| authToken     | string    | Auth Token (scope: channel:read:stream_key) |
+| authToken     | string    | User Access Token (scope: channel:read:stream_key) |
 | broadcasterId | string    | User ID of the broadcaster |
 
 *Optional Parameters*

--- a/docs/content/rest-helix/streams-get-key.md
+++ b/docs/content/rest-helix/streams-get-key.md
@@ -1,0 +1,43 @@
++++
+title="Streams - Get Key"
+weight = 51
++++
+
+# Get Stream Key
+
+## Description
+
+Gets the channel stream key for a user.
+
+## Method Definition
+
+```java
+@RequestLine("GET /streams/key?broadcaster_id={broadcaster_id}")
+@Headers("Authorization: Bearer {token}")
+HystrixCommand<StreamKeyList> getStreamKey(
+    @Param("token") String authToken,
+    @Param("broadcaster_id") String broadcasterId
+);
+```
+
+*Required Parameters*
+
+| Name          | Type      | Description  |
+| ------------- |:---------:| -----------------:|
+| authToken     | string    | Auth Token (scope: channel:read:stream_key) |
+| broadcasterId | string    | User ID of the broadcaster |
+
+*Optional Parameters*
+
+None
+
+## Code-Snippets
+
+### print stream key
+
+```java
+StreamKeyList resultList = twitchClient.getHelix().getStreamKey(authToken, broadcasterId).execute();
+resultList.getKeys().forEach(key -> {
+    System.out.println(key);
+});
+```


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* [Issue #203]

### Additional Information 
Added markdown docs for Helix endpoints `getModerators`, `getModeratorEvents`, and `getStreamKey`.
