### PR TITLE
feat: add isAnonymous field to eventsub subgift event

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Predictor.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Predictor.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,16 +15,19 @@ public class Predictor {
     /**
      * The ID of the user.
      */
+    @JsonAlias("id")
     private String userId;
 
     /**
      * The login name of the user.
      */
+    @JsonAlias("login")
     private String userLogin;
 
     /**
      * The display name of the user.
      */
+    @JsonAlias("name")
     private String userName;
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelSubscriptionGiftEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelSubscriptionGiftEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -7,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 import org.jetbrains.annotations.Nullable;
 
 @Data
@@ -32,5 +34,12 @@ public class ChannelSubscriptionGiftEvent extends EventSubUserChannelEvent {
      */
     @Nullable
     private Integer cumulativeTotal;
+
+    /**
+     * Whether the subscription gift was anonymous.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_anonymous")
+    private Boolean isAnonymous;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ChannelSubscriptionGiftEvent#isAnonymous`

#### Secondary
* Add some aliases for properties in `Predictor` due to [twitch docs inconsistency](https://twitch.uservoice.com/forums/310213-developers/suggestions/43521057-incorrect-documentation-for-predictions)

### Additional Information
`Channel Subscription Gift EventSub subscription type - Added is_anonymous boolean to the event.` <https://dev.twitch.tv/docs/change-log>
