### PR TITLE
feat: add new fields to eventsub channel unsub event

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUnsubscribeEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUnsubscribeEvent.java
@@ -1,8 +1,34 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
+import lombok.AccessLevel;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChannelUnsubscribeEvent extends EventSubUserChannelEvent {}
+public class ChannelUnsubscribeEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The tier of the subscription.
+     * <p>
+     * Prime is treated as 1000, at the time of writing.
+     */
+    private SubscriptionPlan tier;
+
+    /**
+     * Whether the subscription is a gift.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_gift")
+    private Boolean isGift;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project

### Changes Proposed
* EventSub: Add `tier` and `is_gift` fields to Channel Subscription End Event

### Additional Information
https://dev.twitch.tv/docs/change-log
