### PR TITLE
feat: implement new chat badges helix api

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1,10 +1,8 @@
 package com.github.twitch4j.helix;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.feign.ObjectToJsonExpander;
 import com.github.twitch4j.eventsub.EventSubSubscription;
 import com.github.twitch4j.eventsub.EventSubSubscriptionStatus;
-import com.github.twitch4j.eventsub.domain.PollStatus;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
 import com.github.twitch4j.helix.domain.*;
 import com.github.twitch4j.helix.webhooks.domain.WebhookRequest;
@@ -281,6 +279,33 @@ public interface TwitchHelix {
         @Param("reward_id") String rewardId,
         @Param("id") Collection<String> redemptionIds,
         @Param("status") RedemptionStatus newStatus
+    );
+
+    /**
+     * Gets a list of custom chat badges that can be used in chat for the specified channel.
+     * This includes <a href="https://help.twitch.tv/s/article/subscriber-badge-guide">subscriber badges</a> and <a href="https://help.twitch.tv/s/article/custom-bit-badges-guide">Bit badges</a>.
+     *
+     * @param authToken     User OAuth Token from the broadcaster.
+     * @param broadcasterId The id of the broadcaster whose chat badges are being requested. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @return ChatBadgeSetList
+     */
+    @RequestLine("GET /chat/badges?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ChatBadgeSetList> getChannelChatBadges(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
+     * Gets a list of chat badges that can be used in chat for any channel.
+     *
+     * @param authToken User OAuth Token or App Access Token.
+     * @return ChatBadgeSetList
+     */
+    @RequestLine("GET /chat/badges/global")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ChatBadgeSetList> getGlobalChatBadges(
+        @Param("token") String authToken
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadge.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadge.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ChatBadge {
+
+    /**
+     * ID of the chat badge version.
+     */
+    private String id;
+
+    /**
+     * Small image URL.
+     */
+    @JsonProperty("image_url_1x")
+    private String smallImageUrl;
+
+    /**
+     * Medium image URL.
+     */
+    @JsonProperty("image_url_2x")
+    private String mediumImageUrl;
+
+    /**
+     * Large image URL.
+     */
+    @JsonProperty("image_url_4x")
+    private String largeImageUrl;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSet.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSet.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ChatBadgeSet {
+
+    /**
+     * ID for the chat badge set.
+     */
+    private String setId;
+
+    /**
+     * Contains chat badge objects for the set.
+     */
+    private List<ChatBadge> versions;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSetList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSetList.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ChatBadgeSetList {
+
+    /**
+     * The chat badge sets.
+     */
+    @JsonProperty("data")
+    private List<ChatBadgeSet> badgeSets;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Implement `TwitchHelix#getChannelChatBadges(String, String)`
* Implement `TwitchHelix#getGlobalChatBadges(String)`

### Additional Information
Added on 2021‑05‑28: <https://dev.twitch.tv/docs/change-log>
