### PR TITLE
feat: add unofficial multi month chat tags

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -184,8 +184,12 @@ public class IRCEventHandler {
                 // Twitch API specifies that 0 is returned if the user chooses not to share their streak
                 Integer streak = event.getTags().containsKey("msg-param-streak-months") ? Integer.parseInt(event.getTags().get("msg-param-streak-months")) : 0;
 
+                // unofficial: multi month tags
+                Integer multiMonthDuration = Math.max(Integer.parseInt(event.getTags().getOrDefault("msg-param-multimonth-duration", "1")), 1);
+                Integer multiMonthTenure = Integer.parseInt(event.getTags().getOrDefault("msg-param-multimonth-tenure", "0"));
+
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak, null, event.getFlags()));
+                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak, null, multiMonthDuration, multiMonthTenure, event.getFlags()));
             }
             // Receive Gifted Sub
             else if (msgId.equalsIgnoreCase("subgift") || msgId.equalsIgnoreCase("anonsubgift")) {
@@ -203,9 +207,12 @@ public class IRCEventHandler {
                 // Handle multi-month gifts
                 String giftMonthsParam = event.getTags().get("msg-param-gift-months");
                 int giftMonths = giftMonthsParam != null ? Integer.parseInt(giftMonthsParam) : 1;
+                // unofficial: plausible, but hasn't been observed in the wild for this msg-id
+                String multiTenureParam = event.getTags().get("msg-param-multimonth-tenure");
+                Integer multiMonthTenure = StringUtils.isEmpty(multiTenureParam) ? null : Integer.parseInt(multiTenureParam);
 
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths, event.getFlags()));
+                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths, giftMonths, multiMonthTenure, event.getFlags()));
             }
             // Gift X Subs
             else if (msgId.equalsIgnoreCase("submysterygift") || msgId.equalsIgnoreCase("anonsubmysterygift")) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
@@ -12,11 +12,11 @@ import lombok.Value;
  * This event gets called when a user gifts x subscriptions to *random* users in chat.
  * <p>
  * This event will be called simultaneously with the chat announcement,
- * not when the user presses his subscription button.
+ * not necessarily when the user presses the subscription button.
  */
 @Value
 @Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class GiftSubscriptionsEvent extends AbstractChannelEvent {
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -298,7 +298,7 @@ public class IRCMessageEvent extends TwitchEvent {
     }
 
     /**
-     * @return the tier of the bits badge of the user, or empty if there is no bits badge present
+     * @return the tier of the bits badge of the user, or empty if there is no bits badge present (which can also occur for bits leaders)
      */
     public OptionalInt getCheererTier() {
         final String bits = badges.get("bits");

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -8,7 +8,9 @@ import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,11 +19,12 @@ import java.util.Optional;
  * This event gets called when a user gets a new subscriber or a user resubscribes.
  * <p>
  * This event will be called simultaneously with the chat announcement,
- * not when the user presses his subscription button.
+ * not necessary when the user presses the subscription button.
  */
 @Value
 @Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class SubscriptionEvent extends AbstractChannelEvent {
 
     /**
@@ -71,6 +74,19 @@ public class SubscriptionEvent extends AbstractChannelEvent {
     Integer giftMonths;
 
     /**
+     * The number of subscription months just purchased. (Unofficial)
+     */
+    @Unofficial
+    Integer multiMonthDuration;
+
+    /**
+     * The length of multi-month subscription tenure that has already been served. Can be null for gifts. (Unofficial)
+     */
+    @Nullable
+    @Unofficial
+    Integer multiMonthTenure;
+
+    /**
      * The regions of {@link #getMessage()} that were flagged by AutoMod (Unofficial)
      */
     @Unofficial
@@ -79,18 +95,20 @@ public class SubscriptionEvent extends AbstractChannelEvent {
     /**
      * Event Constructor
      *
-     * @param channel    ChatChannel the user subscribed to
-     * @param user       User that subscribed
-     * @param subPlan    Sub Plan
-     * @param message    Sub Message
-     * @param months     Cumulative number of months user has been subscribed (not consecutive)
-     * @param gifted     Is gifted?
-     * @param giftedBy   User that gifted the sub
-     * @param subStreak  Consecutive number of months user has been subscribed (not cumulative); 0 if no streak or user chooses not to share their streak
-     * @param giftMonths The number of months gifted as part of a single, multi-month gift
-     * @param flags      The regions of the message that were flagged by AutoMod.
+     * @param channel            ChatChannel the user subscribed to
+     * @param user               User that subscribed
+     * @param subPlan            Sub Plan
+     * @param message            Sub Message
+     * @param months             Cumulative number of months user has been subscribed (not consecutive)
+     * @param gifted             Is gifted?
+     * @param giftedBy           User that gifted the sub
+     * @param subStreak          Consecutive number of months user has been subscribed (not cumulative); 0 if no streak or user chooses not to share their streak
+     * @param giftMonths         The number of months gifted as part of a single, multi-month gift
+     * @param multiMonthDuration The number of subscription months just purchased
+     * @param multiMonthTenure   The length of multi-month subscription tenure that has already been served
+     * @param flags              The regions of the message that were flagged by AutoMod.
      */
-    public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths, List<AutoModFlag> flags) {
+    public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths, Integer multiMonthDuration, Integer multiMonthTenure, List<AutoModFlag> flags) {
         super(channel);
         this.user = user;
         this.subscriptionPlan = subPlan;
@@ -100,6 +118,8 @@ public class SubscriptionEvent extends AbstractChannelEvent {
         this.giftedBy = giftedBy;
         this.subStreak = subStreak;
         this.giftMonths = giftMonths;
+        this.multiMonthDuration = multiMonthDuration;
+        this.multiMonthTenure = multiMonthTenure;
         this.flags = flags;
     }
 

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -82,7 +82,7 @@ public class TwitchUtils {
                 permissionSet.add(CommandPermission.SUBGIFTER);
             }
             // Cheerer
-            if (badges.containsKey("bits")) {
+            if (badges.containsKey("bits") || badges.containsKey("bits-leader")) {
                 permissionSet.add(CommandPermission.BITS_CHEERER);
             }
             // Founder


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Parse `msg-param-multimonth-duration` & `msg-param-multimonth-tenure` for `SubscriptionEvent` (unofficial)
* Handle `bits-leader` in the same way as `bits` for permissions