### PR TITLE
chore: promote polls predictions api from beta to v1

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollBeginEvent.java
@@ -1,8 +1,24 @@
 package com.github.twitch4j.eventsub.events;
 
+import lombok.AccessLevel;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelPollBeginEvent extends ChannelPollEvent {}
+public class ChannelPollBeginEvent extends ChannelPollEvent {
+
+    /**
+     * The time the poll will end.
+     */
+    private Instant endsAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEndEvent.java
@@ -27,9 +27,4 @@ public class ChannelPollEndEvent extends ChannelPollEvent {
      */
     private Instant endedAt;
 
-    @Override
-    public Instant getEndsAt() {
-        return this.endedAt;
-    }
-
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEndEvent.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.time.Instant;
+
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
@@ -19,5 +21,15 @@ public class ChannelPollEndEvent extends ChannelPollEvent {
      * The status of the poll. Valid values are completed, archived, and terminated.
      */
     private PollStatus status;
+
+    /**
+     * The time the poll ended.
+     */
+    private Instant endedAt;
+
+    @Override
+    public Instant getEndsAt() {
+        return this.endedAt;
+    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEvent.java
@@ -52,9 +52,4 @@ public abstract class ChannelPollEvent extends EventSubChannelEvent {
      */
     private Instant startedAt;
 
-    /**
-     * The time the poll will end.
-     */
-    private Instant endsAt;
-
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollProgressEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollProgressEvent.java
@@ -1,8 +1,24 @@
 package com.github.twitch4j.eventsub.events;
 
+import lombok.AccessLevel;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelPollProgressEvent extends ChannelPollEvent {}
+public class ChannelPollProgressEvent extends ChannelPollEvent {
+
+    /**
+     * The time the poll will end.
+     */
+    private Instant endsAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PollBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PollBeginType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPollBeginCondition;
 import com.github.twitch4j.eventsub.events.ChannelPollBeginEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPollBeginEvent;
  * The channel.poll.begin subscription type sends a notification when a poll begins on the specified channel.
  * <p>
  * Must have the channel:read:polls or channel:manage:polls scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond the 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPollBeginType implements SubscriptionType<ChannelPollBeginCondition, ChannelPollBeginCondition.ChannelPollBeginConditionBuilder<?, ?>, ChannelPollBeginEvent> {
+public class PollBeginType implements SubscriptionType<ChannelPollBeginCondition, ChannelPollBeginCondition.ChannelPollBeginConditionBuilder<?, ?>, ChannelPollBeginEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPollBeginType implements SubscriptionType<ChannelPollBeginCondi
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PollEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PollEndType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPollEndCondition;
 import com.github.twitch4j.eventsub.events.ChannelPollEndEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPollEndEvent;
  * The channel.poll.end subscription type sends a notification when a poll ends on the specified channel.
  * <p>
  * Must have the channel:read:polls or channel:manage:polls scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond the 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPollEndType implements SubscriptionType<ChannelPollEndCondition, ChannelPollEndCondition.ChannelPollEndConditionBuilder<?, ?>, ChannelPollEndEvent> {
+public class PollEndType implements SubscriptionType<ChannelPollEndCondition, ChannelPollEndCondition.ChannelPollEndConditionBuilder<?, ?>, ChannelPollEndEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPollEndType implements SubscriptionType<ChannelPollEndCondition
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PollProgressType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PollProgressType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPollProgressCondition;
 import com.github.twitch4j.eventsub.events.ChannelPollProgressEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPollProgressEvent;
  * The channel.poll.progress subscription type sends a notification when users respond to a poll on the specified channel.
  * <p>
  * Must have the channel:read:polls or channel:manage:polls scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond the 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPollProgressType implements SubscriptionType<ChannelPollProgressCondition, ChannelPollProgressCondition.ChannelPollProgressConditionBuilder<?, ?>, ChannelPollProgressEvent> {
+public class PollProgressType implements SubscriptionType<ChannelPollProgressCondition, ChannelPollProgressCondition.ChannelPollProgressConditionBuilder<?, ?>, ChannelPollProgressEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPollProgressType implements SubscriptionType<ChannelPollProgres
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionBeginType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPredictionBeginCondition;
 import com.github.twitch4j.eventsub.events.ChannelPredictionBeginEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPredictionBeginEvent;
  * The channel.prediction.begin subscription type sends a notification when a Prediction begins on the specified channel.
  * <p>
  * Must have channel:read:predictions or channel:manage:predictions scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPredictionBeginType implements SubscriptionType<ChannelPredictionBeginCondition, ChannelPredictionBeginCondition.ChannelPredictionBeginConditionBuilder<?, ?>, ChannelPredictionBeginEvent> {
+public class PredictionBeginType implements SubscriptionType<ChannelPredictionBeginCondition, ChannelPredictionBeginCondition.ChannelPredictionBeginConditionBuilder<?, ?>, ChannelPredictionBeginEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPredictionBeginType implements SubscriptionType<ChannelPredicti
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionEndType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPredictionEndCondition;
 import com.github.twitch4j.eventsub.events.ChannelPredictionEndEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPredictionEndEvent;
  * The channel.prediction.end subscription type sends a notification when a Prediction ends on the specified channel.
  * <p>
  * Must have channel:read:predictions or channel:manage:predictions scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPredictionEndType implements SubscriptionType<ChannelPredictionEndCondition, ChannelPredictionEndCondition.ChannelPredictionEndConditionBuilder<?, ?>, ChannelPredictionEndEvent> {
+public class PredictionEndType implements SubscriptionType<ChannelPredictionEndCondition, ChannelPredictionEndCondition.ChannelPredictionEndConditionBuilder<?, ?>, ChannelPredictionEndEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPredictionEndType implements SubscriptionType<ChannelPrediction
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionLockType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionLockType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPredictionLockCondition;
 import com.github.twitch4j.eventsub.events.ChannelPredictionLockEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPredictionLockEvent;
  * The channel.prediction.lock subscription type sends a notification when a Prediction is locked on the specified channel.
  * <p>
  * Must have channel:read:predictions or channel:manage:predictions scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPredictionLockType implements SubscriptionType<ChannelPredictionLockCondition, ChannelPredictionLockCondition.ChannelPredictionLockConditionBuilder<?, ?>, ChannelPredictionLockEvent> {
+public class PredictionLockType implements SubscriptionType<ChannelPredictionLockCondition, ChannelPredictionLockCondition.ChannelPredictionLockConditionBuilder<?, ?>, ChannelPredictionLockEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPredictionLockType implements SubscriptionType<ChannelPredictio
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionProgressType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/PredictionProgressType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelPredictionProgressCondition;
 import com.github.twitch4j.eventsub.events.ChannelPredictionProgressEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelPredictionProgressEvent;
  * The channel.prediction.progress subscription type sends a notification when users participate in a Prediction on the specified channel.
  * <p>
  * Must have channel:read:predictions or channel:manage:predictions scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released. Subscriptions should be updated to v1 during this timeframe.
- * Any active beta subscriptions beyond 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaPredictionProgressType implements SubscriptionType<ChannelPredictionProgressCondition, ChannelPredictionProgressCondition.ChannelPredictionProgressConditionBuilder<?, ?>, ChannelPredictionProgressEvent> {
+public class PredictionProgressType implements SubscriptionType<ChannelPredictionProgressCondition, ChannelPredictionProgressCondition.ChannelPredictionProgressConditionBuilder<?, ?>, ChannelPredictionProgressEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaPredictionProgressType implements SubscriptionType<ChannelPredi
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -12,13 +12,6 @@ import java.util.stream.Stream;
 @UtilityClass
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
-    @Unofficial public final BetaPollBeginType BETA_POLL_BEGIN;
-    @Unofficial public final BetaPollProgressType BETA_POLL_PROGRESS;
-    @Unofficial public final BetaPollEndType BETA_POLL_END;
-    @Unofficial public final BetaPredictionBeginType BETA_PREDICTION_BEGIN;
-    @Unofficial public final BetaPredictionProgressType BETA_PREDICTION_PROGRESS;
-    @Unofficial public final BetaPredictionLockType BETA_PREDICTION_LOCK;
-    @Unofficial public final BetaPredictionEndType BETA_PREDICTION_END;
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelCheerType CHANNEL_CHEER;
     public final ChannelFollowType CHANNEL_FOLLOW;
@@ -37,6 +30,13 @@ public class SubscriptionTypes {
     public final HypeTrainBeginType HYPE_TRAIN_BEGIN;
     public final HypeTrainEndType HYPE_TRAIN_END;
     public final HypeTrainProgressType HYPE_TRAIN_PROGRESS;
+    public final PollBeginType POLL_BEGIN;
+    public final PollProgressType POLL_PROGRESS;
+    public final PollEndType POLL_END;
+    public final PredictionBeginType PREDICTION_BEGIN;
+    public final PredictionProgressType PREDICTION_PROGRESS;
+    public final PredictionLockType PREDICTION_LOCK;
+    public final PredictionEndType PREDICTION_END;
     public final StreamOfflineType STREAM_OFFLINE;
     public final StreamOnlineType STREAM_ONLINE;
     public final UserAuthorizationRevokeType USER_AUTHORIZATION_REVOKE;
@@ -49,13 +49,6 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
-                BETA_POLL_BEGIN = new BetaPollBeginType(),
-                BETA_POLL_PROGRESS = new BetaPollProgressType(),
-                BETA_POLL_END = new BetaPollEndType(),
-                BETA_PREDICTION_BEGIN = new BetaPredictionBeginType(),
-                BETA_PREDICTION_PROGRESS = new BetaPredictionProgressType(),
-                BETA_PREDICTION_LOCK = new BetaPredictionLockType(),
-                BETA_PREDICTION_END = new BetaPredictionEndType(),
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHEER = new ChannelCheerType(),
                 CHANNEL_FOLLOW = new ChannelFollowType(),
@@ -74,6 +67,13 @@ public class SubscriptionTypes {
                 HYPE_TRAIN_BEGIN = new HypeTrainBeginType(),
                 HYPE_TRAIN_END = new HypeTrainEndType(),
                 HYPE_TRAIN_PROGRESS = new HypeTrainProgressType(),
+                POLL_BEGIN = new PollBeginType(),
+                POLL_PROGRESS = new PollProgressType(),
+                POLL_END = new PollEndType(),
+                PREDICTION_BEGIN = new PredictionBeginType(),
+                PREDICTION_PROGRESS = new PredictionProgressType(),
+                PREDICTION_LOCK = new PredictionLockType(),
+                PREDICTION_END = new PredictionEndType(),
                 STREAM_OFFLINE = new StreamOfflineType(),
                 STREAM_ONLINE = new StreamOnlineType(),
                 USER_AUTHORIZATION_REVOKE = new UserAuthorizationRevokeType(),

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -123,7 +123,6 @@ public class EventSubEventTest {
 
         assertNotNull(event);
         assertEquals(PollStatus.COMPLETED, event.getStatus());
-        assertNotNull(event.getEndsAt());
         assertNotNull(event.getEndedAt());
     }
 

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -123,6 +123,8 @@ public class EventSubEventTest {
 
         assertNotNull(event);
         assertEquals(PollStatus.COMPLETED, event.getStatus());
+        assertNotNull(event.getEndsAt());
+        assertNotNull(event.getEndedAt());
     }
 
     @Test

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -831,8 +831,6 @@ public interface TwitchHelix {
      * Get information about all polls or specific polls for a Twitch channel.
      * <p>
      * Poll information is available for 90 days.
-     * <p>
-     * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
      * @param authToken     Required: User OAuth token from the broadcaster with the channel:read:polls scope.
      * @param broadcasterId Required: The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
@@ -842,7 +840,6 @@ public interface TwitchHelix {
      * @return PollsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_READ
      */
-    @Unofficial
     @RequestLine("GET /polls?broadcaster_id={broadcaster_id}&id={id}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<PollsList> getPolls(
@@ -855,15 +852,12 @@ public interface TwitchHelix {
 
     /**
      * Create a poll for a specific Twitch channel.
-     * <p>
-     * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
      * @param authToken User OAuth token from the broadcaster with the channel:manage:polls scope.
      * @param poll      The new poll to be created. Required: broadcaster_id, title, choices, choice.title, duration. Optional: bits_voting_enabled, bits_per_vote, channel_points_voting_enabled, channel_points_per_vote.
      * @return PollsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_MANAGE
      */
-    @Unofficial
     @RequestLine("POST /polls")
     @Headers({
         "Authorization: Bearer {token}",
@@ -876,15 +870,12 @@ public interface TwitchHelix {
 
     /**
      * End a poll that is currently active.
-     * <p>
-     * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
      * @param authToken User OAuth token from the broadcaster with the channel:manage:polls scope.
      * @param poll      The poll to be ended. Required: broadcaster_id, id, status (must be TERMINATED or ARCHIVED, depending on whether it should be viewed publicly).
      * @return PollsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_POLLS_MANAGE
      */
-    @Unofficial
     @RequestLine("PATCH /polls")
     @Headers({
         "Authorization: Bearer {token}",
@@ -897,8 +888,6 @@ public interface TwitchHelix {
 
     /**
      * Get information about all Channel Points Predictions or specific Channel Points Predictions for a Twitch channel.
-     * <p>
-     * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
      * @param authToken     Required: User OAuth token from the broadcaster with the channel:read:predictions scope.
      * @param broadcasterId Required: The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
@@ -908,7 +897,6 @@ public interface TwitchHelix {
      * @return PredictionsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_READ
      */
-    @Unofficial
     @RequestLine("GET /predictions?broadcaster_id={broadcaster_id}&id={id}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<PredictionsList> getPredictions(
@@ -921,15 +909,12 @@ public interface TwitchHelix {
 
     /**
      * Create a Channel Points Prediction for a specific Twitch channel.
-     * <p>
-     * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
      * @param authToken  User OAuth token from the broadcaster with the channel:manage:predictions scope.
      * @param prediction The prediction to be created. Required: broadcaster_id, title, outcomes, outcome.title, prediction_window.
      * @return PredictionsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_MANAGE
      */
-    @Unofficial
     @RequestLine("POST /predictions")
     @Headers({
         "Authorization: Bearer {token}",
@@ -945,15 +930,12 @@ public interface TwitchHelix {
      * <p>
      * Active Predictions can be updated to be "locked," "resolved," or "canceled."
      * Locked Predictions can be updated to be "resolved" or "canceled."
-     * <p>
-     * This endpoint is currently available as part of a public beta and should not be used in production environments.
      *
      * @param authToken  User OAuth token from the broadcaster with the channel:manage:predictions scope.
      * @param prediction The prediction to be ended. Required: broadcaster_id, id, status (RESOLVED or CANCELED or LOCKED). Optional: winning_outcome_id (must be present for RESOLVED status).
      * @return PredictionsList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_PREDICTIONS_MANAGE
      */
-    @Unofficial
     @RequestLine("PATCH /predictions")
     @Headers({
         "Authorization: Bearer {token}",


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Remove beta warnings in TwitchHelix
* Replace beta eventsub models with v1

### Additional Information
2021‑05‑24 <https://dev.twitch.tv/docs/change-log>
