### PR TITLE
feat: implement channel.subscription.message v1 eventsub

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelSubscriptionMessageCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelSubscriptionMessageCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelSubscriptionMessageCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Message.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Message.java
@@ -1,0 +1,47 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class Message {
+
+    /**
+     * The text of the re-subscription chat message.
+     */
+    private String text;
+
+    /**
+     * A collection that includes the emote ID and start and end positions for where the emote appears in the text.
+     */
+    private List<Emote> emotes;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @NoArgsConstructor
+    public static class Emote {
+
+        /**
+         * The index of where the Emote starts in the text.
+         */
+        private Integer begin;
+
+        /**
+         * The index of where the Emote ends in the text.
+         */
+        private Integer end;
+
+        /**
+         * The emote ID.
+         */
+        private String id;
+
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelSubscriptionMessageEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelSubscriptionMessageEvent.java
@@ -1,0 +1,49 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
+import com.github.twitch4j.eventsub.domain.Message;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelSubscriptionMessageEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The tier of the user’s subscription.
+     */
+    private SubscriptionPlan tier;
+
+    /**
+     * An object that contains the re-subscription message and emote information needed to recreate the message.
+     */
+    private Message message;
+
+    /**
+     * The total number of months the user has been subscribed to the channel.
+     */
+    @JsonAlias("cumulative_total") // https://github.com/twitchdev/issues/issues/415
+    private Integer cumulativeMonths;
+
+    /**
+     * The number of consecutive months the user’s current subscription has been active.
+     * This value is null if the user has opted out of sharing this information.
+     */
+    @Nullable
+    private Integer streakMonths;
+
+    /**
+     * The month duration of the subscription.
+     */
+    private Integer durationMonths;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUnsubscribeEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUnsubscribeEvent.java
@@ -1,8 +1,32 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
+import lombok.AccessLevel;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelUnsubscribeEvent extends EventSubUserChannelEvent {}
+public class ChannelUnsubscribeEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The tier of the subscription that ended.
+     */
+    private SubscriptionPlan tier;
+
+    /**
+     * Whether the subscription was a gift.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_gift")
+    private Boolean isGift;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelSubscriptionMessageType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelSubscriptionMessageType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.eventsub.condition.ChannelSubscriptionMessageCondition;
+import com.github.twitch4j.eventsub.events.ChannelSubscriptionMessageEvent;
+
+/**
+ * The channel.subscription.message subscription type sends a notification when a user sends a re-subscription chat message in a specific channel.
+ * <p>
+ * Must have channel:read:subscriptions scope.
+ * <p>
+ * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released.
+ * Subscriptions should be updated to v1 during this timeframe. Any active beta subscriptions beyond 30 days will be automatically deleted.
+ */
+@Unofficial
+public class BetaChannelSubscriptionMessageType implements SubscriptionType<ChannelSubscriptionMessageCondition, ChannelSubscriptionMessageCondition.ChannelSubscriptionMessageConditionBuilder<?, ?>, ChannelSubscriptionMessageEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.subscription.message";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelSubscriptionMessageCondition.ChannelSubscriptionMessageConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelSubscriptionMessageCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelSubscriptionMessageEvent> getEventClass() {
+        return ChannelSubscriptionMessageEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelSubscriptionGiftType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelSubscriptionGiftType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelSubscriptionGiftCondition;
 import com.github.twitch4j.eventsub.events.ChannelSubscriptionGiftEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelSubscriptionGiftEvent;
  * The channel.subscription.gift subscription type sends a notification when a user gives one or more gifted subscriptions in a channel.
  * <p>
  * Must have channel:read:subscriptions scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released.
- * Subscriptions should be updated to v1 during this timeframe. Any active beta subscriptions beyond 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaChannelSubscriptionGiftType implements SubscriptionType<ChannelSubscriptionGiftCondition, ChannelSubscriptionGiftCondition.ChannelSubscriptionGiftConditionBuilder<?, ?>, ChannelSubscriptionGiftEvent> {
+public class ChannelSubscriptionGiftType implements SubscriptionType<ChannelSubscriptionGiftCondition, ChannelSubscriptionGiftCondition.ChannelSubscriptionGiftConditionBuilder<?, ?>, ChannelSubscriptionGiftEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaChannelSubscriptionGiftType implements SubscriptionType<Channel
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelSubscriptionMessageType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelSubscriptionMessageType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelSubscriptionMessageCondition;
 import com.github.twitch4j.eventsub.events.ChannelSubscriptionMessageEvent;
 
@@ -8,12 +7,8 @@ import com.github.twitch4j.eventsub.events.ChannelSubscriptionMessageEvent;
  * The channel.subscription.message subscription type sends a notification when a user sends a re-subscription chat message in a specific channel.
  * <p>
  * Must have channel:read:subscriptions scope.
- * <p>
- * Unless otherwise noted, EventSub subscriptions that were released as a public beta will be available for 30 days after their v1 version is released.
- * Subscriptions should be updated to v1 during this timeframe. Any active beta subscriptions beyond 30 days will be automatically deleted.
  */
-@Unofficial
-public class BetaChannelSubscriptionMessageType implements SubscriptionType<ChannelSubscriptionMessageCondition, ChannelSubscriptionMessageCondition.ChannelSubscriptionMessageConditionBuilder<?, ?>, ChannelSubscriptionMessageEvent> {
+public class ChannelSubscriptionMessageType implements SubscriptionType<ChannelSubscriptionMessageCondition, ChannelSubscriptionMessageCondition.ChannelSubscriptionMessageConditionBuilder<?, ?>, ChannelSubscriptionMessageEvent> {
 
     @Override
     public String getName() {
@@ -22,7 +17,7 @@ public class BetaChannelSubscriptionMessageType implements SubscriptionType<Chan
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -25,8 +25,8 @@ public class SubscriptionTypes {
     public final ChannelRaidType CHANNEL_RAID;
     public final ChannelSubscribeType CHANNEL_SUBSCRIBE;
     public final ChannelSubscriptionEndType CHANNEL_SUBSCRIPTION_END;
-    @Unofficial public final BetaChannelSubscriptionGiftType BETA_CHANNEL_SUBSCRIPTION_GIFT;
-    @Unofficial public final BetaChannelSubscriptionMessageType BETA_CHANNEL_SUBSCRIPTION_MESSAGE;
+    public final ChannelSubscriptionGiftType CHANNEL_SUBSCRIPTION_GIFT;
+    public final ChannelSubscriptionMessageType CHANNEL_SUBSCRIPTION_MESSAGE;
     public final ChannelUnbanType CHANNEL_UNBAN;
     public final ChannelUpdateType CHANNEL_UPDATE;
     @Unofficial public final BetaExtensionBitsTransactionCreateType BETA_EXTENSION_BITS_TRANSACTION_CREATE;
@@ -65,8 +65,8 @@ public class SubscriptionTypes {
                 CHANNEL_RAID = new ChannelRaidType(),
                 CHANNEL_SUBSCRIBE = new ChannelSubscribeType(),
                 CHANNEL_SUBSCRIPTION_END = new ChannelSubscriptionEndType(),
-                BETA_CHANNEL_SUBSCRIPTION_GIFT = new BetaChannelSubscriptionGiftType(),
-                BETA_CHANNEL_SUBSCRIPTION_MESSAGE = new BetaChannelSubscriptionMessageType(),
+                CHANNEL_SUBSCRIPTION_GIFT = new ChannelSubscriptionGiftType(),
+                CHANNEL_SUBSCRIPTION_MESSAGE = new ChannelSubscriptionMessageType(),
                 CHANNEL_UNBAN = new ChannelUnbanType(),
                 CHANNEL_UPDATE = new ChannelUpdateType(),
                 BETA_EXTENSION_BITS_TRANSACTION_CREATE = new BetaExtensionBitsTransactionCreateType(),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -26,6 +26,7 @@ public class SubscriptionTypes {
     public final ChannelSubscribeType CHANNEL_SUBSCRIBE;
     public final ChannelSubscriptionEndType CHANNEL_SUBSCRIPTION_END;
     @Unofficial public final BetaChannelSubscriptionGiftType BETA_CHANNEL_SUBSCRIPTION_GIFT;
+    @Unofficial public final BetaChannelSubscriptionMessageType BETA_CHANNEL_SUBSCRIPTION_MESSAGE;
     public final ChannelUnbanType CHANNEL_UNBAN;
     public final ChannelUpdateType CHANNEL_UPDATE;
     @Unofficial public final BetaExtensionBitsTransactionCreateType BETA_EXTENSION_BITS_TRANSACTION_CREATE;
@@ -65,6 +66,7 @@ public class SubscriptionTypes {
                 CHANNEL_SUBSCRIBE = new ChannelSubscribeType(),
                 CHANNEL_SUBSCRIPTION_END = new ChannelSubscriptionEndType(),
                 BETA_CHANNEL_SUBSCRIPTION_GIFT = new BetaChannelSubscriptionGiftType(),
+                BETA_CHANNEL_SUBSCRIPTION_MESSAGE = new BetaChannelSubscriptionMessageType(),
                 CHANNEL_UNBAN = new ChannelUnbanType(),
                 CHANNEL_UPDATE = new ChannelUpdateType(),
                 BETA_EXTENSION_BITS_TRANSACTION_CREATE = new BetaExtensionBitsTransactionCreateType(),


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/415

### Changes Proposed
* Implement Channel Subscription Message (v1) EventSub
* Promote Channel Subscription Gift EventSub from beta to v1
* Add `tier` and `is_gift` fields to Channel Subscription End Event

### Additional Information
https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelsubscriptionmessage
https://dev.twitch.tv/docs/change-log
