### PR TITLE
chore: workflow - gradle update from #229

### DIFF
--- a/.ci/env
+++ b/.ci/env
@@ -1,5 +1,0 @@
-# project
-PROJECT_TYPE=java
-
-# publish
-PUBLISH_TYPE=bintray

--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -1,0 +1,23 @@
+name: Update - Gradle Wrapper
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at 06:00 UTC on the 1, 15 and 29th of every month
+    - cron: 0 6 */14 * *
+
+jobs:
+  gradle_update:
+    name: Gradle Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          ref: develop
+      - name: Gradle Wrapper Check
+        uses: gradle-update/update-gradle-wrapper-action@v1.0.13
+        with:
+          reviewers: PhilippHeuer, iProdigy
+          labels: dependencies
+          base-branch: develop
+          target-branch: develop


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

This will add the first workflow from #229, to schedule a update of the gradle wrapper.
The action will create a MR for each update and runs against develop, it's possible to manually trigger the workflow.
