### PR TITLE
fix: include extendsub in SubscriptionType to avoid null context in pubsub

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/enums/SubscriptionType.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/SubscriptionType.java
@@ -13,7 +13,8 @@ public enum SubscriptionType {
     SUB_GIFT,
     ANON_SUB_GIFT,
     RESUB_GIFT,
-    ANON_RESUB_GIFT;
+    ANON_RESUB_GIFT,
+    EXTEND_SUB;
 
     @Getter
     @Accessors(fluent = true)


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `EXTEND_SUB` to `SubscriptionType`
