### PR TITLE
feat: implement polls predictions helix eventsub public beta

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/annotation/Unofficial.java
+++ b/common/src/main/java/com/github/twitch4j/common/annotation/Unofficial.java
@@ -6,6 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 
 /**
  * Annotates a method or features that uses unofficial api endpoints, those can break at any point in time. Use at your own risk.
+ * <p>
+ * All aspects of this functionality including query parameters and response structure are subject to change without notice.
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPollBeginCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPollBeginCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPollBeginCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPollEndCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPollEndCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPollEndCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPollProgressCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPollProgressCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPollProgressCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionBeginCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionBeginCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPredictionBeginCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionEndCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionEndCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPredictionEndCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionLockCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionLockCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPredictionLockCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionProgressCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelPredictionProgressCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelPredictionProgressCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/BitsVoting.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/BitsVoting.java
@@ -1,0 +1,27 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class BitsVoting {
+
+    /**
+     * Indicates if Bits can be used for voting.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_enabled")
+    private Boolean isEnabled;
+
+    /**
+     * Number of Bits required to vote once with Bits.
+     */
+    private Integer amountPerVote;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ChannelPointsVoting.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ChannelPointsVoting.java
@@ -1,0 +1,27 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class ChannelPointsVoting {
+
+    /**
+     * Indicates if Channel Points can be used for voting.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_enabled")
+    private Boolean isEnabled;
+
+    /**
+     * Number of Channel Points required to vote once with Channel Points.
+     */
+    private Integer amountPerVote;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollChoice.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollChoice.java
@@ -1,0 +1,50 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.Nullable;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+public class PollChoice {
+
+    /**
+     * ID for the choice.
+     */
+    private String id;
+
+    /**
+     * Text displayed for the choice. Maximum: 25 characters.
+     */
+    private String title;
+
+    /**
+     * Total number of votes received for the choice across all methods of voting.
+     */
+    @Nullable
+    private Integer votes;
+
+    /**
+     * Number of votes received via Channel Points.
+     */
+    @Nullable
+    private Integer channelPointsVotes;
+
+    /**
+     * Number of votes received via Bits.
+     */
+    @Nullable
+    private Integer bitsVotes;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollChoice.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollChoice.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 @Jacksonized
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PollChoice {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollStatus.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum PollStatus {
+
+    /**
+     * Poll is currently in progress.
+     */
+    ACTIVE,
+
+    /**
+     * Poll has reached its ended_at time.
+     */
+    COMPLETED,
+
+    /**
+     * Poll has been manually terminated before its ended_at time, but still visible.
+     */
+    TERMINATED,
+
+    /**
+     * Poll is no longer visible on the channel.
+     */
+    ARCHIVED,
+
+    /**
+     * Poll is no longer visible to any user on Twitch.
+     */
+    MODERATED,
+
+    /**
+     * Something went wrong determining the state.
+     */
+    @JsonEnumDefaultValue
+    INVALID
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionColor.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionColor.java
@@ -1,5 +1,5 @@
 package com.github.twitch4j.eventsub.domain;
 
 public enum PredictionColor {
-    PINK, BLUE
+    BLUE, PINK
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionColor.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionColor.java
@@ -1,0 +1,5 @@
+package com.github.twitch4j.eventsub.domain;
+
+public enum PredictionColor {
+    PINK, BLUE
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionOutcome.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionOutcome.java
@@ -1,0 +1,55 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+public class PredictionOutcome {
+
+    /**
+     * The outcome ID.
+     */
+    private String id;
+
+    /**
+     * The outcome title. Maximum: 25 characters.
+     */
+    private String title;
+
+    /**
+     * The color for the outcome.
+     */
+    private PredictionColor color;
+
+    /**
+     * The number of users who used Channel Points on this outcome.
+     */
+    private Integer users;
+
+    /**
+     * The total number of Channel Points used on this outcome.
+     */
+    private Long channelPoints;
+
+    /**
+     * The users who used the most Channel Points on this outcome.
+     */
+    @Nullable
+    private List<Predictor> topPredictors;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionOutcome.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionOutcome.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,7 @@ import java.util.List;
 @Jacksonized
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PredictionOutcome {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PredictionStatus.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.eventsub.domain;
+
+public enum PredictionStatus {
+
+    /**
+     * A winning outcome has been chosen and the Channel Points have been distributed to the users who guessed the correct outcome.
+     */
+    RESOLVED,
+
+    /**
+     * The Prediction is active and viewers can make predictions.
+     */
+    ACTIVE,
+
+    /**
+     * The Prediction has been canceled and the Channel Points have been refunded to participants.
+     */
+    CANCELED,
+
+    /**
+     * The Prediction has been locked and viewers can no longer make predictions.
+     */
+    LOCKED
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Predictor.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Predictor.java
@@ -1,0 +1,43 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class Predictor {
+
+    /**
+     * The ID of the user.
+     */
+    private String userId;
+
+    /**
+     * The login name of the user.
+     */
+    private String userLogin;
+
+    /**
+     * The display name of the user.
+     */
+    private String userName;
+
+    /**
+     * The number of Channel Points won.
+     * <p>
+     * This value is always null in the event payload for Prediction progress and Prediction lock.
+     * This value is 0 if the outcome did not win or if the Prediction was canceled and Channel Points were refunded.
+     */
+    @Nullable
+    private Integer channelPointsWon;
+
+    /**
+     * The number of Channel Points used to participate in the Prediction.
+     */
+    private Integer channelPointsUsed;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollBeginEvent.java
@@ -1,0 +1,8 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPollBeginEvent extends ChannelPollEvent {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEndEvent.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.PollStatus;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPollEndEvent extends ChannelPollEvent {
+
+    /**
+     * The status of the poll. Valid values are completed, archived, and terminated.
+     */
+    private PollStatus status;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEvent.java
@@ -1,0 +1,60 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.BitsVoting;
+import com.github.twitch4j.eventsub.domain.ChannelPointsVoting;
+import com.github.twitch4j.eventsub.domain.PollChoice;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public abstract class ChannelPollEvent extends EventSubChannelEvent {
+
+    /**
+     * ID of the poll.
+     */
+    @JsonProperty("id")
+    private String pollId;
+
+    /**
+     * Question displayed for the poll.
+     */
+    private String title;
+
+    /**
+     * Choices for the poll.
+     */
+    private List<PollChoice> choices;
+
+    /**
+     * The Bits voting settings for the poll.
+     */
+    private BitsVoting bitsVoting;
+
+    /**
+     * The Channel Points voting settings for the poll.
+     */
+    private ChannelPointsVoting channelPointsVoting;
+
+    /**
+     * The time the poll started.
+     */
+    private Instant startedAt;
+
+    /**
+     * The time the poll will end.
+     */
+    private Instant endsAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollProgressEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollProgressEvent.java
@@ -1,0 +1,8 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPollProgressEvent extends ChannelPollEvent {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionBeginEvent.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPredictionBeginEvent extends ChannelPredictionEvent {
+
+    /**
+     * The time the Channel Points Prediction will automatically lock.
+     */
+    private Instant locksAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEndEvent.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.twitch4j.eventsub.domain.PredictionOutcome;
 import com.github.twitch4j.eventsub.domain.PredictionStatus;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -9,6 +11,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.time.Instant;
+import java.util.Optional;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -36,5 +39,19 @@ public class ChannelPredictionEndEvent extends ChannelPredictionEvent {
      * The time the Channel Points Prediction ended.
      */
     private Instant endedAt;
+
+    /**
+     * @return the winning PredictionOutcome, in an optional wrapper
+     */
+    @JsonIgnore
+    public Optional<PredictionOutcome> getWinningOutcome() {
+        if (winningOutcomeId != null) {
+            for (PredictionOutcome outcome : getOutcomes()) {
+                if (outcome != null && winningOutcomeId.equals(outcome.getId()))
+                    return Optional.of(outcome);
+            }
+        }
+        return Optional.empty();
+    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEndEvent.java
@@ -1,0 +1,40 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.PredictionStatus;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPredictionEndEvent extends ChannelPredictionEvent {
+
+    /**
+     * ID of the winning outcome.
+     */
+    private String winningOutcomeId;
+
+    /**
+     * The status of the Channel Points Prediction. Valid values are resolved and canceled.
+     */
+    private PredictionStatus status;
+
+    /**
+     * The time the Channel Points Prediction locked.
+     */
+    private Instant lockedAt;
+
+    /**
+     * The time the Channel Points Prediction ended.
+     */
+    private Instant endedAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEvent.java
@@ -1,0 +1,43 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.PredictionOutcome;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public abstract class ChannelPredictionEvent extends EventSubChannelEvent {
+
+    /**
+     * Channel Points Prediction ID.
+     */
+    @JsonProperty("id")
+    private String predictionId;
+
+    /**
+     * Title for the Channel Points Prediction.
+     */
+    private String title;
+
+    /**
+     * The outcomes for the Channel Points Prediction. May or may not include top_predictors.
+     */
+    private List<PredictionOutcome> outcomes;
+
+    /**
+     * The time the Channel Points Prediction started.
+     */
+    private Instant startedAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionLockEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionLockEvent.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPredictionLockEvent extends ChannelPredictionEvent {
+
+    /**
+     * The time the Channel Points Prediction will automatically lock.
+     */
+    private Instant locksAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionProgressEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionProgressEvent.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelPredictionProgressEvent extends ChannelPredictionEvent {
+
+    /**
+     * The time the Channel Points Prediction will automatically lock.
+     */
+    private Instant locksAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPollBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPollBeginType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPollBeginCondition;
+import com.github.twitch4j.eventsub.events.ChannelPollBeginEvent;
+
+/**
+ * The channel.poll.begin subscription type sends a notification when a poll begins on the specified channel.
+ * <p>
+ * Must have the channel:read:polls or channel:manage:polls scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond the 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPollBeginType implements SubscriptionType<ChannelPollBeginCondition, ChannelPollBeginCondition.ChannelPollBeginConditionBuilder<?, ?>, ChannelPollBeginEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.poll.begin";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPollBeginCondition.ChannelPollBeginConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPollBeginCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPollBeginEvent> getEventClass() {
+        return ChannelPollBeginEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPollEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPollEndType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPollEndCondition;
+import com.github.twitch4j.eventsub.events.ChannelPollEndEvent;
+
+/**
+ * The channel.poll.end subscription type sends a notification when a poll ends on the specified channel.
+ * <p>
+ * Must have the channel:read:polls or channel:manage:polls scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond the 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPollEndType implements SubscriptionType<ChannelPollEndCondition, ChannelPollEndCondition.ChannelPollEndConditionBuilder<?, ?>, ChannelPollEndEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.poll.end";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPollEndCondition.ChannelPollEndConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPollEndCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPollEndEvent> getEventClass() {
+        return ChannelPollEndEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPollProgressType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPollProgressType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPollProgressCondition;
+import com.github.twitch4j.eventsub.events.ChannelPollProgressEvent;
+
+/**
+ * The channel.poll.progress subscription type sends a notification when users respond to a poll on the specified channel.
+ * <p>
+ * Must have the channel:read:polls or channel:manage:polls scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond the 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPollProgressType implements SubscriptionType<ChannelPollProgressCondition, ChannelPollProgressCondition.ChannelPollProgressConditionBuilder<?, ?>, ChannelPollProgressEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.poll.progress";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPollProgressCondition.ChannelPollProgressConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPollProgressCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPollProgressEvent> getEventClass() {
+        return ChannelPollProgressEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionBeginType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPredictionBeginCondition;
+import com.github.twitch4j.eventsub.events.ChannelPredictionBeginEvent;
+
+/**
+ * The channel.prediction.begin subscription type sends a notification when a Prediction begins on the specified channel.
+ * <p>
+ * Must have channel:read:predictions or channel:manage:predictions scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPredictionBeginType implements SubscriptionType<ChannelPredictionBeginCondition, ChannelPredictionBeginCondition.ChannelPredictionBeginConditionBuilder<?, ?>, ChannelPredictionBeginEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.prediction.begin";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPredictionBeginCondition.ChannelPredictionBeginConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPredictionBeginCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPredictionBeginEvent> getEventClass() {
+        return ChannelPredictionBeginEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionEndType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPredictionEndCondition;
+import com.github.twitch4j.eventsub.events.ChannelPredictionEndEvent;
+
+/**
+ * The channel.prediction.end subscription type sends a notification when a Prediction ends on the specified channel.
+ * <p>
+ * Must have channel:read:predictions or channel:manage:predictions scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPredictionEndType implements SubscriptionType<ChannelPredictionEndCondition, ChannelPredictionEndCondition.ChannelPredictionEndConditionBuilder<?, ?>, ChannelPredictionEndEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.prediction.end";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPredictionEndCondition.ChannelPredictionEndConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPredictionEndCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPredictionEndEvent> getEventClass() {
+        return ChannelPredictionEndEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionLockType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionLockType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPredictionLockCondition;
+import com.github.twitch4j.eventsub.events.ChannelPredictionLockEvent;
+
+/**
+ * The channel.prediction.lock subscription type sends a notification when a Prediction is locked on the specified channel.
+ * <p>
+ * Must have channel:read:predictions or channel:manage:predictions scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPredictionLockType implements SubscriptionType<ChannelPredictionLockCondition, ChannelPredictionLockCondition.ChannelPredictionLockConditionBuilder<?, ?>, ChannelPredictionLockEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.prediction.lock";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPredictionLockCondition.ChannelPredictionLockConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPredictionLockCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPredictionLockEvent> getEventClass() {
+        return ChannelPredictionLockEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionProgressType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaPredictionProgressType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelPredictionProgressCondition;
+import com.github.twitch4j.eventsub.events.ChannelPredictionProgressEvent;
+
+/**
+ * The channel.prediction.progress subscription type sends a notification when users participate in a Prediction on the specified channel.
+ * <p>
+ * Must have channel:read:predictions or channel:manage:predictions scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
+ * Any active beta subscriptions beyond 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaPredictionProgressType implements SubscriptionType<ChannelPredictionProgressCondition, ChannelPredictionProgressCondition.ChannelPredictionProgressConditionBuilder<?, ?>, ChannelPredictionProgressEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.prediction.progress";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelPredictionProgressCondition.ChannelPredictionProgressConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelPredictionProgressCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelPredictionProgressEvent> getEventClass() {
+        return ChannelPredictionProgressEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
+import com.github.twitch4j.common.annotation.Unofficial;
 import lombok.experimental.UtilityClass;
 
 import java.util.Collections;
@@ -11,6 +12,13 @@ import java.util.stream.Stream;
 @UtilityClass
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
+    @Unofficial public final BetaPollBeginType BETA_POLL_BEGIN;
+    @Unofficial public final BetaPollProgressType BETA_POLL_PROGRESS;
+    @Unofficial public final BetaPollEndType BETA_POLL_END;
+    @Unofficial public final BetaPredictionBeginType BETA_PREDICTION_BEGIN;
+    @Unofficial public final BetaPredictionProgressType BETA_PREDICTION_PROGRESS;
+    @Unofficial public final BetaPredictionLockType BETA_PREDICTION_LOCK;
+    @Unofficial public final BetaPredictionEndType BETA_PREDICTION_END;
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelCheerType CHANNEL_CHEER;
     public final ChannelFollowType CHANNEL_FOLLOW;
@@ -40,6 +48,13 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
+                BETA_POLL_BEGIN = new BetaPollBeginType(),
+                BETA_POLL_PROGRESS = new BetaPollProgressType(),
+                BETA_POLL_END = new BetaPollEndType(),
+                BETA_PREDICTION_BEGIN = new BetaPredictionBeginType(),
+                BETA_PREDICTION_PROGRESS = new BetaPredictionProgressType(),
+                BETA_PREDICTION_LOCK = new BetaPredictionLockType(),
+                BETA_PREDICTION_END = new BetaPredictionEndType(),
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHEER = new ChannelCheerType(),
                 CHANNEL_FOLLOW = new ChannelFollowType(),

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -2,6 +2,10 @@ package com.github.twitch4j.eventsub.events;
 
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.eventsub.domain.Contribution;
+import com.github.twitch4j.eventsub.domain.PollStatus;
+import com.github.twitch4j.eventsub.domain.PredictionColor;
+import com.github.twitch4j.eventsub.domain.PredictionOutcome;
+import com.github.twitch4j.eventsub.domain.PredictionStatus;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
 import com.github.twitch4j.eventsub.domain.StreamType;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +61,159 @@ public class EventSubEventTest {
 
         assertTrue(event.isPermanent());
         assertNull(event.getEndsAt());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelPollBeginEvent")
+    public void deserializePollBeginEvent() {
+        ChannelPollBeginEvent event = jsonToObject(
+            "{\"id\":\"1243456\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"title\":\"Aren’t shoes just really hard socks?\",\"choices\":[{\"id\":\"123\",\"title\":\"Yeah!\"}," +
+                "{\"id\":\"124\",\"title\":\"No!\"},{\"id\":\"125\",\"title\":\"Maybe!\"}],\"bits_voting\":{\"is_enabled\":true,\"amount_per_vote\":10},\"channel_points_voting\":{\"is_enabled\":true,\"amount_per_vote\":10}," +
+                "\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"ends_at\":\"2020-07-15T17:16:08.17106713Z\"}",
+            ChannelPollBeginEvent.class
+        );
+
+        assertNotNull(event);
+        assertEquals("1243456", event.getPollId());
+        assertEquals("Aren’t shoes just really hard socks?", event.getTitle());
+        assertNotNull(event.getChoices());
+        assertEquals(3, event.getChoices().size());
+        assertEquals("123", event.getChoices().get(0).getId());
+        assertEquals("Maybe!", event.getChoices().get(2).getTitle());
+        assertNotNull(event.getBitsVoting());
+        assertTrue(event.getBitsVoting().isEnabled());
+        assertNotNull(event.getChannelPointsVoting());
+        assertEquals(10, event.getChannelPointsVoting().getAmountPerVote());
+        assertEquals(Instant.parse("2020-07-15T17:16:03.17106713Z"), event.getStartedAt());
+        assertEquals(Instant.parse("2020-07-15T17:16:08.17106713Z"), event.getEndsAt());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelPollProgressEvent")
+    public void deserializePollProgressEvent() {
+        ChannelPollProgressEvent event = jsonToObject(
+            "{\"id\":\"1243456\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"title\":\"Aren’t shoes just really hard socks?\",\"choices\":[{\"id\":\"123\",\"title\":\"Yeah!\"," +
+                "\"bits_votes\":5,\"channel_points_votes\":7,\"votes\":12},{\"id\":\"124\",\"title\":\"No!\",\"bits_votes\":10,\"channel_points_votes\":4,\"votes\":14},{\"id\":\"125\",\"title\":\"Maybe!\",\"bits_votes\":0,\"channel_points_votes\":7," +
+                "\"votes\":7}],\"bits_voting\":{\"is_enabled\":true,\"amount_per_vote\":10},\"channel_points_voting\":{\"is_enabled\":true,\"amount_per_vote\":10},\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"ends_at\":\"2020-07-15T17:16:08" +
+                ".17106713Z\"}",
+            ChannelPollProgressEvent.class
+        );
+
+        assertNotNull(event);
+        assertNotNull(event.getChoices());
+        assertEquals(3, event.getChoices().size());
+        assertNotNull(event.getChoices().get(0));
+        assertEquals(5, event.getChoices().get(0).getBitsVotes());
+        assertNotNull(event.getChoices().get(1));
+        assertEquals(4, event.getChoices().get(1).getChannelPointsVotes());
+        assertNotNull(event.getChoices().get(2));
+        assertEquals(7, event.getChoices().get(2).getVotes());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelPollEndEvent")
+    public void deserializePollEndEvent() {
+        ChannelPollEndEvent event = jsonToObject(
+            "{\"id\":\"1243456\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"title\":\"Aren’t shoes just really hard socks?\",\"choices\":[{\"id\":\"123\",\"title\":\"Blue\"," +
+                "\"bits_votes\":50,\"channel_points_votes\":70,\"votes\":120},{\"id\":\"124\",\"title\":\"Yellow\",\"bits_votes\":100,\"channel_points_votes\":40,\"votes\":140},{\"id\":\"125\",\"title\":\"Green\",\"bits_votes\":10," +
+                "\"channel_points_votes\":70,\"votes\":80}],\"bits_voting\":{\"is_enabled\":true,\"amount_per_vote\":10},\"channel_points_voting\":{\"is_enabled\":true,\"amount_per_vote\":10},\"status\":\"completed\",\"started_at\":\"2020-07-15T17:16:03" +
+                ".17106713Z\",\"ended_at\":\"2020-07-15T17:16:11.17106713Z\"}",
+            ChannelPollEndEvent.class
+        );
+
+        assertNotNull(event);
+        assertEquals(PollStatus.COMPLETED, event.getStatus());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelPredictionBeginEvent")
+    public void deserializePredictionBeginEvent() {
+        ChannelPredictionBeginEvent event = jsonToObject(
+            "{\"id\":\"1243456\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"title\":\"Aren’t shoes just really hard socks?\",\"outcomes\":[{\"id\":\"1243456\",\"title\":\"Yeah!\"," +
+                "\"color\":\"blue\"},{\"id\":\"2243456\",\"title\":\"No!\",\"color\":\"pink\"}],\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"locks_at\":\"2020-07-15T17:21:03.17106713Z\"}",
+            ChannelPredictionBeginEvent.class
+        );
+
+        assertNotNull(event);
+        assertEquals("1243456", event.getPredictionId());
+        assertEquals("Aren’t shoes just really hard socks?", event.getTitle());
+        assertNotNull(event.getOutcomes());
+        assertEquals(2, event.getOutcomes().size());
+        assertNotNull(event.getOutcomes().get(0));
+        assertEquals("1243456", event.getOutcomes().get(0).getId());
+        assertEquals("Yeah!", event.getOutcomes().get(0).getTitle());
+        assertEquals(PredictionColor.BLUE, event.getOutcomes().get(0).getColor());
+        assertNotNull(event.getOutcomes().get(1));
+        assertEquals(PredictionColor.PINK, event.getOutcomes().get(1).getColor());
+        assertEquals(Instant.parse("2020-07-15T17:16:03.17106713Z"), event.getStartedAt());
+        assertEquals(Instant.parse("2020-07-15T17:21:03.17106713Z"), event.getLocksAt());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelPredictionProgressEvent")
+    public void deserializePredictionProgressEvent() {
+        ChannelPredictionProgressEvent event = jsonToObject(
+            "{\"id\":\"1243456\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"title\":\"Aren’t shoes just really hard socks?\",\"outcomes\":[{\"id\":\"1243456\",\"title\":\"Yeah!\"," +
+                "\"color\":\"blue\",\"users\":10,\"channel_points\":15000,\"top_predictors\":[{\"user_name\":\"Cool_User\",\"user_login\":\"cool_user\",\"user_id\":1234,\"channel_points_won\":null,\"channel_points_used\":500}," +
+                "{\"user_name\":\"Coolest_User\",\"user_login\":\"coolest_user\",\"user_id\":1236,\"channel_points_won\":null,\"channel_points_used\":200}]},{\"id\":\"2243456\",\"title\":\"No!\",\"color\":\"pink\"," +
+                "\"top_predictors\":[{\"user_name\":\"Cooler_User\",\"user_login\":\"cooler_user\",\"user_id\":12345,\"channel_points_won\":null,\"channel_points_used\":5000}]}],\"started_at\":\"2020-07-15T17:16:03.17106713Z\"," +
+                "\"locks_at\":\"2020-07-15T17:21:03.17106713Z\"}",
+            ChannelPredictionProgressEvent.class
+        );
+
+        assertNotNull(event);
+        assertNotNull(event.getOutcomes());
+        assertEquals(2, event.getOutcomes().size());
+
+        PredictionOutcome blue = event.getOutcomes().get(0);
+        assertNotNull(blue);
+        assertEquals(10, blue.getUsers());
+        assertEquals(15000, blue.getChannelPoints());
+        assertNotNull(blue.getTopPredictors());
+        assertNotNull(blue.getTopPredictors().get(0));
+        assertEquals("1234", blue.getTopPredictors().get(0).getUserId());
+        assertNotNull(blue.getTopPredictors().get(1));
+        assertEquals(200, blue.getTopPredictors().get(1).getChannelPointsUsed());
+
+        PredictionOutcome pink = event.getOutcomes().get(1);
+        assertNotNull(pink);
+        assertNotNull(pink.getTopPredictors());
+        assertEquals(1, pink.getTopPredictors().size());
+        assertNotNull(pink.getTopPredictors().get(0));
+        assertEquals("cooler_user", pink.getTopPredictors().get(0).getUserLogin());
+        assertEquals("Cooler_User", pink.getTopPredictors().get(0).getUserName());
+        assertNull(pink.getTopPredictors().get(0).getChannelPointsWon());
+
+        assertNotNull(event.getLocksAt());
+    }
+
+    @Test
+    @DisplayName("Deserialize ChannelPredictionEndEvent")
+    @SuppressWarnings("ConstantConditions")
+    public void deserializePredictionEndEvent() {
+        ChannelPredictionEndEvent event = jsonToObject(
+            "{\"id\":\"1243456\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"title\":\"Aren’t shoes just really hard socks?\",\"winning_outcome_id\":\"12345\"," +
+                "\"outcomes\":[{\"id\":\"12345\",\"title\":\"Yeah!\",\"color\":\"blue\",\"users\":2,\"channel_points\":15000,\"top_predictors\":[{\"user_name\":\"Cool_User\",\"user_login\":\"cool_user\",\"user_id\":1234,\"channel_points_won\":10000," +
+                "\"channel_points_used\":500},{\"user_name\":\"Coolest_User\",\"user_login\":\"coolest_user\",\"user_id\":1236,\"channel_points_won\":5000,\"channel_points_used\":100}]},{\"id\":\"22435\",\"title\":\"No!\",\"users\":2," +
+                "\"channel_points\":200,\"color\":\"pink\",\"top_predictors\":[{\"user_name\":\"Cooler_User\",\"user_login\":\"cooler_user\",\"user_id\":12345,\"channel_points_won\":null,\"channel_points_used\":100},{\"user_name\":\"Elite_User\"," +
+                "\"user_login\":\"elite_user\",\"user_id\":1337,\"channel_points_won\":null,\"channel_points_used\":100}]}],\"status\":\"resolved\",\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"locked_at\":\"2020-07-15T17:16:11.17106713Z\"," +
+                "\"ended_at\":\"2020-07-15T17:16:11.17106713Z\"}",
+            ChannelPredictionEndEvent.class
+        );
+
+        assertNotNull(event);
+        assertEquals("12345", event.getWinningOutcomeId());
+        assertTrue(event.getWinningOutcome().isPresent());
+        assertNotNull(event.getOutcomes());
+        assertEquals(2, event.getOutcomes().size());
+        assertNotNull(event.getOutcomes().get(0));
+        assertNotNull(event.getOutcomes().get(0).getTopPredictors());
+        assertEquals(2, event.getOutcomes().get(0).getTopPredictors().size());
+        assertNotNull(event.getOutcomes().get(0).getTopPredictors().get(0));
+        assertEquals(10000, event.getOutcomes().get(0).getTopPredictors().get(0).getChannelPointsWon());
+        assertEquals(PredictionStatus.RESOLVED, event.getStatus());
+        assertEquals(Instant.parse("2020-07-15T17:16:11.17106713Z"), event.getLockedAt());
+        assertEquals(Instant.parse("2020-07-15T17:16:11.17106713Z"), event.getEndedAt());
     }
 
     @Test

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -807,11 +807,11 @@ public interface TwitchHelix {
      * <p>
      * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
-     * @param authToken     User OAuth token from the broadcaster with the channel:read:polls scope.
-     * @param broadcasterId The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
-     * @param pollIds       ID of a poll. Filters results to one or more specific polls. Not providing one or more IDs will return the full list of polls for the authenticated channel. Maximum: 100.
-     * @param after         Cursor for forward pagination: The cursor value specified here is from the pagination response field of a prior query.
-     * @param limit         Maximum number of objects to return. Maximum: 20. Default: 20.
+     * @param authToken     Required: User OAuth token from the broadcaster with the channel:read:polls scope.
+     * @param broadcasterId Required: The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param pollIds       Optional: ID of a poll. Filters results to one or more specific polls. Not providing one or more IDs will return the full list of polls for the authenticated channel. Maximum: 100.
+     * @param after         Optional: Cursor for forward pagination: The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit         Optional: Maximum number of objects to return. Maximum: 20. Default: 20.
      * @return PollsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_READ
      */
@@ -873,11 +873,11 @@ public interface TwitchHelix {
      * <p>
      * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
-     * @param authToken     User OAuth token from the broadcaster with the channel:read:predictions scope.
-     * @param broadcasterId The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
-     * @param predictionId  ID of a Prediction. Filters results to one or more specific Predictions. Not providing one or more IDs will return the full list of Predictions for the authenticated channel. Maximum: 100
-     * @param after         The cursor value specified here is from the pagination response field of a prior query.
-     * @param limit         Maximum number of objects to return. Maximum: 20. Default: 20.
+     * @param authToken     Required: User OAuth token from the broadcaster with the channel:read:predictions scope.
+     * @param broadcasterId Required: The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param predictionId  Optional: ID of a Prediction. Filters results to one or more specific Predictions. Not providing one or more IDs will return the full list of Predictions for the authenticated channel. Maximum: 100
+     * @param after         Optional: The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit         Optional: Maximum number of objects to return. Maximum: 20. Default: 20.
      * @return PredictionsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_READ
      */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.helix;
 
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.feign.ObjectToJsonExpander;
 import com.github.twitch4j.eventsub.EventSubSubscription;
 import com.github.twitch4j.eventsub.EventSubSubscriptionStatus;
+import com.github.twitch4j.eventsub.domain.PollStatus;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
 import com.github.twitch4j.helix.domain.*;
 import com.github.twitch4j.helix.webhooks.domain.WebhookRequest;
@@ -797,6 +799,143 @@ public interface TwitchHelix {
     ) {
         return this.getModeratorEvents(authToken, broadcasterId, userIds, after, 20);
     }
+
+    /**
+     * Get information about all polls or specific polls for a Twitch channel.
+     * <p>
+     * Poll information is available for 90 days.
+     * <p>
+     * This endpoint is currently available as part of a public beta and should not be used in production environments.
+     *
+     * @param authToken     User OAuth token from the broadcaster with the channel:read:polls scope.
+     * @param broadcasterId The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param pollIds       ID of a poll. Filters results to one or more specific polls. Not providing one or more IDs will return the full list of polls for the authenticated channel. Maximum: 100.
+     * @param after         Cursor for forward pagination: The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit         Maximum number of objects to return. Maximum: 20. Default: 20.
+     * @return PollsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_READ
+     */
+    @Unofficial
+    @RequestLine("GET /polls?broadcaster_id={broadcaster_id}&id={id}&after={after}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<PollsList> getPolls(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("id") List<String> pollIds,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    );
+
+    /**
+     * Create a poll for a specific Twitch channel.
+     * <p>
+     * This endpoint is currently available as part of a public beta and should not be used in production environments.
+     *
+     * @param authToken User OAuth token from the broadcaster with the channel:manage:polls scope.
+     * @param poll      The new poll to be created. Required: broadcaster_id, title, choices, choice.title, duration. Optional: bits_voting_enabled, bits_per_vote, channel_points_voting_enabled, channel_points_per_vote.
+     * @return PollsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_MANAGE
+     */
+    @Unofficial
+    @RequestLine("POST /polls")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    HystrixCommand<PollsList> createPoll(
+        @Param("token") String authToken,
+        Poll poll
+    );
+
+    /**
+     * End a poll that is currently active.
+     * <p>
+     * This endpoint is currently available as part of a public beta and should not be used in production environments.
+     *
+     * @param authToken User OAuth token from the broadcaster with the channel:manage:polls scope.
+     * @param poll      The poll to be ended. Required: broadcaster_id, id, status (must be TERMINATED or ARCHIVED, depending on whether it should be viewed publicly).
+     * @return PollsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_MANAGE
+     */
+    @Unofficial
+    @RequestLine("PATCH /polls")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    HystrixCommand<PollsList> endPoll(
+        @Param("token") String authToken,
+        Poll poll
+    );
+
+    /**
+     * Get information about all Channel Points Predictions or specific Channel Points Predictions for a Twitch channel.
+     * <p>
+     * This endpoint is currently available as part of a public beta and should not be used in production environments.
+     *
+     * @param authToken     User OAuth token from the broadcaster with the channel:read:predictions scope.
+     * @param broadcasterId The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param predictionId  ID of a Prediction. Filters results to one or more specific Predictions. Not providing one or more IDs will return the full list of Predictions for the authenticated channel. Maximum: 100
+     * @param after         The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit         Maximum number of objects to return. Maximum: 20. Default: 20.
+     * @return PredictionsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_READ
+     */
+    @Unofficial
+    @RequestLine("GET /predictions?broadcaster_id={broadcaster_id}&id={id}&after={after}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<PredictionsList> getPredictions(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("id") List<String> predictionId,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    );
+
+    /**
+     * Create a Channel Points Prediction for a specific Twitch channel.
+     * <p>
+     * This endpoint is currently available as part of a public beta and should not be used in production environments.
+     *
+     * @param authToken  User OAuth token from the broadcaster with the channel:manage:predictions scope.
+     * @param prediction The prediction to be created. Required: broadcaster_id, title, outcomes, outcome.title, prediction_window.
+     * @return PredictionsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_MANAGE
+     */
+    @Unofficial
+    @RequestLine("POST /predictions")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    HystrixCommand<PredictionsList> createPrediction(
+        @Param("token") String authToken,
+        Prediction prediction
+    );
+
+    /**
+     * Lock, resolve, or cancel a Channel Points Prediction.
+     * <p>
+     * Active Predictions can be updated to be "locked," "resolved," or "canceled."
+     * Locked Predictions can be updated to be "resolved" or "canceled."
+     * <p>
+     * This endpoint is currently available as part of a public beta and should not be used in production environments.
+     *
+     * @param authToken  User OAuth token from the broadcaster with the channel:manage:predictions scope.
+     * @param prediction The prediction to be ended. Required: broadcaster_id, id, status (RESOLVED or CANCELED or LOCKED). Optional: winning_outcome_id (must be present for RESOLVED status).
+     * @return PredictionsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_MANAGE
+     */
+    @Unofficial
+    @RequestLine("PATCH /predictions")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    HystrixCommand<PredictionsList> endPrediction(
+        @Param("token") String authToken,
+        Prediction prediction
+    );
 
     /**
      * Gets games sorted by number of current viewers on Twitch, most popular first.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
@@ -1,0 +1,114 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.PollChoice;
+import com.github.twitch4j.eventsub.domain.PollStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.experimental.Accessors;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+public class Poll {
+
+    /**
+     * ID of the poll.
+     */
+    private String id;
+
+    /**
+     * ID of the broadcaster.
+     */
+    private String broadcasterId;
+
+    /**
+     * Display name of the broadcaster.
+     */
+    private String broadcasterName;
+
+    /**
+     * Login name of the broadcaster.
+     */
+    private String broadcasterLogin;
+
+    /**
+     * Question displayed for the poll. Maximum: 60 characters.
+     */
+    private String title;
+
+    /**
+     * The poll choices. Minimum: 2 choices. Maximum: 5 choices.
+     */
+    private List<PollChoice> choices;
+
+    /**
+     * Indicates whether Bits can be used for voting. Default: false.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("bits_voting_enabled")
+    private Boolean isBitsVotingEnabled;
+
+    /**
+     * Number of Bits required to vote once with Bits. Minimum: 0. Maximum: 10000.
+     */
+    private Integer bitsPerVote;
+
+    /**
+     * Indicates whether Channel Points can be used for voting. Default: false.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("channel_points_voting_enabled")
+    private Boolean isChannelPointsVotingEnabled;
+
+    /**
+     * Number of Channel Points required to vote once with Channel Points. Minimum: 0. Maximum: 1000000.
+     */
+    private Integer channelPointsPerVote;
+
+    /**
+     * Poll status.
+     */
+    private PollStatus status;
+
+    /**
+     * Total duration for the poll (in seconds). Minimum: 15. Maximum: 1800.
+     */
+    @JsonProperty("duration")
+    private Integer durationSeconds;
+
+    /**
+     * UTC timestamp for the poll’s start time.
+     */
+    private Instant startedAt;
+
+    /**
+     * UTC timestamp for the poll’s start time.
+     */
+    @Nullable
+    private Instant endedAt;
+
+    /**
+     * @return the total duration for the poll.
+     */
+    @Nullable
+    public Duration getDuration() {
+        return durationSeconds != null ? Duration.ofSeconds(durationSeconds.longValue()) : null;
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.eventsub.domain.PollChoice;
 import com.github.twitch4j.eventsub.domain.PollStatus;
@@ -25,6 +27,7 @@ import java.util.List;
 @Jacksonized
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Poll {
 
     /**
@@ -107,6 +110,7 @@ public class Poll {
      * @return the total duration for the poll.
      */
     @Nullable
+    @JsonIgnore
     public Duration getDuration() {
         return durationSeconds != null ? Duration.ofSeconds(durationSeconds.longValue()) : null;
     }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.Singular;
 import lombok.With;
 import lombok.experimental.Accessors;
 import lombok.extern.jackson.Jacksonized;
@@ -58,6 +59,7 @@ public class Poll {
     /**
      * The poll choices. Minimum: 2 choices. Maximum: 5 choices.
      */
+    @Singular
     private List<PollChoice> choices;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/PollsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/PollsList.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class PollsList {
+
+    @JsonProperty("data")
+    private List<Poll> polls;
+
+    /**
+     * Cursor for forward pagination: tells the server where to start fetching the next set of results in a multi-page response.
+     */
+    private HelixPagination pagination;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @With
 @Data
@@ -100,6 +101,20 @@ public class Prediction {
     @JsonIgnore
     public Duration getPredictionWindow() {
         return predictionWindowSeconds != null ? Duration.ofSeconds(predictionWindowSeconds.longValue()) : null;
+    }
+
+    /**
+     * @return the winning PredictionOutcome, in an optional wrapper
+     */
+    @JsonIgnore
+    public Optional<PredictionOutcome> getWinningOutcome() {
+        if (winningOutcomeId != null) {
+            for (PredictionOutcome outcome : getOutcomes()) {
+                if (outcome != null && winningOutcomeId.equals(outcome.getId()))
+                    return Optional.of(outcome);
+            }
+        }
+        return Optional.empty();
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.eventsub.domain.PredictionOutcome;
 import com.github.twitch4j.eventsub.domain.PredictionStatus;
@@ -24,6 +26,7 @@ import java.util.List;
 @Jacksonized
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Prediction {
 
     /**
@@ -94,6 +97,7 @@ public class Prediction {
      * @return the total duration for the Prediction.
      */
     @Nullable
+    @JsonIgnore
     public Duration getPredictionWindow() {
         return predictionWindowSeconds != null ? Duration.ofSeconds(predictionWindowSeconds.longValue()) : null;
     }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.Singular;
 import lombok.With;
 import lombok.extern.jackson.Jacksonized;
 import org.jetbrains.annotations.Nullable;
@@ -64,6 +65,7 @@ public class Prediction {
     /**
      * The possible outcomes for the Prediction. Size must be 2.
      */
+    @Singular
     private List<PredictionOutcome> outcomes;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Prediction.java
@@ -1,0 +1,101 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.PredictionOutcome;
+import com.github.twitch4j.eventsub.domain.PredictionStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+public class Prediction {
+
+    /**
+     * ID of the Prediction.
+     */
+    private String id;
+
+    /**
+     * ID of the broadcaster.
+     */
+    private String broadcasterId;
+
+    /**
+     * Display name of the broadcaster.
+     */
+    private String broadcasterName;
+
+    /**
+     * Login name of the broadcaster.
+     */
+    private String broadcasterLogin;
+
+    /**
+     * Title for the Prediction. Maximum: 45 characters.
+     */
+    private String title;
+
+    /**
+     * ID of the winning outcome. If the status is ACTIVE, this is set to null.
+     */
+    @Nullable
+    private String winningOutcomeId;
+
+    /**
+     * The possible outcomes for the Prediction. Size must be 2.
+     */
+    private List<PredictionOutcome> outcomes;
+
+    /**
+     * Total duration for the Prediction (in seconds). Minimum: 1. Maximum: 1800.
+     */
+    @JsonProperty("prediction_window")
+    private Integer predictionWindowSeconds;
+
+    /**
+     * Status of the Prediction.
+     */
+    private PredictionStatus status;
+
+    /**
+     * UTC timestamp for the Prediction’s start time.
+     */
+    private Instant createdAt;
+
+    /**
+     * UTC timestamp for when the Prediction ended. If the status is ACTIVE, this is set to null.
+     */
+    @Nullable
+    private Instant endedAt;
+
+    /**
+     * UTC timestamp for when the Prediction was locked. If the status is not LOCKED, this is set to null.
+     */
+    @Nullable
+    private Instant lockedAt;
+
+    /**
+     * @return the total duration for the Prediction.
+     */
+    @Nullable
+    public Duration getPredictionWindow() {
+        return predictionWindowSeconds != null ? Duration.ofSeconds(predictionWindowSeconds.longValue()) : null;
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/PredictionsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/PredictionsList.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class PredictionsList {
+
+    @JsonProperty("data")
+    private List<Prediction> predictions;
+
+    /**
+     * Cursor for forward pagination: tells the server where to start fetching the next set of results in a multi-page response.
+     */
+    private HelixPagination pagination;
+
+}

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/PollsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/PollsServiceTest.java
@@ -1,0 +1,102 @@
+package com.github.twitch4j.helix.endpoints;
+
+import com.github.twitch4j.eventsub.domain.PollChoice;
+import com.github.twitch4j.eventsub.domain.PollStatus;
+import com.github.twitch4j.helix.domain.Poll;
+import com.github.twitch4j.helix.domain.PollsList;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import static com.github.twitch4j.common.util.TypeConvert.jsonToObject;
+import static com.github.twitch4j.common.util.TypeConvert.objectToJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+@Tag("unittest")
+public class PollsServiceTest extends AbstractEndpointTest {
+
+    @Test
+    @DisplayName("Deserialize PollsList from getPolls example")
+    public void deserializePollsList() {
+        // note: slightly modified from the sample in the official docs
+        String json = "{\"data\":[{\"id\":\"ed961efd-8a3f-4cf5-a9d0-e616c590cd2a\",\"broadcaster_id\":\"55696719\",\"broadcaster_name\":\"TwitchDev\",\"broadcaster_login\":\"twitchdev\",\"title\":\"Heads or Tails?\"," +
+            "\"choices\":[{\"id\":\"4c123012-1351-4f33-84b7-43856e7a0f47\",\"title\":\"Heads\",\"votes\":1,\"channel_points_votes\":69,\"bits_votes\":0},{\"id\":\"279087e3-54a7-467e-bcd0-c1393fcea4f0\",\"title\":\"Tails\",\"votes\":1," +
+            "\"channel_points_votes\":0,\"bits_votes\":1}],\"bits_voting_enabled\":true,\"bits_per_vote\":0,\"channel_points_voting_enabled\":true,\"channel_points_per_vote\":69,\"status\":\"ACTIVE\",\"duration\":1800," +
+            "\"started_at\":\"2021-03-19T06:08:33.871278372Z\"}],\"pagination\":{}}";
+
+        PollsList polls = jsonToObject(json, PollsList.class);
+        assertNotNull(polls);
+        assertNotNull(polls.getPolls());
+        assertEquals(1, polls.getPolls().size());
+
+        Poll poll = polls.getPolls().get(0);
+        assertNotNull(poll);
+        assertEquals("ed961efd-8a3f-4cf5-a9d0-e616c590cd2a", poll.getId());
+        assertEquals("55696719", poll.getBroadcasterId());
+        assertEquals("TwitchDev", poll.getBroadcasterName());
+        assertEquals("twitchdev", poll.getBroadcasterLogin());
+        assertEquals("Heads or Tails?", poll.getTitle());
+        assertTrue(poll.isBitsVotingEnabled());
+        assertEquals(0, poll.getBitsPerVote());
+        assertTrue(poll.isChannelPointsVotingEnabled());
+        assertEquals(69, poll.getChannelPointsPerVote());
+        assertEquals(PollStatus.ACTIVE, poll.getStatus());
+        assertEquals(1800, poll.getDurationSeconds());
+        assertEquals(Instant.parse("2021-03-19T06:08:33.871278372Z"), poll.getStartedAt());
+        assertNull(poll.getEndedAt());
+        assertNotNull(poll.getChoices());
+        assertEquals(2, poll.getChoices().size());
+        assertNotNull(poll.getChoices().get(0));
+        assertEquals("4c123012-1351-4f33-84b7-43856e7a0f47", poll.getChoices().get(0).getId());
+        assertEquals(69, poll.getChoices().get(0).getChannelPointsVotes());
+        assertNotNull(poll.getChoices().get(1));
+        assertEquals("279087e3-54a7-467e-bcd0-c1393fcea4f0", poll.getChoices().get(1).getId());
+        assertEquals(1, poll.getChoices().get(1).getBitsVotes());
+    }
+
+    @Test
+    @DisplayName("Serialize Poll as POJO body for createPoll")
+    public void serializeCreatePoll() {
+        Poll poll = Poll.builder()
+            .broadcasterId("141981764")
+            .title("Heads or Tails?")
+            .isChannelPointsVotingEnabled(true)
+            .channelPointsPerVote(100)
+            .durationSeconds(1800)
+            .choices(
+                Arrays.asList(
+                    PollChoice.builder().title("Heads").build(),
+                    PollChoice.builder().title("Tails").build()
+                )
+            )
+            .build();
+
+        assertEquals(poll, jsonToObject(objectToJson(poll), Poll.class));
+        assertEquals(
+            poll,
+            jsonToObject("{\"broadcaster_id\":\"141981764\",\"title\":\"Heads or Tails?\",\"choices\":[{\"title\":\"Heads\"},{\"title\":\"Tails\"}],\"channel_points_voting_enabled\":true,\"channel_points_per_vote\":100,\"duration\":1800}", Poll.class)
+        );
+    }
+
+    @Test
+    @DisplayName("Serialize Poll as POJO body for endPoll")
+    public void serializeEndPoll() {
+        Poll poll = Poll.builder()
+            .broadcasterId("141981764")
+            .id("ed961efd-8a3f-4cf5-a9d0-e616c590cd2a")
+            .status(PollStatus.TERMINATED)
+            .build();
+
+        assertEquals(poll, jsonToObject(objectToJson(poll), Poll.class));
+        assertEquals(poll, jsonToObject("{\"broadcaster_id\":\"141981764\",\"id\":\"ed961efd-8a3f-4cf5-a9d0-e616c590cd2a\",\"status\":\"TERMINATED\"}", Poll.class));
+    }
+
+}

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/PollsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/PollsServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.Arrays;
 
 import static com.github.twitch4j.common.util.TypeConvert.jsonToObject;
 import static com.github.twitch4j.common.util.TypeConvert.objectToJson;
@@ -71,12 +70,8 @@ public class PollsServiceTest extends AbstractEndpointTest {
             .isChannelPointsVotingEnabled(true)
             .channelPointsPerVote(100)
             .durationSeconds(1800)
-            .choices(
-                Arrays.asList(
-                    PollChoice.builder().title("Heads").build(),
-                    PollChoice.builder().title("Tails").build()
-                )
-            )
+            .choice(PollChoice.builder().title("Heads").build())
+            .choice(PollChoice.builder().title("Tails").build())
             .build();
 
         assertEquals(poll, jsonToObject(objectToJson(poll), Poll.class));

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/PredictionsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/PredictionsServiceTest.java
@@ -1,0 +1,96 @@
+package com.github.twitch4j.helix.endpoints;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.eventsub.domain.PredictionColor;
+import com.github.twitch4j.eventsub.domain.PredictionOutcome;
+import com.github.twitch4j.eventsub.domain.PredictionStatus;
+import com.github.twitch4j.helix.domain.Prediction;
+import com.github.twitch4j.helix.domain.PredictionsList;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import static com.github.twitch4j.common.util.TypeConvert.jsonToObject;
+import static com.github.twitch4j.common.util.TypeConvert.objectToJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Slf4j
+@Tag("unittest")
+public class PredictionsServiceTest extends AbstractEndpointTest {
+
+    @Test
+    @DisplayName("Deserialize PredictionsList from getPredictions example")
+    public void deserializePredictionsList() {
+        String json = "{\"data\":[{\"id\":\"d6676d5c-c86e-44d2-bfc4-100fb48f0656\",\"broadcaster_id\":\"55696719\",\"broadcaster_name\":\"TwitchDev\",\"broadcaster_login\":\"twitchdev\",\"title\":\"Will there be any leaks today?\"," +
+            "\"winning_outcome_id\":null,\"outcomes\":[{\"id\":\"021e9234-5893-49b4-982e-cfe9a0aaddd9\",\"title\":\"Yes\",\"users\":0,\"channel_points\":0,\"top_predictors\":null,\"color\":\"BLUE\"},{\"id\":\"ded84c26-13cb-4b48-8cb5-5bae3ec3a66e\"," +
+            "\"title\":\"No\",\"users\":0,\"channel_points\":0,\"top_predictors\":null,\"color\":\"PINK\"}],\"prediction_window\":600,\"status\":\"ACTIVE\",\"created_at\":\"2021-04-28T16:03:06.320848689Z\",\"ended_at\":null,\"locked_at\":null}]," +
+            "\"pagination\":{}}";
+
+        PredictionsList result = TypeConvert.jsonToObject(json, PredictionsList.class);
+        assertNotNull(result);
+        assertNotNull(result.getPredictions());
+        assertEquals(1, result.getPredictions().size());
+
+        Prediction prediction = result.getPredictions().get(0);
+        assertNotNull(prediction);
+        assertEquals("d6676d5c-c86e-44d2-bfc4-100fb48f0656", prediction.getId());
+        assertEquals("55696719", prediction.getBroadcasterId());
+        assertEquals("TwitchDev", prediction.getBroadcasterName());
+        assertEquals("twitchdev", prediction.getBroadcasterLogin());
+        assertEquals("Will there be any leaks today?", prediction.getTitle());
+        assertNull(prediction.getWinningOutcomeId());
+        assertEquals(600, prediction.getPredictionWindowSeconds());
+        assertEquals(PredictionStatus.ACTIVE, prediction.getStatus());
+        assertEquals(Instant.parse("2021-04-28T16:03:06.320848689Z"), prediction.getCreatedAt());
+        assertNull(prediction.getEndedAt());
+        assertNull(prediction.getLockedAt());
+        assertNotNull(prediction.getOutcomes());
+        assertEquals(2, prediction.getOutcomes().size());
+        assertNotNull(prediction.getOutcomes().get(0));
+        assertEquals("021e9234-5893-49b4-982e-cfe9a0aaddd9", prediction.getOutcomes().get(0).getId());
+        assertEquals(PredictionColor.BLUE, prediction.getOutcomes().get(0).getColor());
+        assertNotNull(prediction.getOutcomes().get(1));
+        assertEquals("ded84c26-13cb-4b48-8cb5-5bae3ec3a66e", prediction.getOutcomes().get(1).getId());
+        assertEquals(PredictionColor.PINK, prediction.getOutcomes().get(1).getColor());
+    }
+
+    @Test
+    @DisplayName("Serialize Prediction as POJO body for createPrediction")
+    public void serializeCreatePrediction() {
+        Prediction prediction = Prediction.builder()
+            .broadcasterId("141981764")
+            .title("Any leeks in the stream?")
+            .predictionWindowSeconds(120)
+            .outcomes(
+                Arrays.asList(
+                    PredictionOutcome.builder().title("Yes, give it time.").build(),
+                    PredictionOutcome.builder().title("Definitely not.").build()
+                )
+            )
+            .build();
+
+        assertEquals(prediction, jsonToObject(objectToJson(prediction), Prediction.class));
+        assertEquals(prediction, jsonToObject("{\"broadcaster_id\":\"141981764\",\"title\":\"Any leeks in the stream?\",\"outcomes\":[{\"title\":\"Yes, give it time.\"},{\"title\":\"Definitely not.\"}],\"prediction_window\":120}", Prediction.class));
+    }
+
+    @Test
+    @DisplayName("Serialize Prediction as POJO body for endPrediction")
+    public void serializeEndPrediction() {
+        Prediction prediction = Prediction.builder()
+            .broadcasterId("141981764")
+            .id("bc637af0-7766-4525-9308-4112f4cbf178")
+            .status(PredictionStatus.RESOLVED)
+            .winningOutcomeId("73085848-a94d-4040-9d21-2cb7a89374b7")
+            .build();
+
+        assertEquals(prediction, jsonToObject(objectToJson(prediction), Prediction.class));
+        assertEquals(prediction, jsonToObject("{\"broadcaster_id\":\"141981764\",\"id\":\"bc637af0-7766-4525-9308-4112f4cbf178\",\"status\":\"RESOLVED\",\"winning_outcome_id\":\"73085848-a94d-4040-9d21-2cb7a89374b7\"}", Prediction.class));
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
**Helix**

- Get Polls
- Create Poll
- End Poll
- Get Predictions
- Create Prediction
- End Prediction

**EventSub**

- Channel Poll Begin
- Channel Poll Progress
- Channel Poll End
- Channel Prediction Begin
- Channel Prediction Progress
- Channel Prediction Lock
- Channel Prediction End

### Additional Information
https://dev.twitch.tv/docs/change-log
