### PR TITLE
chore: resolve build warnings in gql / hide javadoc warnings - delombok

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,6 +136,9 @@ subprojects {
 	tasks {
 		// javadoc / html5 support
 		withType<Javadoc> {
+			// hide javadoc warnings (a lot from delombok)
+			(options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
+
 			if (JavaVersion.current().isJava9Compatible) {
 				(options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
 			}

--- a/graphql/build.gradle.kts
+++ b/graphql/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
 	id("com.apollographql.apollo") version "2.5.6"
 }
+
 // Dependencies
 dependencies {
 	// GraphQL
@@ -14,6 +15,10 @@ dependencies {
 	// Twitch4J Modules
 	api(project(":common"))
 	api(project(":auth"))
+}
+
+tasks.withType<io.freefair.gradle.plugins.lombok.tasks.Delombok> {
+	dependsOn("generateMainServiceApolloSources")
 }
 
 tasks.withType<Javadoc> {


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
- resolves a warning from the gql module (see below)
- hides the many javadoc warnings generated by delombok in the build-log.

### Additional Information

Warning:

```
Execution optimizations have been disabled for task ':graphql:delombok' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'twitch4j\graphql\build\generated\source\apollo\main\service'. Reason: Task ':graphql:delombok' uses this output of task ':graphql:generateMainServiceApolloSources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0/userguide/validation_problems.html#implicit_dependency for more details about this problem.
Gradle detected a problem with the following location: 'twitch4j\graphql\build\generated\source\apollo\main\service'. Reason: Task ':graphql:delombok' uses this output of task ':graphql:generateMainServiceApolloSources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0/userguide/validation_problems.html#implicit_dependency for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.0/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```