### PR TITLE
refactor: avoid double join of own channel on reconnect

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -441,7 +441,7 @@ public class TwitchChat implements ITwitchChat {
                             || baseUrl.equalsIgnoreCase(TWITCH_WEB_SOCKET_SERVER) // check whether the url is exactly the official one
                             || baseUrl.equalsIgnoreCase(TWITCH_WEB_SOCKET_SERVER.substring(0, TWITCH_WEB_SOCKET_SERVER.length() - 4)); // check whether the url matches without the port
                         sendTextToWebSocket(String.format("pass oauth:%s", sendRealPass ? chatCredential.getAccessToken() : CryptoUtils.generateNonce(30)), true);
-                        userName = chatCredential.getUserName();
+                        userName = String.valueOf(chatCredential.getUserName()).toLowerCase();
                     } else {
                         userName = "justinfan" + ThreadLocalRandom.current().nextInt(100000);
                     }
@@ -454,8 +454,8 @@ public class TwitchChat implements ITwitchChat {
 
                     // then join to own channel - required for sending or receiving whispers
                     if (chatCredential != null && chatCredential.getUserName() != null) {
-                        if (autoJoinOwnChannel)
-                            joinChannel(chatCredential.getUserName().toLowerCase());
+                        if (autoJoinOwnChannel && !currentChannels.contains(userName))
+                            joinChannel(userName);
                     } else {
                         log.warn("Chat: The whispers feature is currently not available because the provided credential does not hold information about the user. Please check the documentation on how to pass the token to the credentialManager where it will be enriched with the required information.");
                     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* User complaint about repeated warnings in logs: `WARN  com.github.twitch4j.chat.TwitchChat - Already joined channel <insert bot name>` https://discord.com/channels/143001431388061696/551499165646192650/839195881840181311

### Changes Proposed
* On connect, for the autoJoinOwnChannel logic, check whether the channel is already joined first

### Additional Information
This issue had no side effects other than the logs annoyance (i.e., a second JOIN wasn't being sent over the socket)
