### PR TITLE
feat: add channel point predictions pubsub and badge

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
@@ -42,6 +42,16 @@ public enum CommandPermission {
     CURRENT_HYPE_TRAIN_CONDUCTOR,
 
     /**
+     * Participated in the most recent predictions event for the blue/first option
+     */
+    PREDICTIONS_BLUE,
+
+    /**
+     * Participated in the most recent predictions event for the pink/second option
+     */
+    PREDICTIONS_PINK,
+
+    /**
      * VIP
      */
     VIP,

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -104,6 +104,17 @@ public class TwitchUtils {
             } else if ("2".equals(hypeBadge)) {
                 permissionSet.add(CommandPermission.FORMER_HYPE_TRAIN_CONDUCTOR);
             }
+            // Predictions Participation
+            String predictionBadge = badges.get("predictions");
+            if (StringUtils.isNotEmpty(predictionBadge)) {
+                char first = predictionBadge.charAt(0);
+                char last = predictionBadge.charAt(predictionBadge.length() - 1);
+                if (first == 'b' || last == '1') {
+                    permissionSet.add(CommandPermission.PREDICTIONS_BLUE);
+                } else if (first == 'p' || last == '2') {
+                    permissionSet.add(CommandPermission.PREDICTIONS_PINK);
+                }
+            }
         }
 
         if (userId != null && botOwnerIds != null && botOwnerIds.contains(userId))

--- a/pubsub/build.gradle
+++ b/pubsub/build.gradle
@@ -9,6 +9,9 @@ dependencies {
 	// Cache
 	api group: 'com.github.ben-manes.caffeine', name: 'caffeine'
 
+	// Annotations
+	api group: 'org.jetbrains', name: 'annotations'
+
 	// Twitch4J Modules
 	api project(':' + rootProject.name + '-common')
 	api project(':' + rootProject.name + '-auth')

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -248,6 +248,16 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForChannelPredictionsEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "predictions-channel-v1." + channelId);
+    }
+
+    @Unofficial
+    default PubSubSubscription listenForUserPredictionsEvents(OAuth2Credential credential, String userId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "predictions-user-v1." + userId);
+    }
+
+    @Unofficial
     default PubSubSubscription listenForChannelSubGiftsEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-sub-gifts-v1." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -520,6 +520,22 @@ public class TwitchPubSub implements ITwitchPubSub {
                             } else if (topic.startsWith("polls")) {
                                 PollData pollData = TypeConvert.convertValue(msgData.path("poll"), PollData.class);
                                 eventManager.publish(new PollsEvent(type, pollData));
+                            } else if (topic.startsWith("predictions-channel-v1")) {
+                                if ("event-created".equals(type)) {
+                                    eventManager.publish(TypeConvert.convertValue(msgData, PredictionCreatedEvent.class));
+                                } else if ("event-updated".equals(type)) {
+                                    eventManager.publish(TypeConvert.convertValue(msgData, PredictionUpdatedEvent.class));
+                                } else {
+                                    log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                }
+                            } else if (topic.startsWith("predictions-user-v1")) {
+                                if ("prediction-made".equals(type)) {
+                                    eventManager.publish(TypeConvert.convertValue(msgData, UserPredictionMadeEvent.class));
+                                } else if ("prediction-result".equals(type)) {
+                                    eventManager.publish(TypeConvert.convertValue(msgData, UserPredictionResultEvent.class));
+                                } else {
+                                    log.warn("Unparseable Message: " + message.getType() + "|" + message.getData());
+                                }
                             } else if (topic.startsWith("friendship")) {
                                 eventManager.publish(new FriendshipEvent(TypeConvert.jsonToObject(rawMessage, FriendshipData.class)));
                             } else if (topic.startsWith("presence")) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Prediction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Prediction.java
@@ -1,0 +1,27 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Prediction {
+    private String id;
+    private String eventId;
+    private String outcomeId;
+    private String channelId;
+    private Integer points;
+    private Instant predictedAt;
+    private Instant updatedAt;
+    private String userId;
+    private PredictionResult result; // can be null
+    private String userDisplayName;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Prediction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Prediction.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 
@@ -22,6 +23,7 @@ public class Prediction {
     private Instant predictedAt;
     private Instant updatedAt;
     private String userId;
-    private PredictionResult result; // can be null
+    @Nullable
+    private PredictionResult result;
     private String userDisplayName;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionColor.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionColor.java
@@ -1,0 +1,6 @@
+package com.github.twitch4j.pubsub.domain;
+
+public enum PredictionColor {
+    BLUE,
+    PINK
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionEvent {
+    private String id;
+    private String channelId;
+    private Instant createdAt;
+    private PredictionTrigger createdBy;
+    private Instant endedAt;
+    private PredictionTrigger endedBy;
+    private Instant lockedAt;
+    private PredictionTrigger lockedBy;
+    private List<PredictionOutcome> outcomes;
+    private Integer predictionWindowSeconds;
+    private String status; // e.g. ACTIVE or LOCKED or RESOLVE_PENDING or RESOLVED
+    private String title;
+    private String winningOutcomeId;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
@@ -26,7 +26,7 @@ public class PredictionEvent {
     private List<PredictionOutcome> outcomes;
     private Integer predictionWindowSeconds;
     /**
-     * The status of the prediction (e.g., "ACTIVE", "LOCKED", "RESOLVE_PENDING", "RESOLVED")
+     * The status of the prediction (e.g., "ACTIVE", "CANCELED", "CANCEL_PENDING", "LOCKED", "RESOLVE_PENDING", "RESOLVED")
      */
     private String status;
     private String title;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
@@ -25,7 +25,10 @@ public class PredictionEvent {
     private PredictionTrigger lockedBy;
     private List<PredictionOutcome> outcomes;
     private Integer predictionWindowSeconds;
-    private String status; // e.g. ACTIVE or LOCKED or RESOLVE_PENDING or RESOLVED
+    /**
+     * The status of the prediction (e.g., "ACTIVE", "LOCKED", "RESOLVE_PENDING", "RESOLVED")
+     */
+    private String status;
     private String title;
     private String winningOutcomeId;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionOutcome.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionOutcome.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionOutcome {
+    private String id;
+    private PredictionColor color;
+    private String title;
+    private Integer totalPoints;
+    private Integer totalUsers;
+    private List<Prediction> topPredictors;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionResult.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionResult.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
 
 @Data
 @Setter(AccessLevel.NONE)
@@ -15,9 +16,13 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionResult {
 
-    private String type; // e.g. WIN or LOSE
+    /**
+     * The result type (e.g., "WIN", "LOSE")
+     */
+    private String type;
 
-    private Integer pointsWon; // can be null
+    @Nullable
+    private Integer pointsWon;
 
     @JsonProperty("is_acknowledged")
     @Accessors(fluent = true)

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionResult.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionResult.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Data
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionResult {
+
+    private String type; // e.g. WIN or LOSE
+
+    private Integer pointsWon; // can be null
+
+    @JsonProperty("is_acknowledged")
+    @Accessors(fluent = true)
+    private Boolean isAcknowledged;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionTrigger.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionTrigger.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionTrigger {
+    private String type;
+    private String userId;
+    private String userDisplayName;
+    private String extensionClientId;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionCreatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionCreatedEvent.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PredictionEvent;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionCreatedEvent extends TwitchEvent {
+    private Instant timestamp;
+    private PredictionEvent event;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionUpdatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionUpdatedEvent.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PredictionEvent;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionUpdatedEvent extends TwitchEvent {
+    private Instant timestamp;
+    private PredictionEvent event;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionMadeEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionMadeEvent.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.Prediction;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * Sent on prediction-made for predictions-user-v1
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserPredictionMadeEvent extends TwitchEvent {
+    private Instant timestamp;
+    private Prediction prediction;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionResultEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionResultEvent.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.Prediction;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * Sent on prediction-result for predictions-user-v1
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Setter(AccessLevel.NONE)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserPredictionResultEvent extends TwitchEvent {
+    private Instant timestamp;
+    private Prediction prediction;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Implement `predictions-channel-v1` unofficial pubsub topic
* Implement `predictions-user-v1` unofficial pubsub topic
* Implement `CommandPermission.PREDICTIONS_BLUE` and `CommandPermission.PREDICTIONS_PINK`

### Additional Information 
https://blog.twitch.tv/en/2020/12/12/channel-points-predictions-let-your-viewers-guess-your-destiny/
