### PR TITLE
feat: add unofficial kraken hosts endpoint

### DIFF
--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -234,6 +234,20 @@ public interface TwitchKraken {
     );
 
     /**
+     * Get Hosts of a Target Channel
+     * <p>
+     * This endpoint returns a "host" record for each channel hosting the channel with the provided targetId.
+     *
+     * @param channelId The user ID of the channel for which to get host information.
+     * @return KrakenHostList
+     */
+    @Unofficial
+    @RequestLine("GET /channels/{channel_id}/hosts")
+    HystrixCommand<KrakenHostList> getHostsOf(
+        @Param("channel_id") String channelId
+    );
+
+    /**
      * Update Collection
      * <p>
      * Updates the title of a specified collection.

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenHost.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenHost.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.kraken.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class KrakenHost {
+
+    private String hostId;
+
+    private String targetId;
+
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenHostList.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/domain/KrakenHostList.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.kraken.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class KrakenHostList {
+
+    private List<KrakenHost> hosts;
+
+}

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
@@ -25,7 +25,7 @@ public interface TwitchMessagingInterface {
     HystrixCommand<Chatters> getChatters(
         @Param("channel") String channelName
     );
-    
+
     /**
      * Get Hosts
      * <p>
@@ -42,7 +42,7 @@ public interface TwitchMessagingInterface {
     HystrixCommand<HostList> getHosts(
         @Param("id") List<String> channelIds
     );
-    
+
     /**
      * Get Hosts of target channel
      * <p>
@@ -54,7 +54,9 @@ public interface TwitchMessagingInterface {
      *
      * @param targetId The user ID of the channel for which to get host information.
      * @return List of hosts of the target channel.
+     * @deprecated no longer functioning, so TwitchKraken#getHostsOf should be used
      */
+    @Deprecated
     @RequestLine("GET /hosts?include_logins=1&target={id}")
     HystrixCommand<HostList> getHostsOf(
         @Param("id") String targetId


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `TwitchMessagingInterface#getHostsOf(String)` is no longer working

### Changes Proposed
* Add `TwitchKraken#getHostsOf(String)`
