### PR TITLE
fix: properly deserialize video playback type

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -44,7 +45,7 @@ public class VideoPlaybackData {
             return this.type;
         }
 
-        @Deprecated
+        @JsonCreator
         public static Type fromString(String type) {
             for (Type t : Type.values()) {
                 if (t.type.equalsIgnoreCase(type))


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* `VideoPlaybackData.Type` *does* need the custom `@JsonCreator`
