### PR TITLE
feat: fire global user state chat event

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -77,6 +77,7 @@ public class IRCEventHandler {
         eventManager.onEvent("twitch4j-chat-ritual-trigger", IRCMessageEvent.class, this::onRitual);
         eventManager.onEvent("twitch4j-chat-delete-trigger", IRCMessageEvent.class, this::onMessageDeleteResponse);
         eventManager.onEvent("twitch4j-chat-userstate-trigger", IRCMessageEvent.class, this::onUserState);
+        eventManager.onEvent("twitch4j-chat-globaluserstate-trigger", IRCMessageEvent.class, this::onGlobalUserState);
     }
 
     /**
@@ -580,6 +581,12 @@ public class IRCEventHandler {
     public void onUserState(IRCMessageEvent event) {
         if (event.getCommandType().equals("USERSTATE")) {
             eventManager.publish(new UserStateEvent(event));
+        }
+    }
+
+    public void onGlobalUserState(IRCMessageEvent event) {
+        if ("GLOBALUSERSTATE".equals(event.getCommandType())) {
+            eventManager.publish(new GlobalUserStateEvent(event));
         }
     }
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GlobalUserStateEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GlobalUserStateEvent.java
@@ -1,0 +1,69 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.TwitchEvent;
+import com.github.twitch4j.common.enums.CommandPermission;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class GlobalUserStateEvent extends TwitchEvent {
+
+    /**
+     * Raw Message Event
+     */
+    IRCMessageEvent messageEvent;
+
+    /**
+     * @return the user's display name, or empty if it is never set.
+     */
+    public Optional<String> getDisplayName() {
+        return messageEvent.getTagValue("display-name");
+    }
+
+    /**
+     * @return the user's id, or empty if it is never set.
+     */
+    public Optional<String> getUserId() {
+        return Optional.ofNullable(messageEvent.getUserId());
+    }
+
+    /**
+     * @return hexadecimal RGB color code, or empty if it is never set.
+     */
+    public Optional<String> getColor() {
+        return messageEvent.getTagValue("color");
+    }
+
+    /**
+     * @return collection of emote sets.
+     */
+    public List<String> getEmoteSets() {
+        return Collections.unmodifiableList(Arrays.asList(
+            messageEvent.getTagValue("emote-sets")
+                .map(emoteSets -> StringUtils.split(emoteSets, ','))
+                .orElse(new String[0])
+        ));
+    }
+
+    /**
+     * @return whether the user is a staff member.
+     */
+    public boolean isStaff() {
+        return this.messageEvent.getClientPermissions().contains(CommandPermission.TWITCHSTAFF);
+    }
+
+    /**
+     * @return whether the user has a prime or turbo badge.
+     */
+    public boolean isPrimeOrTurbo() {
+        return this.messageEvent.getClientPermissions().contains(CommandPermission.PRIME_TURBO);
+    }
+
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -25,8 +25,8 @@ import java.util.regex.Pattern;
 @EqualsAndHashCode(callSuper = false)
 public class IRCMessageEvent extends TwitchEvent {
 
-    private static final Pattern MESSAGE_PATTERN = Pattern.compile("^(?:@(?<tags>.+?) )?(?<clientName>.+?)(?: (?<command>[A-Z0-9]+) )(?:#(?<channel>.*?) ?)?(?<payload>[:\\-\\+](?<message>.+))?$");
-    private static final Pattern WHISPER_PATTERN = Pattern.compile("^(?:@(?<tags>.+?) )?:(?<clientName>.+?)!.+?(?: (?<command>[A-Z0-9]+) )(?:(?<channel>.*?) ?)??(?<payload>[:\\-\\+](?<message>.+))$");
+    private static final Pattern MESSAGE_PATTERN = Pattern.compile("^(?:@(?<tags>.+?)\\s)?(?<clientName>.+?)\\s(?<command>[A-Z0-9]+)\\s?(?:#(?<channel>.*?)\\s?)?(?<payload>[:\\-+](?<message>.+))?$");
+    private static final Pattern WHISPER_PATTERN = Pattern.compile("^(?:@(?<tags>.+?)\\s)?:(?<clientName>.+?)!.+?\\s(?<command>[A-Z0-9]+)\\s(?:(?<channel>.*?)\\s?)??(?<payload>[:\\-+](?<message>.+))$");
     private static final Pattern CLIENT_PATTERN = Pattern.compile("^:(.*?)!(.*?)@(.*?).tmi.twitch.tv$");
 
     @Unofficial


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Previously, `GLOBALUSERSTATE` would yield `UNKNOWN` for `commandType` so no event would be fired https://discord.com/channels/143001431388061696/760173135021604914/805985982854987816

### Changes Proposed
* Fix: `MESSAGE_PATTERN`: make the space following the command group optional (`GLOBALUSERSTATE` has no such space)
* Refactor: `MESSAGE_PATTERN` & `WHISPER_PATTERN`: remove unnecessary non-capturing group, unnecessary escape character, convert space characters to `\s`
* New: fire `GlobalUserStateEvent` from `IRCEventHandler` for convenience

### Additional Information
`GLOBALUSERSTATE` is useful for confirming one has logged into chat https://discord.com/channels/143001431388061696/268348117919858688/805966340736548864
