### PR TITLE
fix: remove lockedAt in predictionEnd / rename locksAt to lockedAt in predictionLock

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionEndEvent.java
@@ -31,11 +31,6 @@ public class ChannelPredictionEndEvent extends ChannelPredictionEvent {
     private PredictionStatus status;
 
     /**
-     * The time the Channel Points Prediction locked.
-     */
-    private Instant lockedAt;
-
-    /**
      * The time the Channel Points Prediction ended.
      */
     private Instant endedAt;

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionLockEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPredictionLockEvent.java
@@ -19,6 +19,6 @@ public class ChannelPredictionLockEvent extends ChannelPredictionEvent {
     /**
      * The time the Channel Points Prediction will automatically lock.
      */
-    private Instant locksAt;
+    private Instant lockedAt;
 
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -196,8 +196,7 @@ public class EventSubEventTest {
                 "\"outcomes\":[{\"id\":\"12345\",\"title\":\"Yeah!\",\"color\":\"blue\",\"users\":2,\"channel_points\":15000,\"top_predictors\":[{\"user_name\":\"Cool_User\",\"user_login\":\"cool_user\",\"user_id\":1234,\"channel_points_won\":10000," +
                 "\"channel_points_used\":500},{\"user_name\":\"Coolest_User\",\"user_login\":\"coolest_user\",\"user_id\":1236,\"channel_points_won\":5000,\"channel_points_used\":100}]},{\"id\":\"22435\",\"title\":\"No!\",\"users\":2," +
                 "\"channel_points\":200,\"color\":\"pink\",\"top_predictors\":[{\"user_name\":\"Cooler_User\",\"user_login\":\"cooler_user\",\"user_id\":12345,\"channel_points_won\":null,\"channel_points_used\":100},{\"user_name\":\"Elite_User\"," +
-                "\"user_login\":\"elite_user\",\"user_id\":1337,\"channel_points_won\":null,\"channel_points_used\":100}]}],\"status\":\"resolved\",\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"locked_at\":\"2020-07-15T17:16:11.17106713Z\"," +
-                "\"ended_at\":\"2020-07-15T17:16:11.17106713Z\"}",
+                "\"user_login\":\"elite_user\",\"user_id\":1337,\"channel_points_won\":null,\"channel_points_used\":100}]}],\"status\":\"resolved\",\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"ended_at\":\"2020-07-15T17:16:11.17106713Z\"}",
             ChannelPredictionEndEvent.class
         );
 
@@ -212,7 +211,6 @@ public class EventSubEventTest {
         assertNotNull(event.getOutcomes().get(0).getTopPredictors().get(0));
         assertEquals(10000, event.getOutcomes().get(0).getTopPredictors().get(0).getChannelPointsWon());
         assertEquals(PredictionStatus.RESOLVED, event.getStatus());
-        assertEquals(Instant.parse("2020-07-15T17:16:11.17106713Z"), event.getLockedAt());
         assertEquals(Instant.parse("2020-07-15T17:16:11.17106713Z"), event.getEndedAt());
     }
 


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed

This covers the changes deployed to eventsub today:

- The eventsub channel.prediction.lock payload has a locked_at timestamp, rather than locks_at
- The eventsub channel.prediction.end payload has had its locked_at field removed due to edge cases around predictions that were cancelled or resolved prematurely

### Additional Information

See https://discord.com/channels/504015559252377601/776875921654546463/842867470343864351