### PR TITLE
chore: bump apollo graphql to 2.4.6

### DIFF
--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -18,11 +18,10 @@ dependencies {
 }
 
 // Javadoc
-javadoc {
+tasks.withType(Javadoc) {
 	// Ignore auto-generated files from apollo graphql
 	exclude 'com/github/twitch4j/graphql/internal/**'
 }
-
 // Artifact Info
 project.ext {
 	groupId = 'com.github.twitch4j'

--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -1,21 +1,12 @@
-// Buildscript
-buildscript {
-	repositories {
-		jcenter()
-		maven { url "https://maven.google.com" }
-	}
-	dependencies {
-		classpath 'com.apollographql.apollo:apollo-gradle-plugin:1.2.2'
-	}
-}
-
 // Plugins
-apply plugin: 'com.apollographql.android'
+plugins {
+	id 'com.apollographql.apollo' version '2.4.6'
+}
 
 // Dependencies
 dependencies {
 	// GraphQL
-	api group: 'com.apollographql.apollo', name: 'apollo-runtime', version: '1.2.2'
+	api group: 'com.apollographql.apollo', name: 'apollo-runtime', version: '2.4.6'
 	api group: 'org.jetbrains', name: 'annotations'
 
 	// Hystrix

--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -17,6 +17,12 @@ dependencies {
 	api project(':' + rootProject.name + '-auth')
 }
 
+// Javadoc
+javadoc {
+	// Ignore auto-generated files from apollo graphql
+	exclude 'com/github/twitch4j/graphql/internal/**'
+}
+
 // Artifact Info
 project.ext {
 	groupId = 'com.github.twitch4j'

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFollowUser.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFollowUser.java
@@ -21,8 +21,8 @@ public class CommandFollowUser extends BaseCommand<FollowMutation.Data> {
     }
 
     @Override
-    protected ApolloCall getGraphQLCall() {
-        ApolloCall apolloCall = apolloClient.mutate(
+    protected ApolloCall<FollowMutation.Data> getGraphQLCall() {
+        ApolloCall<FollowMutation.Data> apolloCall = apolloClient.mutate(
             FollowMutation.builder()
                 .followUserInput(
                     FollowUserInput.builder()

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandUnfollowUser.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandUnfollowUser.java
@@ -18,8 +18,8 @@ public class CommandUnfollowUser extends BaseCommand<UnfollowMutation.Data> {
     }
 
     @Override
-    protected ApolloCall getGraphQLCall() {
-        ApolloCall apolloCall = apolloClient.mutate(
+    protected ApolloCall<UnfollowMutation.Data> getGraphQLCall() {
+        ApolloCall<UnfollowMutation.Data> apolloCall = apolloClient.mutate(
             UnfollowMutation.builder()
                 .unfollowUserInput(
                     UnfollowUserInput.builder()


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
Dependabot failures:
* Closes #241 
* Closes #242 

### Changes Proposed
* Bump `apollo-runtime` to 2.4.6
* Utilize `com.apollographql.apollo` plugin rather than legacy buildscript approach
* Improve performance of `BaseCommand#run` via `java.util.concurrent`
* Include generic parameter in `BaseCommand#getGraphQLCall` for clarity
