### PR TITLE
docs: note that delay is now included in getChannelInformation

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
@@ -51,8 +51,6 @@ public class ChannelInformation {
      * Stream delay in seconds.
      * <p>
      * Stream delay is a Twitch Partner feature; trying to set this value for other account types will return a 400 error.
-     * <p>
-     * Note: this is currently used for <i>only</i> {@link com.github.twitch4j.helix.TwitchHelix#updateChannelInformation(String, String, ChannelInformation)}
      */
     @Nullable
     private Integer delay;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/EventSubSubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/EventSubSubscriptionList.java
@@ -38,8 +38,8 @@ public class EventSubSubscriptionList {
     /**
      * Subscription limit for client id that made the subscription creation request.
      *
-     * @see <a href="https://dev.twitch.tv/docs/eventsub/#subscription-limits">Limit Docs</a>
-     * @deprecated no longer enforced in favor of #getMaxTotalCost
+     * @see <a href="https://discuss.dev.twitch.tv/t/eventsub-subscription-limit-cost-based-system-and-limit-field-deprecation/31377">Cost-Based Limit Docs</a>
+     * @deprecated removed in favor of #getMaxTotalCost
      */
     @Deprecated
     private Integer limit;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
Update javadocs for [changes made on 2021-05-14](https://dev.twitch.tv/docs/change-log)
* Get Channel Information; Added `delay` to return values
* Get/Create EventSub Subscriptions: `limit` removed
