### PR TITLE
build: shadow jar - all deps in one jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.freefair.lombok' version '5.2.1' apply false
 	id 'com.jfrog.bintray' version '1.8.5' apply false
 	id 'com.jfrog.artifactory' version '4.13.0' apply false
+	id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 
 // Artifact Info
@@ -37,6 +38,8 @@ subprojects {
 	apply plugin: 'com.jfrog.bintray'
 	apply plugin: 'com.jfrog.artifactory'
 	apply plugin: 'io.freefair.lombok'
+	apply plugin: 'com.github.johnrengelman.shadow'
+
 	lombok {
 		version = "1.18.16"
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'io.freefair.lombok' version '5.2.1' apply false
 	id 'com.jfrog.bintray' version '1.8.5' apply false
 	id 'com.jfrog.artifactory' version '4.13.0' apply false
-	id 'com.github.johnrengelman.shadow' version '6.1.0'
+	id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
 }
 
 // Artifact Info

--- a/deployment.gradle
+++ b/deployment.gradle
@@ -19,6 +19,14 @@ extensions.configure(JavaPluginExtension) {
 	it.withJavadocJar()
 }
 
+// Shadow Jar
+shadowJar {
+	archiveClassifier.set('shaded')
+	manifest {
+		inheritFrom jar.manifest
+	}
+}
+
 /**
  * set base name to lowercase for each jar file
  */

--- a/deployment.gradle
+++ b/deployment.gradle
@@ -19,14 +19,19 @@ extensions.configure(JavaPluginExtension) {
 	it.withJavadocJar()
 }
 
+task shadowJarRelocate(type: com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) {
+	target = shadowJar
+	prefix = "com.github.twitch4j.deps.v${version.toString().replace(".", "_")}" // example result: twitch4j.v1_2_0
+}
+
 // Shadow Jar
 shadowJar {
+	dependsOn shadowJarRelocate
 	archiveClassifier.set('shaded')
 	manifest {
 		inheritFrom jar.manifest
 	}
 }
-
 /**
  * set base name to lowercase for each jar file
  */

--- a/deployment.gradle
+++ b/deployment.gradle
@@ -1,3 +1,5 @@
+import java.util.jar.JarFile
+
 /**
  * Artifact
  */
@@ -19,19 +21,33 @@ extensions.configure(JavaPluginExtension) {
 	it.withJavadocJar()
 }
 
-task shadowJarRelocate(type: com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) {
-	target = shadowJar
-	prefix = "com.github.twitch4j.deps.v${version.toString().replace(".", "_")}" // example result: twitch4j.v1_2_0
-}
-
 // Shadow Jar
 shadowJar {
-	dependsOn shadowJarRelocate
 	archiveClassifier.set('shaded')
+
+	def packages = [] as Set<String>
+	configurations.each { configuration ->
+		configuration.files.each { jar ->
+			JarFile jf = new JarFile(jar)
+			jf.entries().each { entry ->
+				if (entry.name.endsWith(".class")) {
+					packages << entry.name[0..entry.name.lastIndexOf('/')-1].replaceAll('/', '.')
+				}
+			}
+			jf.close()
+		}
+	}
+	packages.each {
+		relocate(it, "com.github.twitch4j.shaded.${version.toString().replace(".", "_")}.${it}") {
+			exclude 'com.github.twitch4j'
+		}
+	}
+
 	manifest {
 		inheritFrom jar.manifest
 	}
 }
+
 /**
  * set base name to lowercase for each jar file
  */


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
1. Apply plugin `com.github.johnrengelman.shadow` - Closes #226 

### Additional Information 
In #226 where providing this plugin and applying `shaded` word into `archiveClassifier` for `shadowJar` task, will automatically adds into `MavenPublication`. 

All those changes are be tested before the pull request.
