### PR TITLE
feat: handle approve deny unban request within chat_moderator_actions pubsub

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -479,14 +479,26 @@ public class TwitchPubSub implements ITwitchPubSub {
 
                             } else if (topic.startsWith("chat_moderator_actions")) {
                                 String channelId = topic.substring(topic.lastIndexOf('.') + 1);
-                                if ("moderation_action".equalsIgnoreCase(type)) {
-                                    ChatModerationAction data = TypeConvert.convertValue(msgData, ChatModerationAction.class);
-                                    eventManager.publish(new ChatModerationEvent(channelId, data));
-                                } else if ("channel_terms_action".equalsIgnoreCase(type)) {
-                                    ChannelTermsAction data = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
-                                    eventManager.publish(new ChannelTermsEvent(channelId, data));
-                                } else {
-                                    log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                                switch (type) {
+                                    case "moderation_action":
+                                        ChatModerationAction modAction = TypeConvert.convertValue(msgData, ChatModerationAction.class);
+                                        eventManager.publish(new ChatModerationEvent(channelId, modAction));
+                                        break;
+
+                                    case "channel_terms_action":
+                                        ChannelTermsAction termsAction = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
+                                        eventManager.publish(new ChannelTermsEvent(channelId, termsAction));
+                                        break;
+
+                                    case "approve_unban_request":
+                                    case "deny_unban_request":
+                                        ModeratorUnbanRequestAction unbanRequestAction = TypeConvert.convertValue(msgData, ModeratorUnbanRequestAction.class);
+                                        eventManager.publish(new ModUnbanRequestActionEvent(channelId, unbanRequestAction));
+                                        break;
+
+                                    default:
+                                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                                        break;
                                 }
                             } else if (topic.startsWith("following")) {
                                 final String channelId = topic.substring(topic.lastIndexOf('.') + 1);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ModeratorUnbanRequestAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ModeratorUnbanRequestAction.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ModeratorUnbanRequestAction {
+
+    /**
+     * Whether the unban request was approved or denied.
+     */
+    private Type moderationAction;
+
+    /**
+     * The user id of the moderator taking this action.
+     */
+    private String createdById;
+
+    /**
+     * The login name of the moderator taking this action.
+     */
+    private String createdByLogin;
+
+    /**
+     * An optional message provided to the target user by the moderator.
+     */
+    @Nullable
+    private String moderatorMessage;
+
+    /**
+     * The id of the user that created the unban request.
+     */
+    private String targetUserId;
+
+    /**
+     * The login name of the user that created the unban request.
+     */
+    private String targetUserLogin;
+
+    public enum Type {
+        APPROVE_UNBAN_REQUEST,
+        DENY_UNBAN_REQUEST
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ModUnbanRequestActionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ModUnbanRequestActionEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ModeratorUnbanRequestAction;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ModUnbanRequestActionEvent extends TwitchEvent {
+    String channelId;
+    ModeratorUnbanRequestAction data;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* `approve_unban_request` & `deny_unban_request` would yield the unparsable message warning

### Changes Proposed
* Add branch and models (e.g., `ModeratorUnbanRequestAction`) to properly handle this case
