### PR TITLE
feat: add sendMessage with nonce or reply to ITwitchChat

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
@@ -2,8 +2,10 @@ package com.github.twitch4j.chat;
 
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import com.github.twitch4j.common.annotation.Unofficial;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Set;
 
 @SuppressWarnings("unused")
@@ -36,6 +38,18 @@ public interface ITwitchChat extends AutoCloseable {
     boolean sendMessage(String channel, String message);
 
     /**
+     * Sends a message to the channel while including an optional nonce and/or reply parent.
+     *
+     * @param channel    the name of the channel to send the message to.
+     * @param message    the message to be sent.
+     * @param nonce      the cryptographic nonce (optional).
+     * @param replyMsgId the msgId of the parent message being replied to (optional).
+     * @return whether the message was added to the queue
+     */
+    @Unofficial
+    boolean sendMessage(String channel, String message, String nonce, String replyMsgId);
+
+    /**
      * Returns a set of all currently joined channels (without # prefix)
      *
      * @return a set of channel names
@@ -44,6 +58,16 @@ public interface ITwitchChat extends AutoCloseable {
 
     @Override
     void close();
+
+    /**
+     * @return cached mappings of channel ids to names
+     */
+    Map<String, String> getChannelIdToChannelName();
+
+    /**
+     * @return cached mappings of channel names to ids
+     */
+    Map<String, String> getChannelNameToChannelId();
 
     /**
      * Check if Chat is currently in a channel

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -638,14 +638,7 @@ public class TwitchChat implements ITwitchChat {
         return this.sendMessage(channel, message, null);
     }
 
-    /**
-     * Sends a message to the channel while including an optional nonce and/or reply parent.
-     *
-     * @param channel    the name of the channel to send the message to.
-     * @param message    the message to be sent.
-     * @param nonce      the cryptographic nonce (optional).
-     * @param replyMsgId the msgId of the parent message being replied to (optional).
-     */
+    @Override
     @Unofficial
     public boolean sendMessage(String channel, String message, String nonce, String replyMsgId) {
         final Map<String, Object> tags = new LinkedHashMap<>(); // maintain insertion order
@@ -746,14 +739,17 @@ public class TwitchChat implements ITwitchChat {
     /**
      * @return the cached map used for channel id to name mapping
      */
+    @Override
     public Map<String, String> getChannelIdToChannelName() {
         return Collections.unmodifiableMap(channelIdToChannelName);
     }
 
     /**
-     * @return the cached map sed for channel name to id mapping
+     * @return the cached map used for channel name to id mapping
      */
+    @Override
     public Map<String, String> getChannelNameToChannelId() {
         return Collections.unmodifiableMap(channelNameToChannelId);
     }
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ITwitchChat#sendMessage(String, String, String, String)` so chat connection pools can use the unofficial nonce & reply feature
* Add `ITwitchChat#getChannelIdToChannelName` and `ITwitchChat#getChannelNameToChannelId` (requested by a discord user)
