### PR TITLE
refactor: remove obsolete EventSubCondition#toMap

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ApplicationEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ApplicationEventSubCondition.java
@@ -10,9 +10,6 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.Collections;
-import java.util.Map;
-
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
@@ -27,10 +24,5 @@ public class ApplicationEventSubCondition extends EventSubCondition {
      * The provided client_id must match the client id in the application access token.
      */
     private String clientId;
-
-    @Override
-    public Map<String, Object> toMap() {
-        return Collections.singletonMap("client_id", this.clientId);
-    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelEventSubCondition.java
@@ -10,9 +10,6 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.Collections;
-import java.util.Map;
-
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
@@ -26,10 +23,5 @@ public class ChannelEventSubCondition extends EventSubCondition {
      * The broadcaster user ID for the channel you want to get notifications for.
      */
     private String broadcasterUserId;
-
-    @Override
-    public Map<String, Object> toMap() {
-        return Collections.singletonMap("broadcaster_user_id", this.broadcasterUserId);
-    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CustomRewardEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CustomRewardEventSubCondition.java
@@ -11,10 +11,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
@@ -29,14 +25,5 @@ public class CustomRewardEventSubCondition extends ChannelEventSubCondition {
      * Specify a reward id to only receive notifications for a specific reward.
      */
     private String rewardId;
-
-    @Override
-    public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("broadcaster_user_id", getBroadcasterUserId());
-        if (rewardId != null)
-            map.put("reward_id", this.rewardId);
-        return Collections.unmodifiableMap(map);
-    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/EventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/EventSubCondition.java
@@ -2,11 +2,5 @@ package com.github.twitch4j.eventsub.condition;
 
 import lombok.experimental.SuperBuilder;
 
-import java.util.Map;
-
 @SuperBuilder
-public abstract class EventSubCondition {
-
-    public abstract Map<String, Object> toMap();
-
-}
+public abstract class EventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/UserEventSubCondition.java
@@ -10,9 +10,6 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.Collections;
-import java.util.Map;
-
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
@@ -26,10 +23,5 @@ public class UserEventSubCondition extends EventSubCondition {
      * The user ID for the user you want notifications for.
      */
     private String userId;
-
-    @Override
-    public Map<String, Object> toMap() {
-        return Collections.singletonMap("user_id", this.userId);
-    }
 
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/util/EventSubConditionConverterTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/util/EventSubConditionConverterTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @Tag("unittest")
@@ -27,7 +30,7 @@ public class EventSubConditionConverterTest {
     public void convertAppCondition() {
         UserAuthorizationRevokeType type = SubscriptionTypes.USER_AUTHORIZATION_REVOKE;
         UserAuthorizationRevokeCondition condition = type.getConditionBuilder().clientId(CryptoUtils.generateNonce(30)).build();
-        test(type, condition);
+        test(type, condition, Collections.singletonMap("client_id", condition.getClientId()));
     }
 
     @Test
@@ -35,7 +38,7 @@ public class EventSubConditionConverterTest {
     public void convertChannelCondition() {
         ChannelBanType type = SubscriptionTypes.CHANNEL_BAN;
         ChannelBanCondition condition = type.getConditionBuilder().broadcasterUserId("42069").build();
-        test(type, condition);
+        test(type, condition, Collections.singletonMap("broadcaster_user_id", condition.getBroadcasterUserId()));
     }
 
     @Test
@@ -46,7 +49,10 @@ public class EventSubConditionConverterTest {
             .broadcasterUserId("42069")
             .rewardId(UUID.randomUUID().toString())
             .build();
-        test(type, condition);
+        Map<String, Object> map = new HashMap<>();
+        map.put("broadcaster_user_id", condition.getBroadcasterUserId());
+        map.put("reward_id", condition.getRewardId());
+        test(type, condition, map);
     }
 
     @Test
@@ -54,11 +60,11 @@ public class EventSubConditionConverterTest {
     public void convertUserCondition() {
         UserUpdateType type = SubscriptionTypes.USER_UPDATE;
         UserUpdateCondition condition = type.getConditionBuilder().userId("1337").build();
-        test(type, condition);
+        test(type, condition, Collections.singletonMap("user_id", condition.getUserId()));
     }
 
-    private static void test(SubscriptionType<?, ?, ?> type, EventSubCondition condition) {
-        Assertions.assertEquals(condition, EventSubConditionConverter.getCondition(type, condition.toMap()));
+    private static void test(SubscriptionType<?, ?, ?> type, EventSubCondition condition, Map<String, Object> map) {
+        Assertions.assertEquals(condition, EventSubConditionConverter.getCondition(type, map));
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove `EventSubCondition#toMap`

### Additional Information 
After changing helix to depend on eventsub-common, `EventSubCondition#toMap` was no longer needed.
