### PR TITLE
build(ci): migration to github actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 /.github export-ignore
 /.gitattributes export-ignore
 /.editorconfig export-ignore
-/circle.yml export-ignore

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,3 @@
+feature: ['feature/*', 'feat/*']
+bugfix: fix/*
+deprecated: deprecate/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: Twitch4J v$RESOLVED_VERSION
+categories:
+  - title: New Features
+    labels:
+      - feature
+      - enhancement
+  - title: Bugs Fixed
+    labels:
+      - 'bug/minor'
+      - 'bug/major'
+      - bugfix
+  - title: Deprecations
+    label: deprecated
+exclude-labels:
+  - wontfix
+replacers:
+  - search: '/CVE-(\d{4})-(\d+)/g' # CVE Security
+    replace: '[CVE-$1-$2](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2)'
+  - search: '/\s+@(PhilippHeuer|iProdigy)/gi' # Skip maintainers
+    replace: ''
+  - search: '/^\[NEW\]/g' # NEW tag (better add them into prefix title)
+    replace: '[**NEW**]'
+template: |
+  [![Discord](https://img.shields.io/discord/143001431388061696?style=flat-square)](https://discord.gg/FQ5vgW3)
+  [![Downloads](https://img.shields.io/bintray/dt/twitch4j/maven/twitch4j/$RESOLVED_VERSION?style=flat-square)](https://bintray.com/twitch4j/maven/twitch4j/$RESOLVED_VERSION)
+  [![Javadoc](https://img.shields.io/static/v1?message=Javadoc&color=brightgreen&style=flat-square)](https://twitch4j.github.io/javadoc)
+
+  # Changelog
+
+  $CHANGES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on: [ push, pull_request ]
+
+jobs:
+  ci:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jvm: [ 8, 11, 14, 15 ]
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+      - name: Prepare cache builds
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: JDK${{ matrix.jvm }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: JDK${{ matrix.jvm }}-gradle-
+      - uses: actions/setup-java@v1
+        name: Setup JDK ${{ matrix.jvm }}
+        with:
+          java-version: ${{ matrix.jvm }}
+      - name: Prepare to Test
+        run: chmod +x ./gradlew
+      - name: Test Unit
+        run: ./gradlew test

--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -1,0 +1,12 @@
+on:
+  release:
+    types: published
+
+jobs:
+  webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: joelwmale/webhook-action@2.0.2
+        with:
+          url: ${{ secrets.DISCORD_WEBHOOK }}
+          body: '{"content":"Twitch4J has new release: **${{ release. }}**","username":"Release Notification","embeds":[{"title":"${{ steps.release.outputs.name }}","url":"${{ steps.release.outputs.html_url }}","description":"${{ steps.release.outputs.body }}"}]}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+on:
+  push:
+    branches: master
+    tags: v*
+
+jobs:
+  prepare:
+    name: Prepare release ${{ github.event.release.tag_name }}
+    runs-on: ubuntu-latest
+    env:
+      TAG_VERSION: ${{ github.event.release.tag_name }}
+      RELEASE_VERSION: ${{ github.event.release.tag_name.substring(1) }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: chmod +x ./gradlew
+  test:
+    needs: prepare
+    name: Finalize test ${{ github.event.release.tag_name }} before deploy
+    strategy:
+      matrix:
+        jvm: [ 8, 11, 14, 15 ]
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: JDK${{ matrix.jvm }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            JDK${{ matrix.jvm }}-gradle-
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jvm }}
+      - run: ./gradlew test
+  javadoc:
+    needs: test
+    name: Release Javadoc ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: JDK11-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            JDK11-gradle-
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/checkout@v2
+        with:
+          repository: https://github.com/twitch4j/twitch4j.github.io.git
+          path: ${GITHUB_WORKSPACE}/docs
+          fetch-depth: 0
+          refs: master
+      - run: |
+          rm -rf ${GITHUB_WORKSPACE}/docs/static/javadoc
+          ./gradlew aggregateJavadoc
+          cd ${GITHUB_WORKSPACE}/docs
+          git add .
+          git commit -m "release: deploy javadoc for ${{ github.event.release.tag_name }}"
+          git push origin master
+  release:
+    needs: test
+    name: Draft release notes ${{ github.event.release.tag_name }}
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: $TAG_VERSION
+          version: $RELEASE_VERSION
+          publish: true
+          prerelease: false
+  upload:
+    needs: test
+    name: Upload release ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: JDK8-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            JDK8-gradle-
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: ./gradlew bintrayUpload
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,0 @@
-####
-# Central CI Pipeline
-####
-
-include:
-- remote: 'https://raw.githubusercontent.com/EnvCLI/modular-pipeline/master/src/libexec/mpi/resources/gitlab/AutoDevOps.gitlab-ci.yml'


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Migration CI/CD to GitHub Actions

### Additional Information
This migration contains:
 - `ci` - which are testing lib in JDK's: 8, 11, 14 and 15 when someone push to some branches or make a PR
 - `release` - works only if you create tag in `master` branch. with [Release Drafter](https://github.com/release-drafter/release-drafter) will create release contains with specific label will be sorted and ordered. It required define `BINTRAY_USER` and `BINTRAY_API_KEY` secrets in repository settings.
 - `publication` - will notify to the discord channel via webhooks. Required define `DISCORD_WEBHOOK` secrets in repository settings.

`GITHUB_TOKEN` secret contains token using by [@github-actions](https://github.com/apps/github-actions) bot

Also there is:
- `release-drafter.yml` - for build Releases. See: [Release Drafter](https://github.com/release-drafter/release-drafter)
- `pr-labeler.yml` - helps automatically label PR's when have some specific conditions. Requires [actions/labeler](https://github.com/actions/labeler) to use it. But there is other way solutions to use [Community Health File](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-default-community-health-file#about-default-community-health-files) directed to `.github` repository for each organizations or users. It will assign automatically without using GH Actions defined inside Front Matter template.