### PR TITLE
feat: implement unofficial automod-queue pubsub topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -169,6 +169,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForAutomodQueueEvents(OAuth2Credential credential, String userId, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "automod-queue." + userId + "." + channelId);
+    }
+
+    @Unofficial
     @Deprecated
     default PubSubSubscription listenForBountyBoardEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-bounty-board-events.cta." + channelId);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -398,6 +398,13 @@ public class TwitchPubSub implements ITwitchPubSub {
                                 PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(eventUser, body, permissions);
                                 eventManager.publish(privateMessageEvent);
 
+                            } else if (topic.startsWith("automod-queue")) {
+                                if ("automod_caught_message".equalsIgnoreCase(type)) {
+                                    AutomodCaughtMessageData data = TypeConvert.convertValue(msgData, AutomodCaughtMessageData.class);
+                                    eventManager.publish(new AutomodCaughtMessageEvent(data));
+                                } else {
+                                    log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                                }
                             } else if (topic.startsWith("community-boost-events-v1")) {
                                 if ("community-boost-progression".equals(type)) {
                                     CommunityBoostProgression progression = TypeConvert.convertValue(msgData, CommunityBoostProgression.class);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessage.java
@@ -1,0 +1,57 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class AutomodCaughtMessage {
+
+    private Content content;
+    private String id;
+    private Sender sender;
+    private Instant sentAt;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Content {
+        private String text;
+        private List<Fragment> fragments;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Fragment {
+        private String text;
+        private FragmentFlags automod;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class FragmentFlags {
+        private Map<String, Integer> topics;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Sender {
+        private String userId;
+        private String login;
+        private String displayName;
+        private String chatColor;
+        private List<Badge> badges;
+
+        @Data
+        @Setter(AccessLevel.PRIVATE)
+        public static class Badge {
+            private String id;
+            private String version;
+        }
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessageData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessageData.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class AutomodCaughtMessageData {
+
+    private AutomodContentClassification contentClassification;
+    private AutomodCaughtMessage message;
+    private String reasonCode;
+    private String resolverId;
+    private String resolverLogin;
+    private Status status;
+
+    public enum Status {
+        PENDING, @Deprecated APPROVED, ALLOWED, DENIED, EXPIRED, @JsonEnumDefaultValue INVALID
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodContentClassification.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodContentClassification.java
@@ -1,0 +1,18 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class AutomodContentClassification {
+
+    private Category category;
+    private Integer level;
+
+    public enum Category {
+        IDENTITY, SEXUAL, AGGRESSIVE, PROFANITY
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/AutomodCaughtMessageEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/AutomodCaughtMessageEvent.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.AutomodCaughtMessageData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class AutomodCaughtMessageEvent extends TwitchEvent {
+    AutomodCaughtMessageData data;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement `automod-queue.<user-id>.<channel-id>` unofficial pubsub topic to track automod acting against messages in chat

### Additional Information
https://github.com/Chatterino/chatterino2/issues/2682#issuecomment-831495637
