### PR TITLE
fix: handle new channel terms changes under moderator pubsub

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -465,8 +465,15 @@ public class TwitchPubSub implements ITwitchPubSub {
 
                             } else if (topic.startsWith("chat_moderator_actions")) {
                                 String channelId = topic.substring(topic.lastIndexOf('.') + 1);
-                                ChatModerationAction data = TypeConvert.convertValue(msgData, ChatModerationAction.class);
-                                eventManager.publish(new ChatModerationEvent(channelId, data));
+                                if ("moderation_action".equalsIgnoreCase(type)) {
+                                    ChatModerationAction data = TypeConvert.convertValue(msgData, ChatModerationAction.class);
+                                    eventManager.publish(new ChatModerationEvent(channelId, data));
+                                } else if ("channel_terms_action".equalsIgnoreCase(type)) {
+                                    ChannelTermsAction data = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
+                                    eventManager.publish(new ChannelTermsEvent(channelId, data));
+                                } else {
+                                    log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                                }
                             } else if (topic.startsWith("following")) {
                                 final String channelId = topic.substring(topic.lastIndexOf('.') + 1);
                                 final FollowingData data = TypeConvert.jsonToObject(rawMessage, FollowingData.class);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelTermsAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelTermsAction.java
@@ -1,0 +1,88 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ChannelTermsAction {
+
+    /**
+     * The type of channel terms action that took place.
+     */
+    private Type type;
+
+    /**
+     * Unique id for the channel term.
+     */
+    private String id;
+
+    /**
+     * The ID of the channel where this action took place.
+     */
+    private String channelId;
+
+    /**
+     * The relevant text for this channel term.
+     */
+    private String text;
+
+    /**
+     * The user id of the executor of the channel terms action.
+     */
+    private String requesterId;
+
+    /**
+     * The user login name of the executor of the channel terms action.
+     */
+    private String requesterLogin;
+
+    /**
+     * UTC timestamp of when this term rule expires.
+     */
+    @Nullable
+    private Instant expiresAt;
+
+    /**
+     * UTC timestamp of when this term was last updated.
+     */
+    private Instant updatedAt;
+
+    /**
+     * Whether the action was executed by Automod.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("from_automod")
+    private Boolean isFromAutomod;
+
+    public enum Type {
+
+        /**
+         * Moderator added a blocked term to AutoMod.
+         */
+        ADD_BLOCKED_TERM,
+
+        /**
+         * Moderator added a permitted term to AutoMod.
+         */
+        ADD_PERMITTED_TERM,
+
+        /**
+         * Moderator deleted a blocked term from AutoMod.
+         */
+        DELETE_BLOCKED_TERM,
+
+        /**
+         * Moderator deleted a permitted term from AutoMod.
+         */
+        DELETE_PERMITTED_TERM
+
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class ChatModerationAction {
 
     /**
-     * The raw string for the class of moderation action. Can be "chat_channel_moderation" or "chat_login_moderation"
+     * The raw string for the class of moderation action. Can be "chat_channel_moderation" or "chat_login_moderation" or "chat_targeted_login_moderation"
      *
      * @see ChatModerationAction#getModType()
      */
@@ -170,7 +170,7 @@ public class ChatModerationAction {
             if ("chat_channel_moderation".equals(twitchString))
                 return CHANNEL;
 
-            if ("chat_login_moderation".equals(twitchString))
+            if ("chat_login_moderation".equals(twitchString) || "chat_targeted_login_moderation".equals(twitchString))
                 return LOGIN;
 
             // API inconsistency documented here https://github.com/twitchdev/issues/issues/99
@@ -276,25 +276,22 @@ public class ChatModerationAction {
          */
         UNRAID,
         /**
-         * The message was flagged by AutoMod for manual review
+         * A user's message was flagged by AutoMod for manual review.
+         */
+        AUTOMOD_MESSAGE_REJECTED("automod_message_rejected"),
+        /**
+         * The user's message was manually approved by a moderator after being flagged by Automod.
+         */
+        AUTOMOD_MESSAGE_APPROVED("automod_message_approved"),
+        /**
+         * The user's message was denied by a moderator after being flagged by Automod.
+         */
+        AUTOMOD_MESSAGE_DENIED("automod_message_denied"),
+        /**
+         * The message was flagged by AutoMod for manual review.
+         * This action is sent to moderators, rather than the user with the offending message.
          */
         AUTOMOD_REJECTED("automod_rejected"),
-        /**
-         * Moderator added a permitted term to AutoMod
-         */
-        ADD_PERMITTED_TERM("add_permitted_term"),
-        /**
-         * Moderator added a blocked term to AutoMod
-         */
-        ADD_BLOCKED_TERM("add_blocked_term"),
-        /**
-         * Moderator deleted a permitted term from AutoMod
-         */
-        DELETE_PERMITTED_TERM("delete_permitted_term"),
-        /**
-         * Moderator deleted a blocked term from AutoMod
-         */
-        DELETE_BLOCKED_TERM("delete_blocked_term"),
         /**
          * Moderator approved a message that was flagged by AutoMod
          */
@@ -304,8 +301,39 @@ public class ChatModerationAction {
          */
         DENIED_AUTOMOD_MESSAGE("denied_automod_message"),
         /**
-         * AutoMod settings were modified
+         * Moderator added a permitted term to AutoMod
+         *
+         * @deprecated use {@link com.github.twitch4j.pubsub.events.ChannelTermsEvent}
          */
+        @Deprecated
+        ADD_PERMITTED_TERM("add_permitted_term"),
+        /**
+         * Moderator added a blocked term to AutoMod
+         *
+         * @deprecated use {@link com.github.twitch4j.pubsub.events.ChannelTermsEvent}
+         */
+        @Deprecated
+        ADD_BLOCKED_TERM("add_blocked_term"),
+        /**
+         * Moderator deleted a permitted term from AutoMod
+         *
+         * @deprecated use {@link com.github.twitch4j.pubsub.events.ChannelTermsEvent}
+         */
+        @Deprecated
+        DELETE_PERMITTED_TERM("delete_permitted_term"),
+        /**
+         * Moderator deleted a blocked term from AutoMod
+         *
+         * @deprecated use {@link com.github.twitch4j.pubsub.events.ChannelTermsEvent}
+         */
+        @Deprecated
+        DELETE_BLOCKED_TERM("delete_blocked_term"),
+        /**
+         * AutoMod settings were modified
+         *
+         * @deprecated this action is no longer sent over this topic
+         */
+        @Deprecated
         MODIFIED_AUTOMOD_PROPERTIES("modified_automod_properties");
 
         @Getter

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelTermsEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChannelTermsEvent.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ChannelTermsAction;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChannelTermsEvent extends TwitchEvent {
+
+    /**
+     * The ID for the channel where the channel terms action took place.
+     */
+    String channelId;
+
+    /**
+     * Data regarding the channel terms action that took place.
+     */
+    ChannelTermsAction data;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Twitch made an undocumented change to this topic where the old parsing system would not properly handle add/remove blocked/permitted terms actions

### Changes Proposed
* Handle messages under `channel_terms_action` via `ChannelTermsEvent`
* For `moderation_action`, include `chat_targeted_login_moderation` under `ModerationType.LOGIN`
* Include `automod_message_rejected`, `automod_message_approved`, & `automod_message_denied` in `ModerationAction` enum

### Additional Information
https://github.com/Chatterino/chatterino2/issues/2682#issuecomment-831495637
https://github.com/Chatterino/chatterino2/issues/2626#issuecomment-831548361
