### PR TITLE
feat: include unofficial fields in AutomodCaughtMessage.Fragment

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessage.java
@@ -1,11 +1,13 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.util.TypeConvert;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.util.EnumMap;
@@ -17,7 +19,7 @@ import java.util.Map;
 public class AutomodCaughtMessage {
 
     /**
-     * Object containing details about the message
+     * Object containing details about the message.
      */
     private Content content;
 
@@ -55,8 +57,43 @@ public class AutomodCaughtMessage {
     @Data
     @Setter(AccessLevel.PRIVATE)
     public static class Fragment {
+
         private String text;
+
+        @Nullable
         private FragmentFlags automod;
+
+        @Nullable
+        @Unofficial
+        private FragmentLink link;
+
+        @Nullable
+        @Unofficial
+        private FragmentMention userMention;
+
+        /**
+         * @return whether this fragment of the message was flagged by AutoMod.
+         */
+        public boolean isFragmentFlagged() {
+            return getAutomod() != null && getAutomod().getTopics() != null && !getAutomod().getTopics().isEmpty();
+        }
+
+        /**
+         * @return whether this fragment of the message is a link.
+         */
+        @Unofficial
+        public boolean isFragmentLink() {
+            return getLink() != null && getLink().getHost() != null;
+        }
+
+        /**
+         * @return whether this fragment of the message is simply a user mention.
+         */
+        @Unofficial
+        public boolean isFragmentMention() {
+            return getUserMention() != null && getUserMention().getUserId() != null;
+        }
+
     }
 
     @Data
@@ -68,6 +105,21 @@ public class AutomodCaughtMessage {
         public Map<AutomodContentClassification.Category, Integer> getParsedTopics() {
             return TypeConvert.convertValue(topics, new TypeReference<EnumMap<AutomodContentClassification.Category, Integer>>() {});
         }
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class FragmentLink {
+        private String host;
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class FragmentMention {
+        @JsonProperty("userID")
+        String userId;
+        String login;
+        String displayName;
     }
 
     @Data

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodContentClassification.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodContentClassification.java
@@ -27,13 +27,13 @@ public class AutomodContentClassification {
         /**
          * Threatening, inciting, or promoting violence or other harm.
          */
-        @JsonAlias("aggression")
+        @JsonAlias({ "aggression", "violence", "threats" })
         AGGRESSIVE,
 
         /**
          * Name-calling, insults, or antagonization.
          */
-        @JsonAlias("namecalling")
+        @JsonAlias({ "namecalling", "insults", "antagonization" })
         BULLYING,
 
         /**
@@ -45,37 +45,36 @@ public class AutomodContentClassification {
         /**
          * Demonstrating hatred or prejudice based on sexual identity, sexual orientation, gender identity, or gender expression.
          */
-        @JsonAlias({ "sexuality", "homophobia" })
+        @JsonAlias({ "sexuality", "homophobia", "gender", "orientation" })
         SEXUALITY_SEX_OR_GENDER,
 
         /**
          * Demonstrating hatred or prejudice against women, including sexual objectification.
          */
-        @JsonAlias("sexism")
+        @JsonAlias({ "sexism", "objectification" })
         MISOGYNY,
 
         /**
          * Demonstrating hatred or prejudice based on race, ethnicity, or religion.
          */
-        @JsonAlias({ "racism", "religion" })
+        @JsonAlias({ "racism", "ethnicity", "religion" })
         RACE_ETHNICITY_OR_RELIGION,
 
         /**
-         * @deprecated This is an old AutoMod category; use {@link #DISABILITY}, {@link #SEXUALITY_SEX_OR_GENDER}, {@link #MISOGYNY}, or {@link #RACE_ETHNICITY_OR_RELIGION} instead.
+         * Identity details (old category).
          */
-        @Deprecated
         IDENTITY,
 
         /**
          * Sexual acts, anatomy.
          */
-        @JsonAlias("sex_based_terms")
+        @JsonAlias({ "sex_based_terms", "anatomy" })
         SEXUAL,
 
         /**
          * Swear words, &*^!#@%*.
          */
-        @JsonAlias("swearing")
+        @JsonAlias({ "swearing", "vulgar" })
         PROFANITY,
 
         /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add undocumented `link` field to `AutomodCaughtMessage.Fragment`
* Add undocumented `user_mention` field to `AutomodCaughtMessage.Fragment`
* Throw more aliases into `AutomodContentClassification.Category` (some of which are observed while most are guesses)
* Undeprecate `AutomodContentClassification.Category#IDENTITY` (this *is* actually still sent over the socket in some cases)
