### PR TITLE
feat: implement helix manage held automod message endpoint

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -28,6 +28,7 @@ public enum TwitchScopes {
     HELIX_CHANNEL_SUBSCRIPTIONS_READ("channel:read:subscriptions"),
     HELIX_CHANNEL_VIDEOS_MANAGE("channel:manage:videos"),
     HELIX_MODERATION_READ("moderation:read"),
+    HELIX_AUTOMOD_MANAGE("moderator:manage:automod"),
     HELIX_USER_EDIT("user:edit"),
     HELIX_USER_EDIT_BROADCAST("user:edit:broadcast"),
     HELIX_USER_EDIT_FOLLOWS("user:edit:follows"),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -636,6 +636,33 @@ public interface TwitchHelix {
     }
 
     /**
+     * Allow or deny a message that was held for review by AutoMod.
+     * <p>
+     * In order to retrieve messages held for review, use ITwitchPubsub#listenForModerationEvents(OAuth2Credential, String, String) and ChatModerationEvent.
+     * <p>
+     * Note that the scope allows this endpoint to be used for any channel that the authenticated user is a moderator, including their own channel.
+     *
+     * @param authToken   User OAuth token from a moderator with the moderator:manage:automod scope.
+     * @param moderatorId The moderator who is approving or rejecting the held message. Must match the user_id in the user OAuth token.
+     * @param messageId   ID of the message to be allowed or denied. These message IDs are retrieved from IRC or PubSub.
+     * @param action      The action to take for the message.
+     * @return 204 No Content upon a successful request.
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_AUTOMOD_MANAGE
+     */
+    @RequestLine("POST /moderation/automod/message")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    @Body("%7B\"user_id\":\"{user_id}\",\"msg_id\":\"{msg_id}\",\"action\":\"{action}\"%7D")
+    HystrixCommand<Void> manageAutoModHeldMessage(
+        @Param("token") String authToken,
+        @Param("user_id") String moderatorId,
+        @Param("msg_id") String messageId,
+        @Param("action") AutoModHeldMessageAction action
+    );
+
+    /**
      * Returns all banned and timed-out users in a channel.
      *
      * @param authToken     Auth Token (scope: moderation:read)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutoModHeldMessageAction.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutoModHeldMessageAction.java
@@ -1,0 +1,11 @@
+package com.github.twitch4j.helix.domain;
+
+/**
+ * The action to take on a message held for review by AutoMod.
+ *
+ * @see com.github.twitch4j.helix.TwitchHelix#manageAutoModHeldMessage(String, String, String, AutoModHeldMessageAction)
+ */
+public enum AutoModHeldMessageAction {
+    ALLOW,
+    DENY
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKraken.java
@@ -165,8 +165,10 @@ public interface TwitchKraken {
      * @param authToken Auth Token
      * @param msgId unique id for the message
      * @return no content for a successful call
+     * @deprecated in favor of TwitchHelix#manageAutoModHeldMessage
      */
     @Unofficial
+    @Deprecated
     @RequestLine("POST /chat/twitchbot/approve")
     @Headers({
         "Authorization: OAuth {token}"
@@ -185,8 +187,10 @@ public interface TwitchKraken {
      * @param authToken Auth Token
      * @param msgId unique id for the message
      * @return no content for a successful call
+     * @deprecated in favor of TwitchHelix#manageAutoModHeldMessage
      */
     @Unofficial
+    @Deprecated
     @RequestLine("POST /chat/twitchbot/deny")
     @Headers({
         "Authorization: OAuth {token}"


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* `TwitchKraken#approveAutomodMessage` & `TwitchKraken#denyAutomodMessage` are being decommissioned tomorrow

### Changes Proposed
* Implement `TwitchHelix#manageAutoModHeldMessage(String, String, String, AutoModHeldMessageAction)`

### Additional Information
<https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages>
