### PR TITLE
feat: add new get followed streams helix endpoint

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -33,6 +33,7 @@ public enum TwitchScopes {
     HELIX_USER_EDIT_FOLLOWS("user:edit:follows"),
     HELIX_USER_BLOCKS_READ("user:read:blocked_users"),
     HELIX_USER_READ_BROADCAST("user:read:broadcast"),
+    HELIX_USER_FOLLOWS_READ("user:read:follows"),
     HELIX_USER_SUBSCRIPTIONS_READ("user:read:subscriptions"),
     HELIX_USER_EMAIL("user:read:email"),
     HELIX_USER_BLOCKS_MANAGE("user:manage:blocked_users"),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -877,6 +877,28 @@ public interface TwitchHelix {
     }
 
     /**
+     * Gets information about active streams belonging to channels that the authenticated user follows.
+     * <p>
+     * Streams are returned sorted by number of current viewers, in descending order.
+     * Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams.
+     *
+     * @param authToken Required: OAuth user token with the user:read:follows scope.
+     * @param after     Optional: Cursor for forward pagination.
+     * @param limit     Optional: Maximum number of objects to return. Maximum: 100. Default: 100.
+     * @param userId    Required: Results will only include active streams from the channels that this Twitch user follows. This must match the User ID in the bearer token.
+     * @return StreamList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_FOLLOWS_READ
+     */
+    @RequestLine("GET /streams/followed?after={after}&first={first}&user_id={user_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<StreamList> getFollowedStreams(
+        @Param("token") String authToken,
+        @Param("after") String after,
+        @Param("first") Integer limit,
+        @Param("user_id") String userId
+    );
+
+    /**
      * Gets the channel stream key for a user
      *
      * @param authToken Auth Token (scope: channel:read:stream_key)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -883,9 +883,9 @@ public interface TwitchHelix {
      * Across multiple pages of results, there may be duplicate or missing streams, as viewers join and leave streams.
      *
      * @param authToken Required: OAuth user token with the user:read:follows scope.
+     * @param userId    Required: Results will only include active streams from the channels that this Twitch user follows. This must match the User ID in the bearer token.
      * @param after     Optional: Cursor for forward pagination.
      * @param limit     Optional: Maximum number of objects to return. Maximum: 100. Default: 100.
-     * @param userId    Required: Results will only include active streams from the channels that this Twitch user follows. This must match the User ID in the bearer token.
      * @return StreamList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_FOLLOWS_READ
      */
@@ -893,9 +893,9 @@ public interface TwitchHelix {
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<StreamList> getFollowedStreams(
         @Param("token") String authToken,
+        @Param("user_id") String userId,
         @Param("after") String after,
-        @Param("first") Integer limit,
-        @Param("user_id") String userId
+        @Param("first") Integer limit
     );
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement `TwitchHelix#getFollowedStreams(String, String, Integer, String)`
* Add `TwitchScopes.HELIX_USER_FOLLOWS_READ`


### Additional Information
https://dev.twitch.tv/docs/api/reference/#get-followed-streams
