### PR TITLE
refactor: set default kraken headers (accept, content-type) using interceptor

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/config/Twitch4JGlobal.java
+++ b/common/src/main/java/com/github/twitch4j/common/config/Twitch4JGlobal.java
@@ -15,6 +15,6 @@ public class Twitch4JGlobal {
     /**
      * Default UserAgent
      */
-    public static String userAgent = "Twitch4J/1.0.0";
+    public static String userAgent = "Twitch4J/1.2.0";
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/feign/interceptor/JsonContentTypeHeaderInterceptor.java
+++ b/common/src/main/java/com/github/twitch4j/common/feign/interceptor/JsonContentTypeHeaderInterceptor.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.common.feign.interceptor;
+
+import feign.Request;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Injects the content-type application/json into all PUT,PATCH,POST requests that didn't specify a content-type
+ */
+public class JsonContentTypeHeaderInterceptor implements RequestInterceptor {
+
+    /**
+     * Holds all http methods that transmit a body (to set the content-type)
+     */
+    private static final Set<String> methodsWithBody = Stream.of(Request.HttpMethod.POST.name(), Request.HttpMethod.PATCH.name(), Request.HttpMethod.PUT.name()).collect(Collectors.toSet());
+
+    /**
+     * Interceptor
+     *
+     * @param t Feign RequestTemplate
+     */
+    @Override
+    public void apply(RequestTemplate t) {
+        // set content-type if not specified in the TwitchKraken interface for POST, PATCH, PUT requests
+        if (!t.headers().containsKey("Content-Type") && !t.headers().containsKey("content-type") && methodsWithBody.contains(t.method())) {
+            t.header("Content-Type", "application/json");
+        }
+    }
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -45,7 +45,6 @@ public interface TwitchKraken {
     @RequestLine("GET /channels/{channelId}/editors")
     @Headers({
         "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
     })
     HystrixCommand<KrakenUserList> getChannelEditors(
         @Param("token") String authToken,
@@ -65,9 +64,6 @@ public interface TwitchKraken {
      * @return {@link KrakenFollowList}
      */
     @RequestLine("GET /channels/{channelId}/follows?limit={limit}&offset={offset}&cursor={cursor}&direction={direction}")
-    @Headers({
-        "Accept: application/vnd.twitchtv.v5+json"
-    })
     HystrixCommand<KrakenFollowList> getChannelFollowers(
         @Param("channelId") String channelId,
         @Param("limit") Integer limit,
@@ -87,8 +83,7 @@ public interface TwitchKraken {
      */
     @RequestLine("DELETE /channels/{channelId}/stream_key")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenChannel> resetChannelStreamKey(
         @Param("token") String authToken,
@@ -109,8 +104,7 @@ public interface TwitchKraken {
      */
     @RequestLine("GET /channels/{channelId}/subscriptions?limit={limit}&offset={offset}&direction={direction}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenSubscriptionList> getChannelSubscribers(
         @Param("token") String authToken,
@@ -132,9 +126,7 @@ public interface TwitchKraken {
     @Unofficial
     @RequestLine("POST /chat/twitchbot/approve")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
+        "Authorization: OAuth {token}"
     })
     @Body("%7B\"msg_id\":\"{msg_id}\"%7D")
     HystrixCommand<Void> approveAutomodMessage(
@@ -154,9 +146,7 @@ public interface TwitchKraken {
     @Unofficial
     @RequestLine("POST /chat/twitchbot/deny")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
+        "Authorization: OAuth {token}"
     })
     @Body("%7B\"msg_id\":\"{msg_id}\"%7D")
     HystrixCommand<Void> denyAutomodMessage(
@@ -173,9 +163,6 @@ public interface TwitchKraken {
      * @return {@link KrakenClip}
      */
     @RequestLine("GET /clips/{slug}")
-    @Headers({
-        "Accept: application/vnd.twitchtv.v5+json"
-    })
     HystrixCommand<KrakenClip> getClip(
         @Param("slug") String slug
     );
@@ -189,9 +176,6 @@ public interface TwitchKraken {
      * @return {@link KrakenCollectionMetadata}
      */
     @RequestLine("GET /collections/{collection_id}")
-    @Headers({
-        "Accept: application/vnd.twitchtv.v5+json"
-    })
     HystrixCommand<KrakenCollectionMetadata> getCollectionMetadata(
         @Param("collection_id") String collectionId
     );
@@ -205,9 +189,6 @@ public interface TwitchKraken {
      * @return {@link KrakenCollection}
      */
     @RequestLine("GET /collections/{collection_id}/items")
-    @Headers({
-        "Accept: application/vnd.twitchtv.v5+json"
-    })
     HystrixCommand<KrakenCollection> getCollection(
         @Param("collection_id") String collectionId
     );
@@ -224,9 +205,6 @@ public interface TwitchKraken {
      * @return {@link KrakenCollectionList}
      */
     @RequestLine("GET /channels/{channel_id}/collections?limit={limit}&cursor={cursor}&containing_item={containing_item}")
-    @Headers({
-        "Accept: application/vnd.twitchtv.v5+json"
-    })
     HystrixCommand<KrakenCollectionList> getCollectionsByChannel(
         @Param("channel_id") String channelId,
         @Param("limit") Integer limit,
@@ -246,9 +224,7 @@ public interface TwitchKraken {
      */
     @RequestLine("POST /channels/{channel_id}/collections")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
+        "Authorization: OAuth {token}"
     })
     @Body("%7B\"title\":\"{title}\"%7D")
     HystrixCommand<KrakenCollectionMetadata> createCollection(
@@ -269,9 +245,7 @@ public interface TwitchKraken {
      */
     @RequestLine("PUT /collections/{collection_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
+        "Authorization: OAuth {token}"
     })
     @Body("%7B\"title\":\"{title}\"%7D")
     HystrixCommand<Void> updateCollection(
@@ -293,8 +267,6 @@ public interface TwitchKraken {
     @RequestLine("PUT /collections/{collection_id}/thumbnail")
     @Headers({
         "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
     })
     @Body("%7B\"item_id\":\"{item_id}\"%7D")
     HystrixCommand<Void> createCollectionThumbnail(
@@ -314,8 +286,7 @@ public interface TwitchKraken {
      */
     @RequestLine("DELETE /collections/{collection_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<Void> deleteCollection(
         @Param("token") String token,
@@ -335,8 +306,6 @@ public interface TwitchKraken {
     @RequestLine("POST /collections/{collection_id}/items")
     @Headers({
         "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
     })
     @Body("%7B\"id\":\"{id}\",\"type\":\"video\"%7D")
     HystrixCommand<KrakenCollectionItem> addItemToCollection(
@@ -357,8 +326,7 @@ public interface TwitchKraken {
      */
     @RequestLine("DELETE /collections/{collection_id}/items/{collection_item_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<Void> deleteItemFromCollection(
         @Param("token") String token,
@@ -379,9 +347,7 @@ public interface TwitchKraken {
      */
     @RequestLine("PUT /collections/{collection_id}/items/{collection_item_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
-        "Content-Type: application/json"
+        "Authorization: OAuth {token}"
     })
     @Body("%7B\"position\":\"{position}\"%7D")
     HystrixCommand<Void> moveItemWithinCollection(
@@ -404,8 +370,7 @@ public interface TwitchKraken {
      */
     @RequestLine("GET /users/{user}/blocks?limit={limit}&offset={offset}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenBlockList> getUserBlockList(
         @Param("token") String authToken,
@@ -426,8 +391,7 @@ public interface TwitchKraken {
      */
     @RequestLine("PUT /users/{from_id}/blocks/{to_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenBlockTransaction> blockUser(
         @Param("token") String authToken,
@@ -447,8 +411,7 @@ public interface TwitchKraken {
      */
     @RequestLine("DELETE /users/{from_id}/blocks/{to_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<Void> unblockUser(
         @Param("token") String authToken,
@@ -468,8 +431,7 @@ public interface TwitchKraken {
      */
     @RequestLine("GET /users/{user}/emotes")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenEmoticonSetList> getUserEmotes(
         @Param("token") String authToken,
@@ -490,8 +452,7 @@ public interface TwitchKraken {
     @Deprecated
     @RequestLine("PUT /users/{user}/follows/channels/{targetUser}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<Object> addFollow(
         @Param("token") String authToken,
@@ -507,7 +468,6 @@ public interface TwitchKraken {
      * @return KrakenIngestList
      */
     @RequestLine("GET /ingests")
-    @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenIngestList> getIngestServers();
 
     /**
@@ -517,7 +477,6 @@ public interface TwitchKraken {
      * @return KrakenTeamList
      */
     @RequestLine("GET /channels/{channel_id}/teams")
-    @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenTeamList> getChannelTeams(
         @Param("channel_id") String channelId
     );
@@ -532,7 +491,6 @@ public interface TwitchKraken {
      * @return KrakenTeamList
      */
     @RequestLine("GET /teams?limit={limit}&offset={offset}")
-    @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenTeamList> getAllTeams(
         @Param("limit") Integer limit,
         @Param("offset") Integer offset
@@ -547,7 +505,6 @@ public interface TwitchKraken {
      * @return KrakenTeam
      */
     @RequestLine("GET /teams/{name}")
-    @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenTeam> getTeamByName(
         @Param("name") String name
     );
@@ -562,8 +519,7 @@ public interface TwitchKraken {
      */
     @RequestLine("GET /user")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenUser> getUser(
         @Param("token") String authToken
@@ -576,7 +532,6 @@ public interface TwitchKraken {
      * @return KrakenUser
      */
     @RequestLine("GET /users/{user_id}")
-    @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<KrakenUser> getUserById(
         @Param("user_id") String userId
     );
@@ -590,9 +545,6 @@ public interface TwitchKraken {
      * @return KrakenUser
      */
     @RequestLine(value = "GET /users?login={logins}", collectionFormat = CollectionFormat.CSV)
-    @Headers({
-        "Accept: application/vnd.twitchtv.v5+json"
-    })
     HystrixCommand<KrakenUserList> getUsersByLogin(
     	@Param("logins") List<String> logins
     );
@@ -610,8 +562,7 @@ public interface TwitchKraken {
      */
     @Deprecated
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json",
+        "Authorization: OAuth {token}"
     })
     @RequestLine("PUT /channels/{channelId}?channel[status]={title}")
     HystrixCommand<Object> updateTitle(
@@ -651,8 +602,7 @@ public interface TwitchKraken {
         collectionFormat = CollectionFormat.CSV
     )
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenCreatedVideo> createVideo(
         @Param("token") String authToken,
@@ -668,7 +618,6 @@ public interface TwitchKraken {
 
     @RequestLine("PUT /upload/{video_id}?part={part}&upload_token={upload_token}")
     @Headers({
-        "Accept: application/vnd.twitchtv.v5+json",
         "Content-Type: application/x-www-form-urlencoded"
     })
     HystrixCommand<Void> uploadVideoPart(
@@ -695,7 +644,6 @@ public interface TwitchKraken {
     }
 
     @RequestLine("POST /upload/{video_id}/complete?upload_token={upload_token}")
-    @Headers("Accept: application/vnd.twitchtv.v5+json")
     HystrixCommand<Void> completeVideoUpload(
         URI baseUrl,
         @Param("video_id") String videoId,
@@ -734,8 +682,7 @@ public interface TwitchKraken {
         collectionFormat = CollectionFormat.CSV
     )
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<KrakenVideo> updateVideo(
         @Param("token") String authToken,
@@ -758,8 +705,7 @@ public interface TwitchKraken {
      */
     @RequestLine("DELETE /videos/{video_id}")
     @Headers({
-        "Authorization: OAuth {token}",
-        "Accept: application/vnd.twitchtv.v5+json"
+        "Authorization: OAuth {token}"
     })
     HystrixCommand<Void> deleteVideo(
         @Param("token") String authToken,


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* adds a interceptor for kraken api requests that:
* - sets the accept header `application/vnd.twitchtv.v5+json` for all requests
* - sets the content-type header for PUT,PATCH,POST requests if not set in the TwitchKraken interface
* bumps the t4j user-agent to Twitch4j/1.2.0 (next release version)

### Additional Information 
