### PR TITLE
refactor: remove drops entitlement pagination workaround for docs issue

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -335,7 +335,7 @@ public interface TwitchHelix {
      * @param userId    Optional: A Twitch User ID.
      * @param gameId    Optional: A Twitch Game ID.
      * @param after     Optional: The cursor used to fetch the next page of data.
-     * @param limit     Optional: Maximum number of entitlements to return. Default: 20. Max: 100.
+     * @param limit     Optional: Maximum number of entitlements to return. Default: 20. Max: 1000.
      * @return DropsEntitlementList
      */
     @RequestLine("GET /entitlements/drops?id={id}&user_id={user_id}&game_id={game_id}&after={after}&first={first}")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlementList.java
@@ -2,13 +2,10 @@ package com.github.twitch4j.helix.domain;
 
 import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Data
@@ -21,23 +18,18 @@ public class DropsEntitlementList {
      */
     private List<DropsEntitlement> data;
 
-    @Getter(AccessLevel.PRIVATE)
-    private Object pagination;
+    private HelixPagination pagination;
 
     /**
      * If present, is the key used to fetch the next page of data.
      * If absent, the current response is the last page of data available.
      *
      * @return the cursor from the pagination object, in an optional wrapper
+     * @deprecated in favor of {@link #getPagination()}
      */
+    @Deprecated
     public Optional<String> getPaginationCursor() {
-        // The example response contained in the official documentation claims that the pagination field in the JSON
-        // is simply a string, deviating from the rest of the helix endpoints which use an object that contains a string.
-        // Since this may be an error that we are unable to test, we provide this code to be agnostic to both approaches.
-        return Optional.ofNullable(pagination instanceof Map ? ((Map<?, ?>) pagination).get("cursor") : pagination)
-            .filter(c -> c instanceof String)
-            .map(c -> (String) c)
-            .filter(StringUtils::isNotBlank);
+        return Optional.ofNullable(pagination).map(HelixPagination::getCursor);
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/340

### Changes Proposed
* Convert `DropsEntitlementList` `pagination` field type from `Object` to `HelixPagination`
* `The maximum value for the number of items return via the first parameter has been increased to 1000.`

### Additional Information
https://dev.twitch.tv/docs/change-log