### PR TITLE
chore: warn on full request logging / keep api auth tokens out of logfiles

### DIFF
--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
@@ -90,6 +90,11 @@ public class TwitchExtensionsBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Warning
+        if (logLevel == Logger.Level.HEADERS || logLevel == Logger.Level.FULL) {
+            log.warn("Extensions: The current feign loglevel will print sensitive information including your access token, please don't share this log!");
+        }
+        
         // Jackson ObjectMapper
         ObjectMapper mapper = TypeConvert.getObjectMapper();
 

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/util/TwitchExtensionsErrorDecoder.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/util/TwitchExtensionsErrorDecoder.java
@@ -46,19 +46,16 @@ public class TwitchExtensionsErrorDecoder implements ErrorDecoder {
                 ex = new UnauthorizedException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 404) {
                 ex = new NotFoundException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 429) {
                 ex = new ContextedRuntimeException("To many requests!")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.
@@ -70,7 +67,6 @@ public class TwitchExtensionsErrorDecoder implements ErrorDecoder {
                 ex = new ContextedRuntimeException("Extensions API Error")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody)
                     .addContextValue("errorType", error.getError())
                     .addContextValue("errorStatus", error.getStatus())

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -116,6 +116,11 @@ public class TwitchHelixBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Warning
+        if (logLevel == Logger.Level.HEADERS || logLevel == Logger.Level.FULL) {
+            log.warn("Helix: The current feign loglevel will print sensitive information including your access token, please don't share this log!");
+        }
+
         // Jackson ObjectMapper
         ObjectMapper mapper = TypeConvert.getObjectMapper();
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -56,19 +56,16 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
                 ex = new UnauthorizedException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 404) {
                 ex = new NotFoundException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 429) {
                 ex = new ContextedRuntimeException("To many requests!")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);;
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.
@@ -80,7 +77,6 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
                 ex = new ContextedRuntimeException("Helix API Error")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody)
                     .addContextValue("errorType", error.getError())
                     .addContextValue("errorStatus", error.getStatus())

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -111,6 +111,11 @@ public class TwitchKrakenBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.TwitchKraken#getChatEmoticons().execution.isolation.thread.timeoutInMilliseconds", timeout * 4);
         ConfigurationManager.getConfigInstance().setProperty("hystrix.command.TwitchKraken#getAllChatEmoticons().execution.isolation.thread.timeoutInMilliseconds", timeout * 8);
 
+        // Warning
+        if (logLevel == Logger.Level.HEADERS || logLevel == Logger.Level.FULL) {
+            log.warn("Kraken: The current feign loglevel will print sensitive information including your access token, please don't share this log!");
+        }
+
         // Jackson ObjectMapper
         ObjectMapper mapper = TypeConvert.getObjectMapper();
 

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
@@ -56,19 +56,16 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
                 ex = new UnauthorizedException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 404) {
                 ex = new NotFoundException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 429) {
                 ex = new ContextedRuntimeException("To many requests!")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);;
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.
@@ -80,7 +77,6 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
                 ex = new ContextedRuntimeException("Kraken API Error")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody)
                     .addContextValue("errorType", error.getError())
                     .addContextValue("errorStatus", error.getStatus())

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -98,6 +98,11 @@ public class TwitchMessagingInterfaceBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Warning
+        if (logLevel == Logger.Level.HEADERS || logLevel == Logger.Level.FULL) {
+            log.warn("TMI: The current feign loglevel will print sensitive information including your access token, please don't share this log!");
+        }
+
         // Create HttpClient with proxy
         okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();
         if (proxyConfig != null)

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceErrorDecoder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceErrorDecoder.java
@@ -52,13 +52,11 @@ public class TwitchMessagingInterfaceErrorDecoder implements ErrorDecoder {
                 throw new UnauthorizedException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 404) {
                 throw new NotFoundException()
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.
@@ -71,7 +69,6 @@ public class TwitchMessagingInterfaceErrorDecoder implements ErrorDecoder {
             return new ContextedRuntimeException("TMI API Error")
                 .addContextValue("requestUrl", response.request().url())
                 .addContextValue("requestMethod", response.request().httpMethod())
-                .addContextValue("requestHeaders", response.request().headers().entrySet().toString())
                 .addContextValue("responseBody", responseBody)
                 .addContextValue("errorType", error.getError())
                 .addContextValue("errorStatus", error.getStatus())


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* prevents printing auth tokens into the log on api request errors
* warning about sharing logs when full-request logging is enabled as they contain the auth headers

### Additional Information

<!-- Any other information that may be able to help me with the problem. Remove this if it is not needed. -->
