### PR TITLE
feat: include timestamp in eventsub follow event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
 			api group: 'com.github.philippheuer.events4j', name: 'events4j-handler-spring', version: '0.9.5'
 
 			// Credential Manager
-			api group: 'com.github.philippheuer.credentialmanager', name: 'credentialmanager', version: '0.1.1'
+			api group: 'com.github.philippheuer.credentialmanager', name: 'credentialmanager', version: '0.1.2'
 
 			// HTTP Client
 			api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.1'

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelFollowEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelFollowEvent.java
@@ -1,8 +1,24 @@
 package com.github.twitch4j.eventsub.events;
 
+import lombok.AccessLevel;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelFollowEvent extends EventSubUserChannelEvent {}
+public class ChannelFollowEvent extends EventSubUserChannelEvent {
+
+    /**
+     * RFC3339 timestamp of when the follow occurred.
+     */
+    private Instant followedAt;
+
+}

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/EventSubNotificationTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/EventSubNotificationTest.java
@@ -31,27 +31,31 @@ public class EventSubNotificationTest {
     @DisplayName("Deserialize Follow Notification")
     public void deserializeFollowNotification() {
         EventSubNotification notif = TypeConvert.jsonToObject(
-            "{\"subscription\":{\"id\":\"f1c2a387-161a-49f9-a165-0f21d7a4e1c4\",\"status\":\"authorization_revoked\",\"type\":\"channel.follow\",\"version\":\"1\",\"condition\":{\"broadcaster_user_id\":\"12826\"},\"transport\":{\"method\":\"webhook\"," +
-                "\"callback\":\"https://example.com/webhooks/callback\"},\"created_at\":\"2019-11-16T10:11:12.123Z\"},\"event\":{\"user_id\":\"1337\",\"user_name\":\"awesome_user\",\"broadcaster_user_id\":\"12826\",\"broadcaster_user_name\":\"twitch\"}}",
+            "{\"subscription\":{\"id\":\"f1c2a387-161a-49f9-a165-0f21d7a4e1c4\",\"type\":\"channel.follow\",\"version\":\"1\",\"status\":\"enabled\",\"condition\":{\"broadcaster_user_id\":\"1337\"},\"transport\":{\"method\":\"webhook\"," +
+                "\"callback\":\"https://example.com/webhooks/callback\"},\"created_at\":\"2019-11-16T10:11:12.123Z\"},\"event\":{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\"," +
+                "\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\",\"followed_at\":\"2020-07-15T18:16:11.17106713Z\"}}",
             EventSubNotification.class
         );
 
         assertNotNull(notif);
         assertNotNull(notif.getSubscription());
         assertEquals("f1c2a387-161a-49f9-a165-0f21d7a4e1c4", notif.getSubscription().getId());
-        assertEquals(EventSubSubscriptionStatus.AUTHORIZATION_REVOKED, notif.getSubscription().getStatus());
+        assertEquals(EventSubSubscriptionStatus.ENABLED, notif.getSubscription().getStatus());
         assertEquals(SubscriptionTypes.CHANNEL_FOLLOW, notif.getSubscription().getType());
-        assertEquals(ChannelFollowCondition.builder().broadcasterUserId("12826").build(), notif.getSubscription().getCondition());
+        assertEquals(ChannelFollowCondition.builder().broadcasterUserId("1337").build(), notif.getSubscription().getCondition());
         assertNotNull(notif.getSubscription().getTransport());
         assertEquals(EventSubTransportMethod.WEBHOOK, notif.getSubscription().getTransport().getMethod());
         assertEquals("https://example.com/webhooks/callback", notif.getSubscription().getTransport().getCallback());
         assertEquals(Instant.parse("2019-11-16T10:11:12.123Z"), notif.getSubscription().getCreatedAt());
         assertTrue(notif.getEvent() instanceof ChannelFollowEvent);
         ChannelFollowEvent event = (ChannelFollowEvent) notif.getEvent();
-        assertEquals("1337", event.getUserId());
-        assertEquals("awesome_user", event.getUserName());
-        assertEquals("12826", event.getBroadcasterUserId());
-        assertEquals("twitch", event.getBroadcasterUserName());
+        assertEquals("1234", event.getUserId());
+        assertEquals("cool_user", event.getUserLogin());
+        assertEquals("Cool_User", event.getUserName());
+        assertEquals("1337", event.getBroadcasterUserId());
+        assertEquals("cooler_user", event.getBroadcasterUserLogin());
+        assertEquals("Cooler_User", event.getBroadcasterUserName());
+        assertEquals(Instant.parse("2020-07-15T18:16:11.17106713Z"), event.getFollowedAt());
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -453,7 +453,7 @@ public interface TwitchHelix {
     /**
      * Modifies channel information for users
      *
-     * @param authToken Auth Token (scope: user:edit:broadcast)
+     * @param authToken Auth Token (scope: channel:manage:broadcast or user:edit:broadcast)
      * @param broadcasterId ID of the channel to be updated (required)
      * @param channelInformation {@link ChannelInformation} (at least one parameter must be provided)
      * @return 204 No Content upon a successful update
@@ -924,7 +924,7 @@ public interface TwitchHelix {
 
     /**
      * Replaces the active stream tags on the specified stream with the specified tags (or clears all tags, if no new tags are specified).
-     * Requires scope: user:edit:broadcast
+     * Requires scope: channel:manage:broadcast or user:edit:broadcast
      *
      * @param authToken     Auth Token
      * @param broadcasterId ID of the stream to replace tags for
@@ -947,7 +947,7 @@ public interface TwitchHelix {
      * Creates a marker at the current time during a live stream. A marker is a temporal indicator that appears on the Twitch web UI for highlight creation and can also be retrieved with
      * {@link #getStreamMarkers(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.lang.String, java.lang.String) getStreamMarkers}. Markers are meant to remind streamers and their video editors of important moments during a stream.
      * Markers can be created only if the broadcast identified by the specified {@code userId} is live and has enabled VOD (past broadcast) storage. Marker creation will fail if the broadcaster is airing a premiere or a rerun.
-     * Requires scope: user:edit:broadcast
+     * Requires scope: channel:manage:broadcast or user:edit:broadcast
      *
      * @param authToken     Auth Token
      * @param highlight     User id and optional description for the marker


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Include new `followedAt` field in `ChannelFollowEvent`

#### Secondary
* Update TwitchHelix javadoc to include new `channel:manage:broadcast` scope
* Bump credential manager version
