### PR TITLE
refactor: include even more helix response login fields

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEvent.java
@@ -50,7 +50,12 @@ public class BannedEvent {
         private String broadcasterId;
 
         /**
-         * The name of the broadcaster where the event took place
+         * The login name of the broadcaster where the event took place
+         */
+        private String broadcasterLogin;
+
+        /**
+         * The display name of the broadcaster where the event took place
          */
         private String broadcasterName;
 
@@ -61,7 +66,12 @@ public class BannedEvent {
         private String userId;
 
         /**
-         * The name of the user that was banned/unbanned
+         * The login name of the user that was banned/unbanned
+         */
+        private String userLogin;
+
+        /**
+         * The display name of the user that was banned/unbanned
          */
         private String userName;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Subscription.java
@@ -12,7 +12,11 @@ public class Subscription {
     @NonNull
     private String broadcasterId;
 
-    /** Username of the broadcaster. */
+    /** Login name of the broadcaster. */
+    @NonNull
+    private String broadcasterLogin;
+
+    /** Display name of the broadcaster. */
     @NonNull
     private String broadcasterName;
 
@@ -21,6 +25,9 @@ public class Subscription {
 
     /** ID of the user who gifted the sub. */
     private String gifterId;
+
+    /** If the subscription was gifted, this is the login of the gifter. */
+    private String gifterLogin;
 
     /** Display name of the user who gifted the sub. */
     private String gifterName;
@@ -37,7 +44,11 @@ public class Subscription {
     @NonNull
     private String userId;
 
-    /** Login name of the subscribed user. */
+    /** Login of the subscribed user. */
+    @NonNull
+    private String userLogin;
+
+    /** Display name of the subscribed user. */
     @NonNull
     private String userName;
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* `BannedEvent` & `Subscription` are no longer missing new `login` fields
