### PR TITLE
feat: add cheer badge to chat permissions

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -297,6 +297,22 @@ public class IRCMessageEvent extends TwitchEvent {
         return OptionalInt.empty();
     }
 
+    /**
+     * @return the tier of the bits badge of the user, or empty if there is no bits badge present
+     */
+    public OptionalInt getCheererTier() {
+        final String bits = badges.get("bits");
+
+        if (bits != null) {
+            try {
+                return OptionalInt.of(Integer.parseInt(bits));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return OptionalInt.empty();
+    }
+
 	/**
 	 * Gets a optional tag from the irc message
      *

--- a/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
@@ -32,6 +32,11 @@ public enum CommandPermission {
     SUBGIFTER,
 
     /**
+     * Cheered bits
+     */
+    BITS_CHEERER,
+
+    /**
      * Was a conductor of the previous hype train
      */
     FORMER_HYPE_TRAIN_CONDUCTOR,

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -50,7 +50,7 @@ public class TwitchUtils {
                 permissionSet.add(CommandPermission.MODERATOR);
             }
             // Twitch Prime
-            if (badges.containsKey("premium")) {
+            if (badges.containsKey("premium") || badges.containsKey("turbo")) {
                 permissionSet.add(CommandPermission.PRIME_TURBO);
             }
             // Moderator
@@ -74,15 +74,19 @@ public class TwitchUtils {
                 permissionSet.add(CommandPermission.TWITCHSTAFF);
             }
             // Subscriber
-            if(badges.containsKey("subscriber")) {
+            if (badges.containsKey("subscriber")) {
                 permissionSet.add(CommandPermission.SUBSCRIBER);
             }
             // SubGifter
-            if(badges.containsKey("sub-gifter")) {
+            if (badges.containsKey("sub-gifter")) {
                 permissionSet.add(CommandPermission.SUBGIFTER);
             }
+            // Cheerer
+            if (badges.containsKey("bits")) {
+                permissionSet.add(CommandPermission.BITS_CHEERER);
+            }
             // Founder
-            if(badges.containsKey("founder")) {
+            if (badges.containsKey("founder")) {
                 permissionSet.add(CommandPermission.FOUNDER);
                 permissionSet.add(CommandPermission.SUBSCRIBER);
 
@@ -131,12 +135,12 @@ public class TwitchUtils {
      */
     public static Map<String, String> parseBadges(String raw) {
         Map<String, String> map = new HashMap<>();
-        if(StringUtils.isBlank(raw)) return map;
+        if (StringUtils.isBlank(raw)) return map;
 
         // Fix Whitespaces
         raw = raw.replace("\\s", " ");
 
-        for (String tag: raw.split(",")) {
+        for (String tag : raw.split(",")) {
             String[] val = tag.split("/");
             final String key = val[0];
             String value = (val.length > 1) ? val[1] : null;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `CommandPermission.BITS_CHEERER` (and associated parsing logic in `TwitchUtils`)
* Add `IRCMessageEvent#getCheererTier` (I'm not in love with this method name so we can change it if you have any ideas)
* Ensure `CommandPermission.PRIME_TURBO` is present for turbo users
* Small code formatting changes in `TwitchUtils`
