### PR TITLE
fix: properly shutdown twitch4j thread pools on close

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
@@ -227,7 +227,8 @@ public class TwitchClient implements ITwitchClient {
         if (scheduledThreadPoolExecutor.getThreadFactory() instanceof BasicThreadFactory) {
             BasicThreadFactory threadFactory = (BasicThreadFactory) scheduledThreadPoolExecutor.getThreadFactory();
 
-            if (threadFactory.getNamingPattern().equalsIgnoreCase("twitch4j-%d")) {
+            String pattern = threadFactory.getNamingPattern();
+            if (pattern != null && pattern.startsWith("twitch4j-") && pattern.endsWith("-%d")) {
                 scheduledThreadPoolExecutor.shutdownNow();
             }
         }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Closes #390 

### Changes Proposed
Loosen our thread pool naming pattern matching so that the following are recognized as twitch4j threadpools that ought to be shutdown on close:
* `"twitch4j"`
* `"twitch4j-" + RandomStringUtils.random(4, true, true)`
* `"twitch4j-chat-" + RandomStringUtils.random(4, true, true)`
* `"twitch4j-pubsub-" + RandomStringUtils.random(4, true, true)`
* `"twitch4j-pool-" + RandomStringUtils.random(4, true, true) + "-chat-" + RandomStringUtils.random(4, true, true)`
* `"twitch4j-pool-" + RandomStringUtils.random(4, true, true) + "-pubsub-" + RandomStringUtils.random(4, true, true)`
