### PR TITLE
fix: resolve pubsub reconnect loop from ping edge case

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -259,6 +259,9 @@ public class TwitchPubSub implements ITwitchPubSub {
                 // Recreate Socket if state does not equal CREATED
                 createWebSocket();
 
+                // Reset last ping to avoid edge case loop where reconnect occurred after sending PING but before receiving PONG
+                this.lastPing = TimeUtils.getCurrentTimeInMillis() - 4 * 60 * 1000;
+
                 // Connect to IRC WebSocket
                 this.webSocket.connect();
             } catch (Exception ex) {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* https://cdn.discordapp.com/attachments/268348117919858688/833003511150805002/7f416530a57784ffc85aed8d2effe5ad.png

### Changes Proposed
* Reset last ping to avoid edge case loop where reconnect occurred after sending PING but before receiving PONG
