### PR TITLE
feat: add convenient reply method to chat events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
@@ -51,8 +51,8 @@ public interface ITwitchChat extends AutoCloseable {
      * @param replyMsgId the msgId of the parent message being replied to (optional).
      * @return whether the message was added to the queue
      */
-    @Unofficial
-    default boolean sendMessage(String channel, String message, String nonce, String replyMsgId) {
+    @SuppressWarnings("UnusedReturnValue")
+    default boolean sendMessage(String channel, String message, @Unofficial String nonce, String replyMsgId) {
         final Map<String, Object> tags = new LinkedHashMap<>(); // maintain insertion order
         if (nonce != null) tags.put(IRCMessageEvent.NONCE_TAG_NAME, nonce);
         if (replyMsgId != null) tags.put(ChatReply.REPLY_MSG_ID_TAG_NAME, replyMsgId);
@@ -64,11 +64,10 @@ public interface ITwitchChat extends AutoCloseable {
      *
      * @param channel the name of the channel to send the message to.
      * @param message the message to be sent.
-     * @param tags    the message tags (unofficial).
+     * @param tags    the message tags.
      * @return whether the message was added to the queue
      */
-    @Unofficial
-    boolean sendMessage(String channel, String message, @Unofficial @Nullable Map<String, Object> tags);
+    boolean sendMessage(String channel, String message, @Nullable Map<String, Object> tags);
 
     /**
      * Returns a set of all currently joined channels (without # prefix)

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -10,9 +10,7 @@ import com.github.twitch4j.chat.events.CommandEvent;
 import com.github.twitch4j.chat.events.IRCEventHandler;
 import com.github.twitch4j.chat.events.channel.ChannelMessageEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.config.ProxyConfig;
-import com.github.twitch4j.common.util.ChatReply;
 import com.github.twitch4j.common.util.CryptoUtils;
 import com.github.twitch4j.common.util.EscapeUtils;
 import com.github.twitch4j.common.util.ExponentialBackoffStrategy;
@@ -666,7 +664,7 @@ public class TwitchChat implements ITwitchChat {
     }
 
     @Override
-    public boolean sendMessage(String channel, String message, @Unofficial Map<String, Object> tags) {
+    public boolean sendMessage(String channel, String message, Map<String, Object> tags) {
         StringBuilder sb = new StringBuilder();
         if (tags != null && !tags.isEmpty()) {
             sb.append('@');

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -65,7 +65,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
     protected final boolean automaticallyPartOnBan = false;
 
     @Override
-    public boolean sendMessage(String channel, String message, @Unofficial @Nullable Map<String, Object> tags) {
+    public boolean sendMessage(String channel, String message, @Nullable Map<String, Object> tags) {
         return this.sendMessage(channel, channel, message, tags);
     }
 
@@ -91,8 +91,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
      * @param replyMsgId                    the msgId of the parent message being replied to (optional).
      * @return whether a {@link TwitchChat} instance was found and used to send the message
      */
-    @Unofficial
-    public boolean sendMessage(final String channelToIdentifyChatInstance, final String targetChannel, final String message, final String nonce, final String replyMsgId) {
+    public boolean sendMessage(final String channelToIdentifyChatInstance, final String targetChannel, final String message, @Unofficial final String nonce, final String replyMsgId) {
         final Map<String, Object> tags = new LinkedHashMap<>();
         if (nonce != null) tags.put(IRCMessageEvent.NONCE_TAG_NAME, nonce);
         if (replyMsgId != null) tags.put(ChatReply.REPLY_MSG_ID_TAG_NAME, replyMsgId);
@@ -105,10 +104,10 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
      * @param channelToIdentifyChatInstance the channel used to identify which {@link TwitchChat} instance should be used to send the message; the instance must be subscribed to this channel.
      * @param targetChannel                 the channel to send the message to, if not null (otherwise it is sent directly on the socket).
      * @param message                       the message to be sent.
-     * @param tags                          the message tags (unofficial).
+     * @param tags                          the message tags.
      * @return whether a {@link TwitchChat} instance was found and used to send the message
      */
-    public boolean sendMessage(String channelToIdentifyChatInstance, String targetChannel, String message, @Unofficial @Nullable Map<String, Object> tags) {
+    public boolean sendMessage(String channelToIdentifyChatInstance, String targetChannel, String message, @Nullable Map<String, Object> tags) {
         if (channelToIdentifyChatInstance == null)
             return false;
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -190,7 +190,7 @@ public class IRCEventHandler {
                 Integer multiMonthTenure = Integer.parseInt(event.getTags().getOrDefault("msg-param-multimonth-tenure", "0"));
 
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak, null, multiMonthDuration, multiMonthTenure, event.getFlags()));
+                eventManager.publish(new SubscriptionEvent(event, channel, user, subPlan, event.getMessage(), cumulativeMonths, false, null, streak, null, multiMonthDuration, multiMonthTenure, event.getFlags()));
             }
             // Receive Gifted Sub
             else if (msgId.equalsIgnoreCase("subgift") || msgId.equalsIgnoreCase("anonsubgift")) {
@@ -213,7 +213,7 @@ public class IRCEventHandler {
                 Integer multiMonthTenure = StringUtils.isEmpty(multiTenureParam) ? null : Integer.parseInt(multiTenureParam);
 
                 // Dispatch Event
-                eventManager.publish(new SubscriptionEvent(channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths, giftMonths, multiMonthTenure, event.getFlags()));
+                eventManager.publish(new SubscriptionEvent(event, channel, user, subPlan, event.getMessage(), subStreak, true, giftedBy != null ? giftedBy : ANONYMOUS_GIFTER, 0, giftMonths, giftMonths, multiMonthTenure, event.getFlags()));
             }
             // Gift X Subs
             else if (msgId.equalsIgnoreCase("submysterygift") || msgId.equalsIgnoreCase("anonsubmysterygift")) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -153,7 +153,7 @@ public class IRCEventHandler {
                 int subTier = event.getSubscriptionTier().orElse(0);
 
                 // Dispatch Event
-                eventManager.publish(new CheerEvent(channel, user != null ? user : ANONYMOUS_CHEERER, message, bits, subMonths, subTier, event.getFlags()));
+                eventManager.publish(new CheerEvent(event, channel, user != null ? user : ANONYMOUS_CHEERER, message, bits, subMonths, subTier, event.getFlags()));
             }
         }
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
@@ -19,7 +19,7 @@ import java.util.Set;
 @Value
 @Getter
 @EqualsAndHashCode(callSuper = false)
-public class ChannelMessageActionEvent extends AbstractChannelEvent {
+public class ChannelMessageActionEvent extends AbstractChannelEvent implements ReplyableEvent {
 
     /**
      * RAW Message Event

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -66,7 +66,6 @@ public class ChannelMessageEvent extends AbstractChannelEvent implements Replyab
      * Information regarding the parent message being replied to, if applicable.
      */
     @Nullable
-    @Unofficial
     @Getter(lazy = true)
     private ChatReply replyInfo = ChatReply.parse(getMessageEvent().getTags());
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -23,7 +23,7 @@ import java.util.Set;
 @Value
 @Getter
 @EqualsAndHashCode(callSuper = false)
-public class ChannelMessageEvent extends AbstractChannelEvent {
+public class ChannelMessageEvent extends AbstractChannelEvent implements ReplyableEvent {
 
     /**
      * RAW Message Event

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
@@ -17,7 +17,12 @@ import java.util.List;
 @Value
 @Getter
 @EqualsAndHashCode(callSuper = false)
-public class CheerEvent extends AbstractChannelEvent {
+public class CheerEvent extends AbstractChannelEvent implements ReplyableEvent {
+
+    /**
+     * Raw IRC Message Event
+     */
+    IRCMessageEvent messageEvent;
 
 	/**
 	 * Event Target User
@@ -50,19 +55,21 @@ public class CheerEvent extends AbstractChannelEvent {
     @Unofficial
     private List<AutoModFlag> flags;
 
-	/**
-	 * Event Constructor
+    /**
+     * Event Constructor
      *
-     * @param channel The channel that this event originates from.
-     * @param user The donating user.
-     * @param message The donation message.
-     * @param bits The amount of bits.
+     * @param event            The raw message event.
+     * @param channel          The channel that this event originates from.
+     * @param user             The donating user.
+     * @param message          The donation message.
+     * @param bits             The amount of bits.
      * @param subscriberMonths The exact number of months the user has been a subscriber.
      * @param subscriptionTier The tier at which the user is subscribed.
-     * @param flags The regions of the message that were flagged by AutoMod.
+     * @param flags            The regions of the message that were flagged by AutoMod.
      */
-	public CheerEvent(EventChannel channel, EventUser user, String message, Integer bits, int subscriberMonths, int subscriptionTier, List<AutoModFlag> flags) {
+	public CheerEvent(IRCMessageEvent event, EventChannel channel, EventUser user, String message, Integer bits, int subscriberMonths, int subscriptionTier, List<AutoModFlag> flags) {
 		super(channel);
+		this.messageEvent = event;
 		this.user = user;
 		this.message = message;
 		this.bits = bits;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.ITwitchChat;
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.util.CryptoUtils;
 
@@ -20,7 +19,6 @@ public interface ReplyableEvent {
      * @param chat    the {@link ITwitchChat} instance to send the message from.
      * @param message the message to be sent.
      */
-    @Unofficial
     default void reply(ITwitchChat chat, String message) {
         chat.sendMessage(getChannel().getName(), message, CryptoUtils.generateNonce(32), getMessageEvent().getMessageId().orElse(null));
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.ITwitchChat;
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.util.CryptoUtils;
+
+@FunctionalInterface
+public interface ReplyableEvent {
+
+    IRCMessageEvent getMessageEvent();
+
+    default EventChannel getChannel() {
+        return getMessageEvent().getChannel();
+    }
+
+    /**
+     * Sends a reply to this chat message.
+     *
+     * @param chat    the {@link ITwitchChat} instance to send the message from.
+     * @param message the message to be sent.
+     */
+    @Unofficial
+    default void reply(ITwitchChat chat, String message) {
+        chat.sendMessage(getChannel().getName(), message, CryptoUtils.generateNonce(32), getMessageEvent().getMessageId().orElse(null));
+    }
+
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -101,6 +101,7 @@ public class SubscriptionEvent extends AbstractChannelEvent implements Replyable
     /**
      * Event Constructor
      *
+     * @param event              The raw message event.
      * @param channel            ChatChannel the user subscribed to
      * @param user               User that subscribed
      * @param subPlan            Sub Plan

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.chat.events.channel;
 
+import com.github.twitch4j.chat.ITwitchChat;
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.chat.flag.AutoModFlag;
 import com.github.twitch4j.common.annotation.Unofficial;
@@ -25,7 +26,12 @@ import java.util.Optional;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class SubscriptionEvent extends AbstractChannelEvent {
+public class SubscriptionEvent extends AbstractChannelEvent implements ReplyableEvent {
+
+    /**
+     * Raw IRC Message Event
+     */
+    IRCMessageEvent messageEvent;
 
     /**
      * Event Target User
@@ -108,8 +114,9 @@ public class SubscriptionEvent extends AbstractChannelEvent {
      * @param multiMonthTenure   The length of multi-month subscription tenure that has already been served
      * @param flags              The regions of the message that were flagged by AutoMod.
      */
-    public SubscriptionEvent(EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths, Integer multiMonthDuration, Integer multiMonthTenure, List<AutoModFlag> flags) {
+    public SubscriptionEvent(IRCMessageEvent event, EventChannel channel, EventUser user, String subPlan, Optional<String> message, Integer months, Boolean gifted, EventUser giftedBy, Integer subStreak, Integer giftMonths, Integer multiMonthDuration, Integer multiMonthTenure, List<AutoModFlag> flags) {
         super(channel);
+        this.messageEvent = event;
         this.user = user;
         this.subscriptionPlan = subPlan;
         this.message = message;
@@ -121,6 +128,16 @@ public class SubscriptionEvent extends AbstractChannelEvent {
         this.multiMonthDuration = multiMonthDuration;
         this.multiMonthTenure = multiMonthTenure;
         this.flags = flags;
+    }
+
+    /**
+     * Replies to this sub event, <i>if</i> a message was included when the subscription was shared.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void reply(ITwitchChat chat, String message) {
+        getMessage().ifPresent(m -> ReplyableEvent.super.reply(chat, message));
     }
 
     /**

--- a/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.common.util;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -12,7 +11,6 @@ import static com.github.twitch4j.common.util.EscapeUtils.unescapeTagValue;
  * Meta-info regarding the <i>parent</i> message being replied to.
  */
 @Value
-@Unofficial
 public class ChatReply {
 
     public static final String REPLY_MSG_ID_TAG_NAME = "reply-parent-msg-id";


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Closes #245 

### Changes Proposed
* Create `ReplyableEvent` interface (to simply sending a chat reply) & implement it for `ChannelMessageEvent`, `ChannelMessageActionEvent`, `CheerEvent`, and `SubscriptionEvent`
