### PR TITLE
feat: include challenge in EventSubNotification

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubNotification.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubNotification.java
@@ -24,4 +24,9 @@ public class EventSubNotification {
      */
     private EventSubEvent event;
 
+    /**
+     * The value of challenge from the callback verification request must be returned to complete the verification process.
+     */
+    private String challenge;
+
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/util/NotificationDeserializer.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/util/NotificationDeserializer.java
@@ -25,7 +25,8 @@ public class NotificationDeserializer extends JsonDeserializer<EventSubNotificat
         final SubscriptionType<?, ?, ?> type = sub.getType();
         final EventSubEvent event = type != null ? getObject(p.getCodec(), root, "event", type.getEventClass()) : null;
 
-        return new EventSubNotification(sub, event);
+        final String challenge = root.path("challenge").asText(null);
+        return new EventSubNotification(sub, event, challenge);
     }
 
     private static <T> T getObject(ObjectCodec codec, JsonNode parent, String field, Class<T> clazz) {

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/EventSubNotificationTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/EventSubNotificationTest.java
@@ -4,6 +4,7 @@ import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.eventsub.condition.ChannelFollowCondition;
 import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
 import com.github.twitch4j.eventsub.subscriptions.SubscriptionTypes;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class EventSubNotificationTest {
 
     @Test
+    @DisplayName("Deserialize Challenge")
+    public void deserializeChallenge() {
+        String json = "{\"subscription\":{\"id\":\"b9ee086b-4ff1-4f11-8be8-9c93e3cd9515\",\"status\":\"webhook_callback_verification_pending\",\"type\":\"channel.follow\",\"version\":\"1\",\"condition\":{\"broadcaster_user_id\":\"207813352\"}," +
+            "\"transport\":{\"method\":\"webhook\",\"callback\":\"https://twitch4j.ngrok.io\"},\"created_at\":\"2021-01-20T19:41:07.513199878Z\"},\"challenge\":\"sample-challenge\"}";
+
+        EventSubNotification notif = TypeConvert.jsonToObject(json, EventSubNotification.class);
+        assertEquals("sample-challenge", notif.getChallenge());
+    }
+
+    @Test
+    @DisplayName("Deserialize Follow Notification")
     public void deserializeFollowNotification() {
         EventSubNotification notif = TypeConvert.jsonToObject(
             "{\"subscription\":{\"id\":\"f1c2a387-161a-49f9-a165-0f21d7a4e1c4\",\"status\":\"authorization_revoked\",\"type\":\"channel.follow\",\"version\":\"1\",\"condition\":{\"broadcaster_user_id\":\"12826\"},\"transport\":{\"method\":\"webhook\"," +

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -144,6 +144,8 @@ public interface TwitchHelix {
 
     /**
      * Creates a Custom Reward on a channel.
+     * <p>
+     * Query parameter broadcaster_id must match the user_id in the User-Access token.
      *
      * @param authToken     User access token for the broadcaster (scope: channel:manage:redemptions).
      * @param broadcasterId The id of the target channel, which must match the token user id.
@@ -164,7 +166,7 @@ public interface TwitchHelix {
     /**
      * Deletes a Custom Reward on a channel.
      * <p>
-     * Only rewards created manually by a broadcaster in the Creator Dashboard or created programmatically by the same client_id can be deleted.
+     * Only rewards created programmatically by the same client_id can be deleted.
      * Any UNFULFILLED Custom Reward Redemptions of the deleted Custom Reward will be updated to the FULFILLED status.
      *
      * @param authToken     User access token for the broadcaster (scope: channel:manage:redemptions).
@@ -183,7 +185,7 @@ public interface TwitchHelix {
     /**
      * Returns a list of Custom Reward objects for the Custom Rewards on a channel.
      * <p>
-     * Developers only have access to update and delete rewards that were created manually by a broadcaster in the Creator Dashboard or created programmatically by the same/calling client_id.
+     * Developers only have access to update and delete rewards that were created programmatically by the same/calling client_id.
      * <p>
      * There is a limit of 50 Custom Rewards on a channel at a time. This includes both enabled and disabled Custom Rewards.
      *
@@ -205,7 +207,7 @@ public interface TwitchHelix {
     /**
      * Returns Custom Reward Redemption objects for a Custom Reward on a channel that was created by the same client_id.
      * <p>
-     * Developers only have access to get and update redemptions for the rewards created manually by a broadcaster in the Creator Dashboard or created programmatically by the same client_id.
+     * Developers only have access to get and update redemptions for the rewards created programmatically by the same client_id.
      *
      * @param authToken     User access token for the broadcaster (scope: channel:manage:redemptions).
      * @param broadcasterId The id of the target channel, which must match the token user id.
@@ -233,7 +235,7 @@ public interface TwitchHelix {
     /**
      * Updates a Custom Reward created on a channel.
      * <p>
-     * Only rewards created manually by a broadcaster in the Creator Dashboard or created programmatically by the same client_id can be updated.
+     * Only rewards created programmatically by the same client_id can be updated.
      *
      * @param authToken     User access token for the broadcaster (scope: channel:manage:redemptions).
      * @param broadcasterId The id of the target channel, which must match the token user id.
@@ -256,7 +258,7 @@ public interface TwitchHelix {
     /**
      * Updates the status of Custom Reward Redemption objects on a channel that are in the UNFULFILLED status.
      * <p>
-     * Only redemptions for a reward created manually by a broadcaster in the Creator Dashboard, or created programmatically by the same client_id as attached to the access token can be updated.
+     * Only redemptions for a reward created programmatically by the same client_id as attached to the access token can be updated.
      *
      * @param authToken     User access token for the broadcaster (scope: channel:manage:redemptions).
      * @param broadcasterId The id of the target channel, which must match the token user id.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Include `challenge` field in `EventSubNotification`
* Remove twitch documentation error regarding api access to manually created rewards
