### PR TITLE
refactor: remove unnecessary jackson annotations

### DIFF
--- a/chat/src/test/java/com/github/twitch4j/chat/TwitchChatTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/TwitchChatTest.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.chat;
 import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.CredentialManagerBuilder;
 import com.github.philippheuer.events4j.core.EventManager;
-import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
 import com.github.twitch4j.chat.events.CommandEvent;
 import com.github.twitch4j.chat.events.channel.ChannelMessageEvent;

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscription.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscription.java
@@ -2,10 +2,7 @@ package com.github.twitch4j.eventsub;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.condition.EventSubCondition;
 import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
 import com.github.twitch4j.eventsub.subscriptions.SubscriptionTypes;
@@ -27,8 +24,6 @@ import java.util.Map;
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSubSubscription {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubTransport.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubTransport.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,8 +14,6 @@ import lombok.extern.jackson.Jacksonized;
 @NoArgsConstructor
 @AllArgsConstructor
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSubTransport {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ApplicationEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ApplicationEventSubCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -18,8 +15,6 @@ import java.util.Map;
 @SuperBuilder
 @EqualsAndHashCode(callSuper = false)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplicationEventSubCondition extends EventSubCondition {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelBanCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelBanCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -10,8 +7,6 @@ import lombok.extern.jackson.Jacksonized;
 
 @SuperBuilder
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ChannelBanCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelCheerCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelCheerCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelCheerCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelEventSubCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -18,8 +15,6 @@ import java.util.Map;
 @SuperBuilder
 @EqualsAndHashCode(callSuper = false)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelEventSubCondition extends EventSubCondition {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelFollowCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelFollowCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelFollowCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardAddCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardAddCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsCustomRewardAddCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardRedemptionAddCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardRedemptionAddCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsCustomRewardRedemptionAddCondition extends CustomRewardEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardRedemptionUpdateCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardRedemptionUpdateCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsCustomRewardRedemptionUpdateCondition extends CustomRewardEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardRemoveCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardRemoveCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsCustomRewardRemoveCondition extends CustomRewardEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardUpdateCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPointsCustomRewardUpdateCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsCustomRewardUpdateCondition extends CustomRewardEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelSubscribeCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelSubscribeCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelSubscribeCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelUnbanCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelUnbanCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelUnbanCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelUpdateCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelUpdateCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelUpdateCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CustomRewardEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CustomRewardEventSubCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -21,8 +18,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomRewardEventSubCondition extends ChannelEventSubCondition {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/HypeTrainBeginCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/HypeTrainBeginCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainBeginCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/HypeTrainEndCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/HypeTrainEndCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainEndCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/HypeTrainProgressCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/HypeTrainProgressCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainProgressCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/StreamOfflineCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/StreamOfflineCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamOfflineCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/StreamOnlineCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/StreamOnlineCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamOnlineCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserAuthorizationRevokeCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserAuthorizationRevokeCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserAuthorizationRevokeCondition extends ApplicationEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserEventSubCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -18,8 +15,6 @@ import java.util.Map;
 @SuperBuilder
 @EqualsAndHashCode(callSuper = false)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserEventSubCondition extends EventSubCondition {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserUpdateCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserUpdateCondition.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -12,6 +9,4 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserUpdateCondition extends UserEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Contribution.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Contribution.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,8 +9,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Contribution {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GlobalCooldown.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GlobalCooldown.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,8 +10,6 @@ import lombok.experimental.Accessors;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GlobalCooldown {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerStream.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerStream.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,8 +10,6 @@ import lombok.experimental.Accessors;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MaxPerStream {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerUserPerStream.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerUserPerStream.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,8 +10,6 @@ import lombok.experimental.Accessors;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MaxPerUserPerStream {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Reward.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Reward.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -10,7 +9,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Reward {
 
     /**
@@ -36,7 +34,6 @@ public class Reward {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Image {
         @JsonProperty("url_1x")
         private String url1x;

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCheerEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCheerEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.TwitchUtils;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -18,8 +15,6 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelCheerEvent extends EventSubUserChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPointsCustomRewardEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPointsCustomRewardEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.GlobalCooldown;
 import com.github.twitch4j.eventsub.domain.MaxPerStream;
 import com.github.twitch4j.eventsub.domain.MaxPerUserPerStream;
@@ -23,8 +20,6 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ChannelPointsCustomRewardEvent extends EventSubChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPointsCustomRewardRedemptionEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPointsCustomRewardRedemptionEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
 import com.github.twitch4j.eventsub.domain.Reward;
 import lombok.AccessLevel;
@@ -19,8 +16,6 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ChannelPointsCustomRewardRedemptionEvent extends EventSubUserChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelSubscribeEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelSubscribeEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -18,8 +15,6 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelSubscribeEvent extends EventSubUserChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUpdateEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,8 +14,6 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelUpdateEvent extends EventSubChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubChannelEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubChannelEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +10,6 @@ import lombok.Setter;
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSubChannelEvent extends EventSubEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubUserChannelEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubUserChannelEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +10,6 @@ import lombok.Setter;
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSubUserChannelEvent extends EventSubEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubUserEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubUserEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +10,6 @@ import lombok.Setter;
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSubUserEvent extends EventSubEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainBeginEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.Contribution;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -18,8 +15,6 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainBeginEvent extends HypeTrainEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEndEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,8 +14,6 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainEndEvent extends HypeTrainEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.Contribution;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -19,8 +16,6 @@ import java.util.List;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class HypeTrainEvent extends EventSubChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainProgressEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainProgressEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.Contribution;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -18,8 +15,6 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainProgressEvent extends HypeTrainEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/StreamOnlineEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/StreamOnlineEvent.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.github.twitch4j.eventsub.domain.StreamType;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -14,7 +13,6 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamOnlineEvent extends EventSubChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserAuthorizationRevokeEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserAuthorizationRevokeEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,8 +12,6 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserAuthorizationRevokeEvent extends EventSubUserEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserUpdateEvent.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,7 +12,6 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserUpdateEvent extends EventSubUserEvent {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/PubSubResponsePayloadMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/PubSubResponsePayloadMessage.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.pubsub;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PubSubResponsePayloadMessage {
 
     private String type;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/BitsBadgeData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/BitsBadgeData.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BitsBadgeData {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelBitsData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelBitsData.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelBitsData {
 
     /**
@@ -62,8 +57,6 @@ public class ChannelBitsData {
     private BadgeEntitlement badgeEntitlement;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class BadgeEntitlement {
         /**
          * The number of bits associated with the previous badge

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsBalance.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsBalance.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsBalance {
     private String userId;
     private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsEarned.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsEarned.java
@@ -1,15 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsEarned {
     private Instant timestamp;
     private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsGain.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsGain.java
@@ -1,15 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsGain {
     private String userId;
     private String channelId;
@@ -19,8 +14,6 @@ public class ChannelPointsGain {
     private List<PointGainMultiplier> multipliers;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PointGainMultiplier {
         private String reasonCode;
         private Double factor;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsRedemption {
 
 	/**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -1,14 +1,9 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsReward {
 
 	private String id;
@@ -29,7 +24,6 @@ public class ChannelPointsReward {
 	private String updatedForIndicatorAt;
 
 	@Data
-	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class Image {
 		@JsonProperty("url_1x")
 		private String url1x;
@@ -40,8 +34,6 @@ public class ChannelPointsReward {
 	}
 
 	@Data
-	@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class MaxPerStream {
 		private Boolean isEnabled;
 		private long maxPerStream;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsUser.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsUser.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelPointsUser {
 
 	private String id;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.Getter;
 
@@ -16,8 +13,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChatModerationAction {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CheerbombData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CheerbombData.java
@@ -1,10 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CheerbombData {
     private String userID;
     private String displayName;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClaimData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClaimData.java
@@ -1,22 +1,15 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClaimData {
     private Instant timestamp;
     private Claim claim;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Claim {
         private String id;
         private String userId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommerceData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommerceData.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CommerceData {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommerceMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommerceMessage.java
@@ -1,15 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CommerceMessage {
 
     /**
@@ -23,8 +18,6 @@ public class CommerceMessage {
     private List<CommerceEmote> emotes;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class CommerceEmote {
         /**
          * The index in the message where the emote starts

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreateNotificationData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreateNotificationData.java
@@ -1,10 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateNotificationData {
     private NotificationSummary summary;
     private OnsiteNotification notification;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatedUnbanRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatedUnbanRequest.java
@@ -1,9 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -16,8 +12,6 @@ import java.time.Instant;
 @Setter(AccessLevel.PRIVATE)
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatedUnbanRequest extends UnbanRequest {
 
     private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FollowingData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FollowingData.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class FollowingData {
     private String displayName;
     private String username;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
@@ -1,9 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.Arrays;
@@ -12,8 +8,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class FriendshipData {
     private String userId;
     private String targetUserId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
@@ -1,17 +1,12 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.MilliInstantDeserializer;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeLevelUp {
     @JsonDeserialize(using = MilliInstantDeserializer.class)
     private Instant timeToExpire;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeProgression {
     private String userId;
     private Integer sequenceId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductor.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductor.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainConductor {
     private String source;
     private HypeTrainConductorUser user;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductorUser.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductorUser.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainConductorUser {
     private String id;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainConfig {
     private String channelId;
     private Boolean isEnabled;
@@ -30,8 +25,6 @@ public class HypeTrainConfig {
     private Boolean hasConductorBadges;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class HypeTrainKickoff {
         private Integer numOfEvents;
         private Integer minPoints;
@@ -39,7 +32,6 @@ public class HypeTrainConfig {
     }
 
     @Data
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ConductorRewards {
         @JsonProperty("BITS")
         private ConductorReward bits;
@@ -48,7 +40,6 @@ public class HypeTrainConfig {
         private ConductorReward subs;
 
         @Data
-        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class ConductorReward {
             @JsonProperty("CURRENT")
             private List<RewardType> current;
@@ -57,8 +48,6 @@ public class HypeTrainConfig {
             private List<RewardType> former;
 
             @Data
-            @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-            @JsonIgnoreProperties(ignoreUnknown = true)
             public static class RewardType {
                 private String type;
                 private String id;
@@ -71,7 +60,6 @@ public class HypeTrainConfig {
     }
 
     @Data
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DifficultySettings {
         @JsonProperty("EASY")
         private List<DifficultySetting> easy;
@@ -89,8 +77,6 @@ public class HypeTrainConfig {
         private List<DifficultySetting> insane;
 
         @Data
-        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class DifficultySetting {
             private Integer value;
             private Integer goal;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
@@ -1,17 +1,12 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.MilliInstantDeserializer;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainEnd {
     @JsonDeserialize(using = MilliInstantDeserializer.class)
     private Instant endedAt;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
@@ -1,15 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainLevel {
     private Integer value;
     private Integer goal;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipations.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipations.java
@@ -1,11 +1,9 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainParticipations {
     @JsonProperty("BITS.CHEER")
     private Integer cheerBits;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainProgress.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainProgress.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainProgress {
     private HypeTrainLevel level;
     private Integer value;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainReward.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainReward {
     private String type;
     private String id;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainRewardsData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainRewardsData.java
@@ -1,23 +1,16 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainRewardsData {
     private String channelId;
     private Integer completedLevel;
     private List<Reward> rewards;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Reward {
         private String type; // e.g. "EMOTE"
         private String id;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
@@ -1,17 +1,12 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.MilliInstantDeserializer;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainStart {
     private String channelId;
     private String id;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Leaderboard.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Leaderboard.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.NanoInstantDeserializer;
 import lombok.Data;
 
@@ -11,8 +8,6 @@ import java.time.Instant;
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Leaderboard {
     private Identifier identifier;
     private List<Entry> top;
@@ -20,8 +15,6 @@ public class Leaderboard {
     private Event event;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Identifier {
         private String domain;
         private String groupingKey;
@@ -30,8 +23,6 @@ public class Leaderboard {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Entry {
         private Integer rank;
         private Long score;
@@ -39,16 +30,12 @@ public class Leaderboard {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Context {
         private Entry entry;
         private List<Entry> context;
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Event {
         private String domain;
         private String id;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/NotificationSummary.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/NotificationSummary.java
@@ -1,15 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class NotificationSummary {
     private Integer unseenViewCount;
     private Instant lastSeenAt;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/OnsiteNotification.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/OnsiteNotification.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class OnsiteNotification {
     private String userId;
     private String id;
@@ -26,8 +21,6 @@ public class OnsiteNotification {
     private List<Creator> creators;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Action {
         private String id;
         private String type;
@@ -38,8 +31,6 @@ public class OnsiteNotification {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Creator {
         private String userId;
         private String userName;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PointsSpent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PointsSpent.java
@@ -1,22 +1,15 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PointsSpent {
     private Instant timestamp;
     private Balance balance;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Balance {
         private String userId;
         private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PollData {
     private String pollId;
     private String ownedBy;
@@ -32,8 +27,6 @@ public class PollData {
     private Contributor topChannelPointsContributor;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PollSettings {
         private Setting multiChoice;
         private Setting subscriberOnly;
@@ -42,8 +35,6 @@ public class PollData {
         private Setting channelPointsVotes;
 
         @Data
-        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Setting {
             private Boolean isEnabled;
             private Long cost;
@@ -51,8 +42,6 @@ public class PollData {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PollChoice {
         private String choiceId;
         private String title;
@@ -62,8 +51,6 @@ public class PollData {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Votes {
         private Long total;
         private Long bits;
@@ -72,16 +59,12 @@ public class PollData {
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Tokens {
         private Long bits;
         private Long channelPoints;
     }
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Contributor {
         private String userId;
         private String displayName;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Prediction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Prediction.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Prediction {
     private String id;
     private String eventId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.util.List;
 
 @Data
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionEvent {
     private String id;
     private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionOutcome.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionOutcome.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,8 +8,6 @@ import java.util.List;
 
 @Data
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionOutcome {
     private String id;
     private PredictionColor color;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionResult.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionResult.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import org.jetbrains.annotations.Nullable;
 
 @Data
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionResult {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionTrigger.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PredictionTrigger.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionTrigger {
     private String type;
     private String userId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceData.java
@@ -1,17 +1,12 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.time.Instant;
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PresenceData {
     private String userId;
     private String userLogin;
@@ -25,8 +20,6 @@ public class PresenceData {
     private List<Activity> activities;
 
     @Data
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Activity {
         /**
          * Activity Type. Examples include: "none", "watching", "broadcasting"

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceSettings.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceSettings.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PresenceSettings {
     private Boolean shareActivity;
     private String availabilityOverride;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubRequest.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.pubsub.enums.PubSubType;
 import lombok.Data;
 
@@ -16,8 +13,6 @@ import java.util.Map;
  * Will ignore null values when serializing the request
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PubSubRequest {
 

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubResponse.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubResponse.java
@@ -1,14 +1,9 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.pubsub.enums.PubSubType;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PubSubResponse {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubResponsePayload.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubResponsePayload.java
@@ -1,17 +1,12 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PubSubResponsePayload {
 
     private String topic;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioData.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.twitch4j.common.util.NanoInstantDeserializer;
@@ -12,7 +11,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RadioData {
 
     @JsonProperty("userID")

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioTrack.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioTrack.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -10,7 +9,6 @@ import java.util.List;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RadioTrack {
 
     private String asin;
@@ -25,7 +23,6 @@ public class RadioTrack {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Artist {
         private String asin;
         private String name;
@@ -33,7 +30,6 @@ public class RadioTrack {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class AlbumInfo {
         private String asin;
         private String name;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RaidData.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RaidData {
     private String id;
     private String creatorId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RedemptionProgress.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RedemptionProgress.java
@@ -1,13 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RedemptionProgress {
     private String id;
     private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubGiftData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubGiftData.java
@@ -1,14 +1,9 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import lombok.Data;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SubGiftData {
     private Integer count;
     private SubscriptionPlan tier;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubscriptionData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubscriptionData.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.enums.SubscriptionType;
 import lombok.Data;
@@ -13,8 +10,6 @@ import java.time.Instant;
 import java.time.Month;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SubscriptionData {
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UnbanRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UnbanRequest.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UnbanRequest {
 
     private String id;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdateSummaryData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdateSummaryData.java
@@ -1,10 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UpdateSummaryData {
     private NotificationSummary summary;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdatedUnbanRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UpdatedUnbanRequest.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +10,6 @@ import lombok.ToString;
 @Setter(AccessLevel.PRIVATE)
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UpdatedUnbanRequest extends UnbanRequest {
 
     private String resolverId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -1,15 +1,9 @@
 package com.github.twitch4j.pubsub.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoPlaybackData {
     /**
      * The type of the video playback event.

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionCreatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionCreatedEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.PredictionEvent;
 import lombok.AccessLevel;
@@ -15,8 +12,6 @@ import java.time.Instant;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionCreatedEvent extends TwitchEvent {
     private Instant timestamp;
     private PredictionEvent event;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionUpdatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PredictionUpdatedEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.PredictionEvent;
 import lombok.AccessLevel;
@@ -15,8 +12,6 @@ import java.time.Instant;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredictionUpdatedEvent extends TwitchEvent {
     private Instant timestamp;
     private PredictionEvent event;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidCancelEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidCancelEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.RaidData;
 import lombok.AccessLevel;
@@ -13,8 +10,6 @@ import lombok.Setter;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RaidCancelEvent extends TwitchEvent {
     private RaidData raid;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidGoEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.RaidData;
 import lombok.AccessLevel;
@@ -13,8 +10,6 @@ import lombok.Setter;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RaidGoEvent extends TwitchEvent {
     private RaidData raid;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RaidUpdateEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.RaidData;
 import lombok.AccessLevel;
@@ -13,8 +10,6 @@ import lombok.Setter;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class RaidUpdateEvent extends TwitchEvent {
     private RaidData raid;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionMadeEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionMadeEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.Prediction;
 import lombok.AccessLevel;
@@ -18,8 +15,6 @@ import java.time.Instant;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserPredictionMadeEvent extends TwitchEvent {
     private Instant timestamp;
     private Prediction prediction;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionResultEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPredictionResultEvent.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.pubsub.events;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.Prediction;
 import lombok.AccessLevel;
@@ -18,8 +15,6 @@ import java.time.Instant;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @Setter(AccessLevel.NONE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserPredictionResultEvent extends TwitchEvent {
     private Instant timestamp;
     private Prediction prediction;

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/TwitchPubSubTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/TwitchPubSubTest.java
@@ -31,7 +31,6 @@ public class TwitchPubSubTest {
     public void localTestRun() {
         // listen for events in channel
         twitchPubSub.listenForCheerEvents(TestUtils.getCredential(), "149223493");
-        twitchPubSub.listenForCommerceEvents(TestUtils.getCredential(), "149223493");
         twitchPubSub.listenForSubscriptionEvents(TestUtils.getCredential(), "149223493");
         twitchPubSub.listenForWhisperEvents(TestUtils.getCredential(), "149223493");
 

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/Channel.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/Channel.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +8,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Channel {
 
     private String id;

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ChannelList.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ChannelList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,7 +14,6 @@ import java.util.List;
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelList extends ExtensionsPagination {
 
     private List<Channel> channels;

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ConfigurationSegment.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ConfigurationSegment.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,7 +8,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConfigurationSegment {
     private Segment segment;
     private Record record;
@@ -19,8 +15,6 @@ public class ConfigurationSegment {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Segment {
         private ConfigurationSegmentType segmentType;
         private String channelId;
@@ -29,7 +23,6 @@ public class ConfigurationSegment {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Record {
         private String content;
         private String version;

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionConfigurationSegment.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionConfigurationSegment.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,8 +15,6 @@ import lombok.With;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionConfigurationSegment {
 
     @NonNull

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionInformation.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionInformation.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.annotation.Unofficial;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -15,8 +12,6 @@ import java.util.Map;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 @Unofficial
 public class ExtensionInformation {
 

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionSecret.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionSecret.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,7 +10,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionSecret {
 
     private Instant active;

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionSecretList.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionSecretList.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,8 +10,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionSecretList {
 
     private Integer formatVersion;

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionsPagination.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/domain/ExtensionsPagination.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.extensions.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,7 +11,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionsPagination {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ActiveExtension.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ActiveExtension.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +12,6 @@ import lombok.Setter;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ActiveExtension {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AnaylticsDateRange.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AnaylticsDateRange.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -17,7 +16,6 @@ import java.util.Date;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AnaylticsDateRange {
 
     /** Starting date/time for returned reports, in RFC3339 format with the hours, minutes, and seconds zeroed out and the UTC timezone: YYYY-MM-DDT00:00:00Z. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceCheck.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceCheck.java
@@ -1,14 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
 import java.util.UUID;
 
 @Value
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @AllArgsConstructor
 public class AutomodEnforceCheck {
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceStatus.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceStatus.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +8,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AutomodEnforceStatus {
     /**
      * The msg_id passed in the body of the POST message. Maps each message to its status.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceStatusList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceStatusList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -13,7 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AutomodEnforceStatusList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,8 +12,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BannedEvent {
     /**
      * Event ID.
@@ -47,8 +42,6 @@ public class BannedEvent {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class EventData {
         /**
          * The id of the broadcaster where the event took place

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEventList.java
@@ -18,7 +18,6 @@ public class BannedEventList {
     @JsonProperty("data")
     private List<BannedEvent> events;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEventList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -13,7 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BannedEventList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUser.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUser.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,8 +11,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BannedUser {
     /**
      * User ID of a user who has been banned.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUserList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUserList.java
@@ -18,7 +18,6 @@ public class BannedUserList {
     @JsonProperty("data")
     private List<BannedUser> results;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUserList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUserList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -13,7 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BannedUserList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboard.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboard.java
@@ -17,7 +17,6 @@ public class BitsLeaderboard {
     @JsonProperty("data")
     private List<BitsLeaderboardEntry> entries;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboard.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboard.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
@@ -12,9 +9,8 @@ import java.util.List;
  * Bits Leaderboard
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BitsLeaderboard {
+
     /**
      * Data
      */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboardEntry.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BitsLeaderboardEntry.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 /**
@@ -11,8 +8,6 @@ import lombok.*;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BitsLeaderboardEntry {
 
     /** ID of the user (viewer) in the leaderboard entry. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BlockedUser.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BlockedUser.java
@@ -1,14 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(value = AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class BlockedUser {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CategorySearchList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CategorySearchList.java
@@ -19,7 +19,6 @@ public class CategorySearchList {
     @JsonProperty("data")
     private List<Game> results;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CategorySearchList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CategorySearchList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -15,7 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CategorySearchList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelEditor.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelEditor.java
@@ -1,7 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +8,6 @@ import java.time.Instant;
 
 @Data
 @Setter(value = AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ChannelEditor {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
@@ -1,9 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.github.twitch4j.helix.TwitchHelix;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,16 +7,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.With;
 
-import java.util.List;
-
 @Data
 @With
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelInformation {
+
     /**
      * Twitch User ID of this channel owner
      */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformationList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformationList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelInformationList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchList.java
@@ -21,7 +21,6 @@ public class ChannelSearchList {
     @JsonProperty("data")
     private List<ChannelSearchResult> results;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelSearchList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchResult.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchResult.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,8 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChannelSearchResult {
     /**
      * Channel ID

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Cheermote.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Cheermote.java
@@ -1,10 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -21,8 +17,6 @@ import java.util.stream.Collectors;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Cheermote {
     /**
      * The name of the Cheermote (e.g., "Cheer", "PogChamp", "Kappa")
@@ -77,8 +71,6 @@ public class Cheermote {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Tier {
         /**
          * ID of the emote tier. Possible tiers are: 1, 100, 500, 1000, 5000, 10k, or 100k
@@ -114,8 +106,6 @@ public class Cheermote {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ThemedImages {
         private ImageSet dark;
         private ImageSet light;
@@ -123,8 +113,6 @@ public class Cheermote {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ImageSet {
         @JsonProperty("animated")
         private SizedImages animatedImages;
@@ -135,8 +123,6 @@ public class Cheermote {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SizedImages {
         /**
          * Image at 1.0x

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CheermoteList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CheermoteList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CheermoteList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,8 +16,6 @@ import java.util.Date;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Clip {
 
     /** ID of the clip being queried. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ClipList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ClipList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClipList {
 
     private List<Clip> data;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ClipList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ClipList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,7 +17,6 @@ public class ClipList {
 
     private List<Clip> data;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatus.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatus.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +8,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CodeStatus {
     /**
      * The code to check the status of or to redeem.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatusList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatusList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -13,7 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CodeStatusList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Commercial.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Commercial.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +8,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Commercial {
     /**
      * Length of the triggered commercial

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CommercialList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CommercialList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CommercialList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreateClip.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreateClip.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,8 +12,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateClip {
 
     private String id;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreateClip.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreateClip.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,8 +13,14 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CreateClip {
 
+    /**
+     * ID of the clip that was created.
+     */
     private String id;
 
-    @JsonProperty("edit_url")
+    /**
+     * URL of the edit page for the clip.
+     */
     private String editUrl;
+
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreateClipList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreateClipList.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.util.List;
@@ -13,8 +10,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateClipList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomReward.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomReward.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.Reward;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,8 +25,6 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 @Jacksonized
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CustomReward {
 
@@ -152,8 +147,6 @@ public class CustomReward {
     @NoArgsConstructor
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class MaxPerStreamSetting extends Setting {
         private Integer maxPerStream;
     }
@@ -163,8 +156,6 @@ public class CustomReward {
     @NoArgsConstructor
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class MaxPerUserPerStreamSetting extends Setting {
         private Integer maxPerUserPerStream;
     }
@@ -174,8 +165,6 @@ public class CustomReward {
     @NoArgsConstructor
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class GlobalCooldownSetting extends Setting {
         private Integer globalCooldownSeconds;
     }
@@ -183,8 +172,6 @@ public class CustomReward {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Setting {
         @Accessors(fluent = true)
         @JsonProperty("is_enabled")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomRewardList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomRewardList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -12,7 +11,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomRewardList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomRewardRedemption.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomRewardRedemption.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -15,8 +12,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomRewardRedemption {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomRewardRedemptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomRewardRedemptionList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -12,7 +11,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomRewardRedemptionList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlement.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlement.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,8 +13,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class DropsEntitlement {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
@@ -15,7 +14,6 @@ import java.util.Optional;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class DropsEntitlementList {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/EventSubSubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/EventSubSubscriptionList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.eventsub.EventSubSubscription;
 import lombok.AccessLevel;
@@ -13,7 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSubSubscriptionList {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Extension.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -18,8 +15,6 @@ import java.util.List;
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Extension {
 
     /** ID of the extension. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionActiveList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionActiveList.java
@@ -24,7 +24,6 @@ public class ExtensionActiveList {
     @JsonProperty("data")
     private ActiveExtensions data;
 
-    @JsonProperty("pagination")
     @Deprecated
     private HelixPagination pagination;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionActiveList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionActiveList.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,7 +19,6 @@ import java.util.stream.Collectors;
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionActiveList {
 
     @JsonProperty("data")
@@ -35,7 +33,6 @@ public class ExtensionActiveList {
     @Builder(toBuilder = true)
     @NoArgsConstructor
     @AllArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ActiveExtensions {
 
         /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalytics.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalytics.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 /**
@@ -12,8 +9,6 @@ import lombok.*;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionAnalytics {
 
     /** ID of the extension whose analytics data is being provided. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalyticsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalyticsList.java
@@ -16,7 +16,6 @@ public class ExtensionAnalyticsList {
     @JsonProperty("data")
     private List<ExtensionAnalytics> extensionAnalytics;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalyticsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionAnalyticsList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
@@ -12,8 +9,6 @@ import java.util.List;
  * Extension Analytics List
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionAnalyticsList {
     /**
      * Data

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -15,7 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransaction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransaction.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,8 +9,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionTransaction {
 
     /**
@@ -67,7 +62,6 @@ public class ExtensionTransaction {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ProductData {
 
         /**
@@ -95,7 +89,6 @@ public class ExtensionTransaction {
         @Data
         @Setter(AccessLevel.PRIVATE)
         @NoArgsConstructor
-        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Cost {
 
             /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransactionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ExtensionTransactionList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -12,7 +11,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExtensionTransactionList {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Follow.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Follow.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -20,8 +17,6 @@ import java.time.ZoneOffset;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Follow {
 
     /** ID of the user following the to_id user. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/FollowList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/FollowList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class FollowList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/FollowList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/FollowList.java
@@ -28,7 +28,6 @@ public class FollowList {
      */
     private Integer total;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Game.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Game.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,8 +13,6 @@ import java.util.regex.Pattern;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Game {
 
     /** Game ID. */
@@ -28,7 +23,7 @@ public class Game {
 
     /** Template URL for the game’s box art. */
     private String boxArtUrl;
-    
+
     /**
      * Gets the game's box art url for specific dimensions
      *

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalytics.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalytics.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 /**
@@ -12,8 +9,6 @@ import lombok.*;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GameAnalytics {
 
     /** ID of the extension whose analytics data is being provided. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalyticsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalyticsList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
@@ -12,8 +9,6 @@ import java.util.List;
  * Game Analytics List
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GameAnalyticsList {
     /**
      * Data

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalyticsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameAnalyticsList.java
@@ -16,7 +16,6 @@ public class GameAnalyticsList {
     @JsonProperty("data")
     private List<GameAnalytics> gameAnalytics;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GameList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameList.java
@@ -19,7 +19,6 @@ public class GameList {
     @JsonProperty("data")
     private List<Game> games;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameTopList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameTopList.java
@@ -19,7 +19,6 @@ public class GameTopList {
     @JsonProperty("data")
     private List<Game> games;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameTopList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/GameTopList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GameTopList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HearthstoneMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HearthstoneMetadata.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 /**
@@ -12,8 +9,6 @@ import lombok.*;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HearthstoneMetadata {
 
     /** The Broadcaster */
@@ -30,8 +25,6 @@ public class HearthstoneMetadata {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     static class HearthstonePlayer {
 
         /** Hero Type */
@@ -45,8 +38,6 @@ public class HearthstoneMetadata {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     static class HearthstoneHero {
 
         /** Name of the Hearthstone hero. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HelixPagination.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HelixPagination.java
@@ -1,9 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -15,11 +11,8 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HelixPagination {
 
-    @JsonProperty("cursor")
     private String cursor;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Highlight.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Highlight.java
@@ -1,30 +1,28 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
- * Data for creating Stream Markers. The {@code userId} of the streamer on whose 
+ * Data for creating Stream Markers. The {@code userId} of the streamer on whose
  * stream to create the marker is required; the {@code description} is optional.
  */
 @Data
 public class Highlight {
-    
+
     /**
      * ID of the broadcaster to create a marker for
      */
-    @JsonProperty("user_id")
     private final String userId;
-    
+
     /**
      * Optional description to include with the marker
      */
     private final String description;
-    
+
     public Highlight(String userId) {
         this(userId, "");
     }
-    
+
     public Highlight(String userId, String description) {
         this.userId = userId;
         if(description == null)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,8 +13,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainEvent {
     /**
      * The distinct ID of the event
@@ -50,8 +45,6 @@ public class HypeTrainEvent {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class EventData {
         /**
          * Channel ID of which Hype Train events the clients are interested in
@@ -111,8 +104,6 @@ public class HypeTrainEvent {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Contribution {
         /**
          * Total amount contributed.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEventList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HypeTrainEventList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEventList.java
@@ -21,7 +21,6 @@ public class HypeTrainEventList {
     @JsonProperty("data")
     private List<HypeTrainEvent> events;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/IngestServer.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/IngestServer.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,8 +10,6 @@ import lombok.experimental.Accessors;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class IngestServer {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/IngestServerList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/IngestServerList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,7 +10,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class IngestServerList {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Moderator.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Moderator.java
@@ -1,15 +1,10 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Moderator {
 
     /** ID of the moderator. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEvent.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.time.Instant;
@@ -14,8 +11,6 @@ import java.time.ZoneOffset;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ModeratorEvent {
 
     /**
@@ -62,8 +57,6 @@ public class ModeratorEvent {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ModeratorEventData {
 
         /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEventList.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ModeratorEventList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorEventList.java
@@ -11,7 +11,6 @@ public class ModeratorEventList {
     @JsonProperty("data")
     private List<ModeratorEvent> events;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorList.java
@@ -11,7 +11,6 @@ public class ModeratorList {
     @JsonProperty("data")
     private List<Moderator> moderators;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratorList.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ModeratorList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OverwatchMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OverwatchMetadata.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 /**
@@ -11,8 +8,6 @@ import lombok.*;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class OverwatchMetadata {
 
     /** The Broadcaster */
@@ -25,8 +20,6 @@ public class OverwatchMetadata {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OverwatchPlayer {
 
         /** Hero Type */
@@ -40,8 +33,6 @@ public class OverwatchMetadata {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OverwatchHero {
 
         /** Name of the Overwatch hero. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -1,12 +1,13 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.TimeUtils;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -22,8 +23,6 @@ import java.util.regex.Pattern;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Stream {
 
     /** Stream ID. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamKey.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamKey.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,8 +9,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamKey {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamKeyList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamKeyList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamKeyList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
@@ -12,8 +9,6 @@ import java.util.List;
  * Stream List
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamList {
     /**
      * Data

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamList.java
@@ -16,7 +16,6 @@ public class StreamList {
     @JsonProperty("data")
     private List<Stream> streams;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarker.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarker.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,12 +15,11 @@ import java.util.Map;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamMarker {
-    
+
     private String createdAt, description, id;
     private Long positionSeconds;
-    
+
     @JsonProperty("data")
     private void unpack(List<Map<String, String>> data) {
         if(!data.isEmpty()) {
@@ -32,5 +30,5 @@ public class StreamMarker {
             positionSeconds = Long.parseLong(marker.get("position_seconds"));
         }
     }
-    
+
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkers.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkers.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.util.List;
@@ -15,8 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamMarkers {
 
     /** Stream ID. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkersList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkersList.java
@@ -19,7 +19,6 @@ public class StreamMarkersList {
     @JsonProperty("data")
     private List<StreamMarkers> streamMarkers;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkersList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamMarkersList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.util.List;
@@ -16,8 +13,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamMarkersList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTag.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTag.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.util.Map;
@@ -14,8 +11,6 @@ import java.util.UUID;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamTag {
     /** Tag ID. */
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTagList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTagList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
@@ -12,8 +9,6 @@ import java.util.List;
  * Stream Tags List
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamTagList {
     /**
      * Data

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTagList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTagList.java
@@ -16,7 +16,6 @@ public class StreamTagList {
     @JsonProperty("data")
     private List<StreamTag> streamTags;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Subscription {
 
     /** User ID of the broadcaster. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionEvent.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,8 +11,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SubscriptionEvent {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionEventList.java
@@ -19,7 +19,6 @@ public class SubscriptionEventList {
     /**
      * A cursor value, to be used in a subsequent request to specify the starting point of the next set of results.
      */
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionEventList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionEventList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -12,7 +11,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SubscriptionEventList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
@@ -1,16 +1,11 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SubscriptionList {
     @JsonProperty("data")
     private List<Subscription> subscriptions;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
@@ -10,7 +10,6 @@ public class SubscriptionList {
     @JsonProperty("data")
     private List<Subscription> subscriptions;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UploadEntitlementUrl.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UploadEntitlementUrl.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -11,7 +10,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UploadEntitlementUrl {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UploadEntitlementUrlList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UploadEntitlementUrlList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,7 +15,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UploadEntitlementUrlList {
 
     @NonNull

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/User.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/User.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,8 +13,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class User {
 
     /** User’s ID. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UserList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UserList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UserList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UserList.java
@@ -19,7 +19,6 @@ public class UserList {
     @JsonProperty("data")
     private List<User> users;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,8 +16,6 @@ import java.util.Date;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Video {
 
     /** ID of the video. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoList.java
@@ -19,7 +19,6 @@ public class VideoList {
     @JsonProperty("data")
     private List<Video> videos;
 
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarker.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarker.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.twitch4j.common.util.TimeUtils;
 import lombok.*;
 
@@ -19,8 +16,6 @@ import java.util.Calendar;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoMarker {
 
     /** Stream ID. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarkers.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/VideoMarkers.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.util.List;
@@ -15,8 +12,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoMarkers {
 
     /** Stream ID. */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscription.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscription.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,8 +13,6 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class WebhookSubscription {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscriptionList.java
@@ -30,7 +30,6 @@ public class WebhookSubscriptionList {
      * A cursor value, to be used in a subsequent request to specify the starting point of the next set of results.
      * If this is empty, you are at the last page.
      */
-    @JsonProperty("pagination")
     private HelixPagination pagination;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscriptionList.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,6 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class WebhookSubscriptionList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookNotification.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookNotification.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.helix.webhooks.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.util.Map;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class WebhookNotification {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookNotification.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookNotification.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.webhooks.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +10,6 @@ import java.util.Map;
 @Setter(AccessLevel.PRIVATE)
 public class WebhookNotification {
 
-    @JsonProperty("data")
     private Map<String, Object> data;
 
 }

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/BitsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/BitsServiceTest.java
@@ -24,7 +24,7 @@ public class BitsServiceTest extends AbstractEndpointTest {
     @DisplayName("Fetch the bits leaderboard")
     public void getBitsLeaderboard() {
         // TestCase
-        BitsLeaderboard resultList = testUtils.getTwitchHelixClient().getBitsLeaderboard(testUtils.getCredential().getAccessToken(), "10", "all", null, null).execute();
+        BitsLeaderboard resultList = testUtils.getTwitchHelixClient().getBitsLeaderboard(testUtils.getCredential().getAccessToken(), 10, "all", null, null).execute();
 
         // Test
         assertTrue(resultList.getEntries().size() == 0, "That account can't get bits, so it's always a empty list");

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/ModerationServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/ModerationServiceTest.java
@@ -23,7 +23,7 @@ public class ModerationServiceTest extends AbstractEndpointTest {
     @Test
     @DisplayName("Get Banned Users")
     public void getBannedUsers() {
-        List<BannedUser> results = TestUtils.getTwitchHelixClient().getBannedUsers(TestUtils.getCredential().getAccessToken(), TWITCH_USER_ID, null, null, null)
+        List<BannedUser> results = TestUtils.getTwitchHelixClient().getBannedUsers(TestUtils.getCredential().getAccessToken(), TWITCH_USER_ID, null, null, null, null)
             .execute()
             .getResults();
 

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
@@ -117,9 +117,9 @@ public class UsersServiceTest extends AbstractEndpointTest {
         ExtensionActiveList resultList = testUtils.getTwitchHelixClient().getUserActiveExtensions(testUtils.getCredential().getAccessToken(), twitchUserId).execute();
 
         // Test
-        assertTrue(resultList.getData().getPanels().size() == 3, "Should always get 3 panels!");
-        assertTrue(resultList.getData().getOverlays().size() == 1, "Should always get 1 overlay!");
-        assertTrue(resultList.getData().getComponents().size() == 2, "Should always get 2 components!");
+        assertTrue(resultList.getData().getActivePanels().size() == 3, "Should always get 3 panels!");
+        assertTrue(resultList.getData().getActiveOverlays().size() == 1, "Should always get 1 overlay!");
+        assertTrue(resultList.getData().getActiveComponents().size() == 2, "Should always get 2 components!");
     }
 
     @Test

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/AbstractResultList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/AbstractResultList.java
@@ -1,18 +1,14 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 /**
  * Abstract base for result lists.
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class AbstractResultList {
+
 	/**
 	 * Cursor
 	 */

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlock.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlock.java
@@ -1,13 +1,11 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenBlock {
     private KrakenUser user;
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,7 +12,6 @@ import java.util.List;
 @ToString(callSuper = true)
 @Setter(AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenBlockList extends AbstractResultList {
     private List<KrakenBlock> blocks;
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockTransaction.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenBlockTransaction.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenBlockTransaction {
     @JsonProperty("_id")
     private String id;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenChannel.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenChannel.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenChannel {
     @JsonProperty("_id")
     private String id;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenClip.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenClip.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,8 +8,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenClip {
     private String slug;
     private String trackingId;
@@ -32,8 +27,6 @@ public class KrakenClip {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class SimpleUser {
         private String id;
         private String name;
@@ -44,7 +37,6 @@ public class KrakenClip {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class VideoOnDemand {
         private String id;
         private String url;
@@ -52,7 +44,6 @@ public class KrakenClip {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Thumbnail {
         private String medium;
         private String small;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollection.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollection.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -10,7 +9,6 @@ import java.util.List;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenCollection {
 
     @JsonProperty("_id")

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionItem.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionItem.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class KrakenCollectionItem {
 
     @JsonProperty("_id")

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
 import java.util.List;
@@ -9,7 +8,6 @@ import java.util.List;
 @ToString(callSuper = true)
 @Setter(AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenCollectionList extends AbstractResultList {
     private List<KrakenCollectionMetadata> collections;
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionMetadata.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionMetadata.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,10 +9,7 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class KrakenCollectionMetadata {
-
     @JsonProperty("_id")
     private String id;
     private Instant createdAt;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionThumbnails.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCollectionThumbnails.java
@@ -1,13 +1,11 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenCollectionThumbnails {
     public String large;
     public String medium;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCreatedVideo.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenCreatedVideo.java
@@ -1,13 +1,11 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenCreatedVideo {
 
     /**
@@ -37,7 +35,6 @@ public class KrakenCreatedVideo {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Upload {
         /**
          * The URL where you will upload video parts.

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticon.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticon.java
@@ -1,13 +1,11 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenEmoticon {
     private Integer id;
     private String code;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticonSetList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenEmoticonSetList.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,8 +9,6 @@ import java.util.Set;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenEmoticonSetList {
     private Map<String, Set<KrakenEmoticon>> emoticonSets;
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollow.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollow.java
@@ -1,7 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -11,7 +9,6 @@ import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenFollow {
 
     @JsonProperty("created_at")

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollowList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenFollowList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,7 +12,6 @@ import java.util.List;
 @ToString(callSuper = true)
 @Setter(AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenFollowList extends AbstractResultList {
     private List<KrakenFollow> follows;
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenIngestList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenIngestList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
@@ -9,11 +8,10 @@ import java.util.List;
  * Model representing a list of ingest servers.
  */
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenIngestList {
-	/**
-	 * Data
-	 */
-	private List<KrakenIngest> ingests;
+    /**
+     * Data
+     */
+    private List<KrakenIngest> ingests;
 
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenSubscriptionList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenSubscriptionList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -8,9 +7,8 @@ import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenSubscriptionList extends AbstractResultList {
 
-	private List<KrakenSubscription> subscriptions;
+    private List<KrakenSubscription> subscriptions;
 
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeam.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeam.java
@@ -19,7 +19,6 @@ public class KrakenTeam {
 
     private String name;
 
-    @JsonProperty("display_name")
     private String displayName;
 
     private String info;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamList.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
@@ -9,11 +8,10 @@ import java.util.List;
  * Model representing teams.
  */
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenTeamList {
-	/**
-	 * Data
-	 */
-	private List<KrakenTeam> teams;
+    /**
+     * Data
+     */
+    private List<KrakenTeam> teams;
 
 }

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenTeamUser.java
@@ -17,13 +17,11 @@ public class KrakenTeamUser {
     @JsonProperty("_id")
     private long id;
 
-    @JsonProperty("broadcaster_language")
     private String broadcasterLanguage;
 
     @JsonProperty("created_at")
     private Instant createdAtInstant;
 
-    @JsonProperty("display_name")
     private String displayName;
 
     private long followers;
@@ -40,10 +38,8 @@ public class KrakenTeamUser {
 
     private Boolean partner;
 
-    @JsonProperty("profile_banner")
     private String profileBanner;
 
-    @JsonProperty("profile_banner_background_color")
     private Object profileBannerBackgroundColor;
 
     private String status;
@@ -53,7 +49,6 @@ public class KrakenTeamUser {
 
     private String url;
 
-    @JsonProperty("video_banner")
     private Object videoBanner;
 
     private long views;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
@@ -17,7 +17,6 @@ public class KrakenUser {
 
     private String name;
 
-    @JsonProperty("display_name")
     private String displayName;
 
     private String logo;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUser.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -11,7 +10,6 @@ import java.time.Instant;
 import java.util.Date;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenUser {
 
     @JsonProperty("_id")
@@ -66,7 +64,6 @@ public class KrakenUser {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Notifications {
         private Boolean email;
         private Boolean push;

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUserList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenUserList.java
@@ -1,12 +1,10 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenUserList {
 	/**
 	 * Data

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenVideo.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenVideo.java
@@ -1,9 +1,6 @@
 package com.github.twitch4j.kraken.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -14,8 +11,6 @@ import java.util.Map;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class KrakenVideo {
     @JsonProperty("_id")
     private String id;
@@ -50,7 +45,6 @@ public class KrakenVideo {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Preview {
         private String small;
         private String medium;
@@ -60,7 +54,6 @@ public class KrakenVideo {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Thumbnail {
         private String type;
         private String url;
@@ -68,7 +61,6 @@ public class KrakenVideo {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Thumbnails {
         private List<Thumbnail> small;
         private List<Thumbnail> medium;
@@ -78,8 +70,6 @@ public class KrakenVideo {
 
     @Data
     @Setter(AccessLevel.PRIVATE)
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Channel {
         @JsonProperty("_id")
         private String id;

--- a/rest-kraken/src/test/java/kraken/endpoints/ClipsServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/ClipsServiceTest.java
@@ -2,7 +2,6 @@ package kraken.endpoints;
 
 import com.github.twitch4j.kraken.domain.KrakenClip;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/rest-kraken/src/test/java/kraken/endpoints/TeamServiceTest.java
+++ b/rest-kraken/src/test/java/kraken/endpoints/TeamServiceTest.java
@@ -32,8 +32,8 @@ public class TeamServiceTest extends AbstractKrakenServiceTest {
 
         assertNotNull(team, "Didn't find the specified team!");
         assertNotNull(team.getDisplayName(), "Team did not have a Display Name");
-        assertNotNull(team.getCreatedAt(), "Team did not have a 'Created At' date");
-        assertNotNull(team.getUpdatedAt(), "Team did not have a 'Updated At' date");
+        assertNotNull(team.getCreatedAtInstant(), "Team did not have a 'Created At' date");
+        assertNotNull(team.getUpdatedAtInstant(), "Team did not have a 'Updated At' date");
         assertTrue(team.getUsers().size() > 1, "Should be at least one team member");
     }
 

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Chatters.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Chatters.java
@@ -1,10 +1,7 @@
 package com.github.twitch4j.tmi.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -14,8 +11,6 @@ import java.util.Map;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Chatters {
 
     /** Viewer Count */

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Host.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/Host.java
@@ -1,8 +1,5 @@
 package com.github.twitch4j.tmi.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,8 +8,6 @@ import lombok.Setter;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Host {
 
     private String hostId;

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/HostList.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/domain/HostList.java
@@ -1,9 +1,5 @@
 package com.github.twitch4j.tmi.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,11 +10,8 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class HostList {
-	
-	@JsonProperty("hosts")
-	private List<Host> hosts;
-	
+
+    private List<Host> hosts;
+
 }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove `@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)` (which is deprecated)
* Remove `@JsonIgnoreProperties(ignoreUnknown = true)`
* Remove `@JsonProperty` when not needed
* Replace some deprecated methods in tests with non-deprecated equivalents

### Additional Information 
TypeConvert's [object mapper settings](https://github.com/twitch4j/twitch4j/blob/develop/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java#L21-L22) make these annotations redundant
