### PR TITLE
chore: bump openfeign from 11.1 to 11.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,10 +79,10 @@ subprojects {
 			api(group = "com.github.philippheuer.credentialmanager", name = "credentialmanager", version = "0.1.2")
 
 			// HTTP Client
-			api(group = "io.github.openfeign", name = "feign-slf4j", version = "11.1")
-			api(group = "io.github.openfeign", name = "feign-okhttp", version = "11.1")
-			api(group = "io.github.openfeign", name = "feign-jackson", version = "11.1")
-			api(group = "io.github.openfeign", name = "feign-hystrix", version = "11.1")
+			api(group = "io.github.openfeign", name = "feign-slf4j", version = "11.2")
+			api(group = "io.github.openfeign", name = "feign-okhttp", version = "11.2")
+			api(group = "io.github.openfeign", name = "feign-jackson", version = "11.2")
+			api(group = "io.github.openfeign", name = "feign-hystrix", version = "11.2")
 
 			// WebSocket
 			api(group = "com.neovisionaries", name = "nv-websocket-client", version = "2.14")


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by feign.DefaultMethodHandler (file:/C:/Users/User/.m2/repository/io/github/openfeign/feign-core/11.0/feign-core-11.0.jar) to field java.lang.invoke.MethodHandles$Lookup.IMPL_LOOKUP
WARNING: Please consider reporting this to the maintainers of feign.DefaultMethodHandler
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

### Changes Proposed
* Bump `feign` dependencies to 11.2
