### PR TITLE
chore: kraken hosts was decommissioned by twitch

### DIFF
--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -283,9 +283,11 @@ public interface TwitchKraken {
      *
      * @param channelId The user ID of the channel for which to get host information.
      * @return KrakenHostList
+     * @deprecated Decommissioned by Twitch.
      */
     @Unofficial
     @RequestLine("GET /channels/{channel_id}/hosts")
+    @Deprecated
     HystrixCommand<KrakenHostList> getHostsOf(
         @Param("channel_id") String channelId
     );

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
@@ -111,7 +111,7 @@ public interface TwitchMessagingInterface {
      *
      * @param targetId The user ID of the channel for which to get host information.
      * @return List of hosts of the target channel.
-     * @deprecated no longer functioning, so TwitchKraken#getHostsOf should be used
+     * @deprecated Decommissioned by Twitch.
      */
     @Deprecated
     @RequestLine("GET /hosts?include_logins=1&target={id}")


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate `TwitchKraken#getHostsOf(String)`

### Additional Information
`{"error":"Gone","status":410,"message":"Endpoint has been decommissioned"}`
