### PR TITLE
fix: pass query params to url for updateRedemptionStatus

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -269,7 +269,7 @@ public interface TwitchHelix {
      * @param newStatus     The new status to set redemptions to. Can be either FULFILLED or CANCELED. Updating to CANCELED will refund the user their points.
      * @return CustomRewardRedemptionList
      */
-    @RequestLine("PATCH /channel_points/custom_rewards/redemptions")
+    @RequestLine("PATCH /channel_points/custom_rewards/redemptions?broadcaster_id={broadcaster_id}&reward_id={reward_id}&id={id}")
     @Headers({
         "Authorization: Bearer {token}",
         "Content-Type: application/json"


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* `[4:responseBody={"error":"Bad Request","status":400,"message":"Missing required parameter \"broadcaster_id\""}]`

### Changes Proposed
* Remember to pass the query params to the url for `TwitchHelix#updateRedemptionStatus`

### Additional Information
Thanks to Jilence#0001 for reporting
