### PR TITLE
docs: javadoc aggregation and delombok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ config/*
 client.log
 
 # JavaDoc
-/docs/javadoc/*
+/docs/static/javadoc/*
 
 # Example Code
 src/*/java/twitch4j/example/*

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // Plugins
 plugins {
+	id 'io.freefair.lombok' version '5.2.1' apply false
 	id 'com.jfrog.bintray' version '1.8.5' apply false
 	id 'com.jfrog.artifactory' version '4.13.0' apply false
 }
@@ -35,6 +36,12 @@ subprojects {
 	apply plugin: 'maven-publish'
 	apply plugin: 'com.jfrog.bintray'
 	apply plugin: 'com.jfrog.artifactory'
+	apply plugin: 'io.freefair.lombok'
+	lombok {
+		version = "1.18.10"
+	}
+	// prevent to generate 'lombok.config' - more about: https://projectlombok.org/features/configuration
+	generateLombokConfig.enabled = false
 
 	// Source Compatibility
 	sourceCompatibility = 1.8
@@ -100,10 +107,11 @@ subprojects {
 	plugins.withType(JavaPlugin) {
 		dependencies {
 			// Annotation processors
-			compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-			annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-			testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-			testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
+			// DEPRECATED: removal if 'io.freefair.lombok' has been applied
+//			compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
+//			annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
+//			testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
+//			testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
 
 			// Apache Commons
 			api group: 'org.apache.commons', name: 'commons-lang3'
@@ -117,5 +125,23 @@ subprojects {
 			testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.7.0')
 			testImplementation 'org.junit.jupiter:junit-jupiter'
 		}
+	}
+}
+
+tasks.register("aggregateJavadoc", Javadoc) {
+	it.group = JavaBasePlugin.DOCUMENTATION_GROUP
+	it.options {
+		title = "${project.artifactName} (v${project.version})"
+		windowTitle = "${project.artifactName} (v${project.version})"
+		encoding = "UTF-8"
+	}
+
+	it.source(subprojects.collect { it.delombok })
+	it.classpath = files(subprojects.collect { it.sourceSets.main.compileClasspath })
+
+	destinationDir = file("${rootDir}/docs/static/javadoc")
+
+	if (JavaVersion.current() != JavaVersion.VERSION_1_8){
+		it.options.addBooleanOption('html5', true)
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
 	apply plugin: 'com.jfrog.artifactory'
 	apply plugin: 'io.freefair.lombok'
 	lombok {
-		version = "1.18.10"
+		version = "1.18.16"
 	}
 	// prevent to generate 'lombok.config' - more about: https://projectlombok.org/features/configuration
 	generateLombokConfig.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -106,13 +106,6 @@ subprojects {
 	// Common Dependencies
 	plugins.withType(JavaPlugin) {
 		dependencies {
-			// Annotation processors
-			// DEPRECATED: removal if 'io.freefair.lombok' has been applied
-//			compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-//			annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-//			testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-//			testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
-
 			// Apache Commons
 			api group: 'org.apache.commons', name: 'commons-lang3'
 			api group: 'commons-io', name: 'commons-io'

--- a/deployment.gradle
+++ b/deployment.gradle
@@ -41,6 +41,8 @@ test {
  * Javadoc
  */
 javadoc {
+	dependsOn(delombok)
+	source delombok
     options {
         title = "${project.artifactName} (v${project.version})"
         windowTitle = "${project.artifactName} (v${project.version})"


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
- adding 'io.freefair.lombok' version '5.2.1'
- append all javadocs source to delombok task - [reference](https://docs.freefair.io/gradle-plugins/5.2.1/reference/#_io_freefair_lombok)
- ignores auto-generate 'lombok.config' for each existed project
- adding 'aggregateJavadoc' to generate combined javadoc for new incoming website

### Additional Information 
@iProdigy request it and he have it. Feel free to checking changes. Also i've added new task which he generate whole project aggregate into one javadoc. For new website purpose (soon™️). Here is diffrence between non-delomboked and delomboked files:

![diff](https://cdn.discordapp.com/attachments/455001263893905418/770024700540878848/unknown.png)
