### PR TITLE
feat: include new total field in helix SubscriptionList

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
@@ -7,9 +7,21 @@ import java.util.List;
 
 @Data
 public class SubscriptionList {
+
+    /**
+     * The subscriptions.
+     */
     @JsonProperty("data")
     private List<Subscription> subscriptions;
 
+    /**
+     * A cursor value, to be used in a subsequent request to specify the starting point of the next set of results. If this is empty, you are at the last page.
+     */
     private HelixPagination pagination;
+
+    /**
+     * The number of Twitch users subscribed to the broadcaster.
+     */
+    private Integer total;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Include `total` in `SubscriptionList`

### Additional Information
2021-06-02: Get Broadcaster Subscriptions - total subscription count added to the response. <https://dev.twitch.tv/docs/change-log>
