### PR TITLE
Fix userId being undefined

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java
@@ -57,7 +57,7 @@ public class TwitchIdentityProvider extends OAuth2IdentityProvider {
             if (response.isSuccessful()) {
                 ObjectMapper objectMapper = new ObjectMapper();
                 HashMap<String, Object> tokenInfo = objectMapper.readValue(responseBody, new TypeReference<HashMap<String, Object>>() {});
-                String userId = (String) tokenInfo.get("user_id");
+                String userId = (String) tokenInfo.get("client_id");
                 String userName = (String) tokenInfo.get("login");
                 List<String> scopes = (List<String>) tokenInfo.get("scopes");
                 int expiresIn = (int) tokenInfo.get("expires_in");


### PR DESCRIPTION
When creating an OAuth Token for twitch, using CredentialManager, TwitchIdentityProdider and a user-id/user-secret,  getAdditionalCredentialInformation would return a OAuth2Credential, that didn't have a userId set. The effects are, that in the CredentialManager, the getOAuth2CredentialByUserId Method doesn't work. This Pull Request Changes this, by actually getting the right key in the request.

<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature - See https://github.com/twitch4j/twitch4j/blob/master/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java#L69

...
<!-- Uncomment this section if this PR is related to any issues.
### Issues Fixed 
* [Issue #1]

...
 -->

### Changes Proposed

* getAdditionalCredentialInformation is now returning an actual userId, rather than null

...

### Additional Information 
<!-- Any other information that may be able to help me with the problem. Remove this if it is not needed. -->
