### PR TITLE
feat: update eventsub with february changes

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscription.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscription.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.With;
 
 import java.time.Instant;
 import java.util.Map;
@@ -57,6 +58,7 @@ public class EventSubSubscription {
     /**
      * Object indicating the notification delivery specific information
      */
+    @With
     private EventSubTransport transport;
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelBanEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelBanEvent.java
@@ -1,8 +1,40 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
 
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelBanEvent extends EventSubUserChannelEvent {}
+public class ChannelBanEvent extends EventSubModerationEvent {
+
+    /**
+     * The reason behind the ban.
+     */
+    private String reason;
+
+    /**
+     * Will be null if permanent ban. If it is a timeout, this field shows when the timeout will end.
+     */
+    @Nullable
+    private Instant endsAt;
+
+    /**
+     * Indicates whether the ban is permanent (true) or a timeout (false). If true, {@link #getEndsAt()} will be null.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_permanent")
+    private Boolean isPermanent;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUnbanEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUnbanEvent.java
@@ -5,4 +5,4 @@ import lombok.ToString;
 
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelUnbanEvent extends EventSubUserChannelEvent {}
+public class ChannelUnbanEvent extends EventSubModerationEvent {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubModerationEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubModerationEvent.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public abstract class EventSubModerationEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The user ID of the issuer of the moderation action.
+     */
+    private String moderatorUserId;
+
+    /**
+     * The user login of the issuer of the moderation action.
+     */
+    private String moderatorUserLogin;
+
+    /**
+     * The user name of the issuer of the moderation action.
+     */
+    private String moderatorUserName;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardAddType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardAddType.java
@@ -6,7 +6,7 @@ import com.github.twitch4j.eventsub.events.CustomRewardAddEvent;
 /**
  * A custom channel points reward has been created for the specified channel.
  * <p>
- * Must have channel:read:redemptions scope.
+ * Must have channel:read:redemptions or channel:manage:redemptions scope.
  */
 public class ChannelPointsCustomRewardAddType implements SubscriptionType<ChannelPointsCustomRewardAddCondition,
     ChannelPointsCustomRewardAddCondition.ChannelPointsCustomRewardAddConditionBuilder<?, ?>, CustomRewardAddEvent> {

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardRedemptionAddType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardRedemptionAddType.java
@@ -6,7 +6,7 @@ import com.github.twitch4j.eventsub.events.CustomRewardRedemptionAddEvent;
 /**
  * A viewer has redeemed a custom channel points reward on the specified channel.
  * <p>
- * Must have channel:read:redemptions scope.
+ * Must have channel:read:redemptions or channel:manage:redemptions scope.
  */
 public class ChannelPointsCustomRewardRedemptionAddType implements SubscriptionType<ChannelPointsCustomRewardRedemptionAddCondition,
     ChannelPointsCustomRewardRedemptionAddCondition.ChannelPointsCustomRewardRedemptionAddConditionBuilder<?, ?>, CustomRewardRedemptionAddEvent> {

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardRedemptionUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardRedemptionUpdateType.java
@@ -6,7 +6,7 @@ import com.github.twitch4j.eventsub.events.CustomRewardRedemptionUpdateEvent;
 /**
  * A redemption of a channel points custom reward has been updated for the specified channel.
  * <p>
- * Must have channel:read:redemptions scope.
+ * Must have channel:read:redemptions or channel:manage:redemptions scope.
  */
 public class ChannelPointsCustomRewardRedemptionUpdateType implements SubscriptionType<ChannelPointsCustomRewardRedemptionUpdateCondition,
     ChannelPointsCustomRewardRedemptionUpdateCondition.ChannelPointsCustomRewardRedemptionUpdateConditionBuilder<?, ?>, CustomRewardRedemptionUpdateEvent> {

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardRemoveType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardRemoveType.java
@@ -6,7 +6,7 @@ import com.github.twitch4j.eventsub.events.CustomRewardRemoveEvent;
 /**
  * A custom channel points reward has been removed from the specified channel.
  * <p>
- * Must have channel:read:redemptions scope.
+ * Must have channel:read:redemptions or channel:manage:redemptions scope.
  */
 public class ChannelPointsCustomRewardRemoveType implements SubscriptionType<ChannelPointsCustomRewardRemoveCondition,
     ChannelPointsCustomRewardRemoveCondition.ChannelPointsCustomRewardRemoveConditionBuilder<?, ?>, CustomRewardRemoveEvent> {

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsCustomRewardUpdateType.java
@@ -6,7 +6,7 @@ import com.github.twitch4j.eventsub.events.CustomRewardUpdateEvent;
 /**
  * A custom channel points reward has been updated for the specified channel.
  * <p>
- * Must have channel:read:redemptions scope.
+ * Must have channel:read:redemptions or channel:manage:redemptions scope.
  */
 public class ChannelPointsCustomRewardUpdateType implements SubscriptionType<ChannelPointsCustomRewardUpdateCondition,
     ChannelPointsCustomRewardUpdateCondition.ChannelPointsCustomRewardUpdateConditionBuilder<?, ?>, CustomRewardUpdateEvent> {

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/util/EventSubVerifier.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/util/EventSubVerifier.java
@@ -41,19 +41,19 @@ public class EventSubVerifier {
     /**
      * Java algorithm name that corresponds to {@link #SIGNATURE_HASH_PREFIX}
      */
-    private final String JAVA_HASH_ALGORITHM = "HmacSHA256";
+    public final String JAVA_HMAC_ALGORITHM = "HmacSHA256";
 
     /**
-     * The number of characters in hashes produced by {@link #JAVA_HASH_ALGORITHM}
+     * The number of characters in hashes produced by {@link #JAVA_HMAC_ALGORITHM}
      */
     private final int HASH_LENGTH = 256 / 4;
 
     /**
-     * A thread-local {@link Mac} instance of {@link #JAVA_HASH_ALGORITHM}
+     * A thread-local {@link Mac} instance of {@link #JAVA_HMAC_ALGORITHM}
      */
-    private final ThreadLocal<Mac> HASH_FUNCTION = ThreadLocal.withInitial(() -> {
+    private final ThreadLocal<Mac> HMAC_FUNCTION = ThreadLocal.withInitial(() -> {
         try {
-            return Mac.getInstance(JAVA_HASH_ALGORITHM);
+            return Mac.getInstance(JAVA_HMAC_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             return null;
         }
@@ -105,7 +105,7 @@ public class EventSubVerifier {
             return false;
         }
 
-        final Mac mac = HASH_FUNCTION.get();
+        final Mac mac = HMAC_FUNCTION.get();
         if (mac == null) {
             log.error("Unable to prepare hash function for eventsub signature verification!");
             return false;
@@ -134,7 +134,7 @@ public class EventSubVerifier {
      * @see #verifySignature(SecretKeySpec, String, String, byte[], String)
      */
     public boolean verifySignature(byte[] secret, String messageId, String messageTimestamp, byte[] requestBody, String expectedSignature) {
-        return verifySignature(new SecretKeySpec(secret, JAVA_HASH_ALGORITHM), messageId, messageTimestamp, requestBody, expectedSignature);
+        return verifySignature(new SecretKeySpec(secret, JAVA_HMAC_ALGORITHM), messageId, messageTimestamp, requestBody, expectedSignature);
     }
 
     /**

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -12,24 +12,67 @@ import java.time.Instant;
 
 import static com.github.twitch4j.common.util.TypeConvert.jsonToObject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("unittest")
 public class EventSubEventTest {
 
     @Test
-    @DisplayName("Deserialize ChannelBanEvent")
-    public void deserializeSimpleUserChannelEvent() {
+    @DisplayName("Deserialize ChannelBanEvent: Timeout")
+    public void deserializeModerationEvent() {
         ChannelBanEvent event = jsonToObject(
-            "{\"user_id\":\"1234\",\"user_name\":\"cool_user\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_name\":\"cooler_user\"}",
+            "{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\",\"moderator_user_id\":\"1339\"," +
+                "\"moderator_user_login\":\"mod_user\",\"moderator_user_name\":\"Mod_User\",\"reason\":\"Offensive language\",\"ends_at\":\"2020-07-15T18:16:11.17106713Z\",\"is_permanent\":false}",
             ChannelBanEvent.class
         );
 
         assertEquals("1234", event.getUserId());
-        assertEquals("cool_user", event.getUserName());
+        assertEquals("cool_user", event.getUserLogin());
+        assertEquals("Cool_User", event.getUserName());
+
         assertEquals("1337", event.getBroadcasterUserId());
-        assertEquals("cooler_user", event.getBroadcasterUserName());
+        assertEquals("cooler_user", event.getBroadcasterUserLogin());
+        assertEquals("Cooler_User", event.getBroadcasterUserName());
+
+        assertEquals("1339", event.getModeratorUserId());
+        assertEquals("mod_user", event.getModeratorUserLogin());
+        assertEquals("Mod_User", event.getModeratorUserName());
+
+        assertEquals("Offensive language", event.getReason());
+        assertEquals(Instant.parse("2020-07-15T18:16:11.17106713Z"), event.getEndsAt());
+        assertFalse(event.isPermanent());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelBanEvent: Ban")
+    public void deserializeModerationEvent2() {
+        ChannelBanEvent event = jsonToObject(
+            "{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\",\"moderator_user_id\":\"1339\"," +
+                "\"moderator_user_login\":\"mod_user\",\"moderator_user_name\":\"Mod_User\",\"reason\":\"Offensive language\",\"ends_at\":null,\"is_permanent\":true}",
+            ChannelBanEvent.class
+        );
+
+        assertTrue(event.isPermanent());
+        assertNull(event.getEndsAt());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelFollowEvent")
+    public void deserializeSimpleUserChannelEvent() {
+        ChannelFollowEvent event = jsonToObject(
+            "{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\"}",
+            ChannelFollowEvent.class
+        );
+
+        assertEquals("1234", event.getUserId());
+        assertEquals("cool_user", event.getUserLogin());
+        assertEquals("Cool_User", event.getUserName());
+        assertEquals("1337", event.getBroadcasterUserId());
+        assertEquals("cooler_user", event.getBroadcasterUserLogin());
+        assertEquals("Cooler_User", event.getBroadcasterUserName());
     }
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* EventSub Channel Ban v1 now includes moderator information, reason for ban, and timeout duration if the ban was a timeout.
* EventSub Channel Unban v1 now includes moderator information.
* In EventSub, the authorization scopes allowed for all Channel Point subscription types have been updated to accept channel:read:redemptions or channel:manage:redemptions.

### Additional Information 
https://dev.twitch.tv/docs/change-log