### PR TITLE
feat: implement new helix schedule api

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class TypeConvert {
         .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
         .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         .addModule(new JavaTimeModule())
         .build();

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -991,6 +991,113 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets all scheduled broadcasts or specific scheduled broadcasts from a channel’s stream schedule.
+     *
+     * @param authToken     User OAuth Token or App Access Token.
+     * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule.
+     * @param ids           The ID of the stream segment to return.Maximum: 100.
+     * @param startTime     A timestamp in RFC3339 format to start returning stream segments from. If not specified, the current date and time is used.
+     * @param utcOffset     A timezone offset for the requester specified in minutes. For example, a timezone that is +4 hours from GMT would be “240.” If not specified, “0” is used for GMT.
+     * @param after         Cursor for forward pagination: tells the server where to start fetching the next set of results in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+     * @param limit         Maximum number of stream segments to return.Maximum: 25. Default: 20.
+     * @return StreamScheduleResponse
+     */
+    @RequestLine("GET /schedule?broadcaster_id={broadcaster_id}&id={id}&start_time={start_time}&utc_offset={utc_offset}&first={first}&after={after}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<StreamScheduleResponse> getChannelStreamSchedule(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("id") Collection<String> ids,
+        @Param("start_time") Instant startTime,
+        @Param("utc_offset") String utcOffset,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    );
+
+    /**
+     * Gets all scheduled broadcasts from a channel’s stream schedule as an iCalendar.
+     *
+     * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule.
+     * @return iCalendar data is returned according to RFC5545. The expected MIME type is text/calendar.
+     */
+    @RequestLine("GET /schedule/icalendar?broadcaster_id={broadcaster_id}")
+    HystrixCommand<Response> getChannelInternetCalendar(
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
+     * Update the settings for a channel’s stream schedule.
+     *
+     * @param authToken       User OAuth Token of the broadcaster (scope: "channel:manage:schedule").
+     * @param broadcasterId   User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param vacationEnabled Indicates whether Vacation Mode is enabled.
+     * @param vacationStart   Start time for vacation specified in RFC3339 format. Required if is_vacation_enabled is set to true.
+     * @param vacationEnd     End time for vacation specified in RFC3339 format. Required if is_vacation_enabled is set to true.
+     * @param timezone        The timezone for when the vacation is being scheduled using the IANA time zone database format. Required if is_vacation_enabled is set to true.
+     * @return 204 No Content upon a successful call.
+     */
+    @RequestLine("PATCH /schedule/settings?broadcaster_id={broadcaster_id}&is_vacation_enabled={is_vacation_enabled}&vacation_start_time={vacation_start_time}&vacation_end_time={vacation_end_time}&timezone={timezone}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> updateChannelStreamSchedule(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("is_vacation_enabled") Boolean vacationEnabled,
+        @Param("vacation_start_time") Instant vacationStart,
+        @Param("vacation_end_time") Instant vacationEnd,
+        @Param("timezone") String timezone
+    );
+
+    /**
+     * Create a single scheduled broadcast or a recurring scheduled broadcast for a channel’s stream schedule.
+     *
+     * @param authToken     User OAuth Token of the broadcaster (scope: "channel:manage:schedule").
+     * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param segment       Properties of the scheduled broadcast (required: start_time, timezone, is_recurring).
+     * @return StreamScheduleResponse
+     */
+    @RequestLine("POST /schedule/segment?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<StreamScheduleResponse> createStreamScheduleSegment(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        ScheduleSegmentInput segment
+    );
+
+    /**
+     * Update a single scheduled broadcast or a recurring scheduled broadcast for a channel’s stream schedule.
+     *
+     * @param authToken     User OAuth Token of the broadcaster (scope: "channel:manage:schedule").
+     * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param id            The ID of the streaming segment to update.
+     * @param segment       Updated properties of the scheduled broadcast.
+     * @return StreamScheduleResponse
+     */
+    @RequestLine("PATCH /schedule/segment?broadcaster_id={broadcaster_id}&id={id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<StreamScheduleResponse> updateStreamScheduleSegment(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("id") String id,
+        ScheduleSegmentInput segment
+    );
+
+    /**
+     * Delete a single scheduled broadcast or a recurring scheduled broadcast for a channel’s stream schedule.
+     *
+     * @param authToken     User OAuth Token of the broadcaster (scope: "channel:manage:schedule").
+     * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param id            The ID of the streaming segment to delete.
+     * @return 204 No Content upon a successful call.
+     */
+    @RequestLine("DELETE /schedule/segment?broadcaster_id={broadcaster_id}&id={id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> deleteStreamScheduleSegment(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("id") String id
+    );
+
+    /**
      * Gets information about active streams.
      * <p>
      * Streams are returned sorted by number of current viewers, in descending order.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -995,11 +995,11 @@ public interface TwitchHelix {
      *
      * @param authToken     User OAuth Token or App Access Token.
      * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule.
-     * @param ids           The ID of the stream segment to return.Maximum: 100.
+     * @param ids           The ID of the stream segment to return. Maximum: 100.
      * @param startTime     A timestamp in RFC3339 format to start returning stream segments from. If not specified, the current date and time is used.
      * @param utcOffset     A timezone offset for the requester specified in minutes. For example, a timezone that is +4 hours from GMT would be “240.” If not specified, “0” is used for GMT.
      * @param after         Cursor for forward pagination: tells the server where to start fetching the next set of results in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
-     * @param limit         Maximum number of stream segments to return.Maximum: 25. Default: 20.
+     * @param limit         Maximum number of stream segments to return. Maximum: 25. Default: 20.
      * @return StreamScheduleResponse
      */
     @RequestLine("GET /schedule?broadcaster_id={broadcaster_id}&id={id}&start_time={start_time}&utc_offset={utc_offset}&first={first}&after={after}")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ScheduleSegmentInput.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ScheduleSegmentInput.java
@@ -1,0 +1,70 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+import java.time.Instant;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ScheduleSegmentInput {
+
+    /**
+     * Start time for the scheduled broadcast specified in RFC3339 format.
+     */
+    private Instant startTime;
+
+    /**
+     * The timezone of the application creating the scheduled broadcast using the IANA time zone database format.
+     *
+     * @see <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>
+     */
+    private String timezone;
+
+    /**
+     * Indicates if the scheduled broadcast is recurring weekly.
+     */
+    @JsonProperty("is_recurring")
+    private Boolean recurring;
+
+    /**
+     * Indicated if the scheduled broadcast is canceled.
+     */
+    @JsonProperty("is_canceled")
+    private Boolean canceled;
+
+    /**
+     * Duration of the scheduled broadcast in minutes from the start_time.
+     * Default: 240.
+     */
+    @JsonProperty("duration")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Integer durationMinutes;
+
+    /**
+     * Game/Category ID for the scheduled broadcast.
+     */
+    private String categoryId;
+
+    /**
+     * Title for the scheduled broadcast.
+     * Maximum: 140 characters.
+     */
+    private String title;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ScheduledSegment.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ScheduledSegment.java
@@ -1,0 +1,74 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ScheduledSegment {
+
+    /**
+     * The ID for the scheduled broadcast.
+     */
+    private String id;
+
+    /**
+     * Scheduled start time for the scheduled broadcast in RFC3339 format.
+     */
+    private Instant startTime;
+
+    /**
+     * Scheduled end time for the scheduled broadcast in RFC3339 format.
+     */
+    private Instant endTime;
+
+    /**
+     * Title for the scheduled broadcast.
+     */
+    private String title;
+
+    /**
+     * Used with recurring scheduled broadcasts.
+     * Specifies the date of the next recurring broadcast in RFC3339 format if one or more specific broadcasts have been deleted in the series.
+     * Set to null otherwise.
+     */
+    @Nullable
+    private Instant canceledUntil;
+
+    /**
+     * The category for the scheduled broadcast.
+     * Set to null if no category has been specified.
+     */
+    @Nullable
+    private Category category;
+
+    /**
+     * Indicates whether the scheduled broadcast is recurring weekly.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_recurring")
+    private Boolean isRecurring;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Category {
+
+        /**
+         * Game/category ID.
+         */
+        private String id;
+
+        /**
+         * Game/category name.
+         */
+        private String name;
+
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ScheduledVacation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ScheduledVacation.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ScheduledVacation {
+
+    /**
+     * Start time for vacation specified in RFC3339 format.
+     */
+    private Instant startTime;
+
+    /**
+     * End time for vacation specified in RFC3339 format.
+     */
+    private Instant endTime;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamSchedule.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamSchedule.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class StreamSchedule {
+
+    /**
+     * Scheduled broadcasts for this stream schedule.
+     */
+    private List<ScheduledSegment> segments;
+
+    /**
+     * User ID of the broadcaster.
+     */
+    private String broadcasterId;
+
+    /**
+     * Display name of the broadcaster.
+     */
+    private String broadcasterName;
+
+    /**
+     * Login name of the broadcaster.
+     */
+    private String broadcasterLogin;
+
+    /**
+     * If Vacation Mode is enabled, this includes start and end dates for the vacation.
+     * If Vacation Mode is disabled, this value is set to null.
+     */
+    @Nullable
+    private ScheduledVacation vacation;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamScheduleResponse.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamScheduleResponse.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class StreamScheduleResponse {
+
+    @JsonProperty("data")
+    private StreamSchedule schedule;
+
+    private HelixPagination pagination;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#getChannelStreamSchedule`
* Add `TwitchHelix#getChannelInternetCalendar`
* Add `TwitchHelix#updateChannelStreamSchedule`
* Add `TwitchHelix#createStreamScheduleSegment`
* Add `TwitchHelix#updateStreamScheduleSegment`
* Add `TwitchHelix#deleteStreamScheduleSegment`

### Additional Information
https://dev.twitch.tv/docs/change-log
