### PR TITLE
feat: add viewer event to client helper and channel cache getter

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
@@ -36,6 +36,11 @@ public class ChannelCache {
     private String gameId;
 
     /**
+     * Current Viewer Count
+     */
+    private final AtomicReference<Integer> viewerCount = new AtomicReference<>();
+
+    /**
      * Last Follow Check
      */
     private Instant lastFollowCheck;

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelViewerCountUpdateEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelViewerCountUpdateEvent.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.helix.domain.Stream;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChannelViewerCountUpdateEvent extends TwitchEvent {
+
+    /**
+     * The channel that changed in viewer count.
+     */
+    EventChannel channel;
+
+    /**
+     * The stream data.
+     */
+    Stream stream;
+
+    /**
+     * @return the new viewer count.
+     */
+    public Integer getViewerCount() {
+        return stream.getViewerCount();
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Create `ChannelViewerCountUpdateEvent` & fire from client helper
* Create `TwitchClientHelper#getCachedInformation(String)` (has been requested a few times on discord)
