### PR TITLE
feat: add update drops entitlements helix endpoint

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -361,19 +361,50 @@ public interface TwitchHelix {
      * @param id        Optional: Unique Identifier of the entitlement.
      * @param userId    Optional: A Twitch User ID.
      * @param gameId    Optional: A Twitch Game ID.
+     * @param status    Optional: Fulfillment status used to filter entitlements.
      * @param after     Optional: The cursor used to fetch the next page of data.
      * @param limit     Optional: Maximum number of entitlements to return. Default: 20. Max: 1000.
      * @return DropsEntitlementList
      */
-    @RequestLine("GET /entitlements/drops?id={id}&user_id={user_id}&game_id={game_id}&after={after}&first={first}")
+    @RequestLine("GET /entitlements/drops?id={id}&user_id={user_id}&game_id={game_id}&fulfillment_status={fulfillment_status}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<DropsEntitlementList> getDropsEntitlements(
         @Param("token") String authToken,
         @Param("id") String id,
         @Param("user_id") String userId,
         @Param("game_id") String gameId,
+        @Param("fulfillment_status") DropFulfillmentStatus status,
         @Param("after") String after,
         @Param("first") Integer limit
+    );
+
+    @Deprecated
+    default HystrixCommand<DropsEntitlementList> getDropsEntitlements(
+        @Param("token") String authToken,
+        @Param("id") String id,
+        @Param("user_id") String userId,
+        @Param("game_id") String gameId,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    ) {
+        return getDropsEntitlements(authToken, id, userId, gameId, null, after, limit);
+    }
+
+    /**
+     * Updates the fulfillment status on a set of Drops entitlements, specified by their entitlement IDs.
+     *
+     * @param authToken User OAuth Token or App Access Token where the client ID associated with the access token must have ownership of the game.
+     * @param input     The fulfillment_status to assign to each of the entitlement_ids.
+     * @return UpdatedDropEntitlementsList
+     */
+    @RequestLine("PATCH /entitlements/drops")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    HystrixCommand<UpdatedDropEntitlementsList> updateDropsEntitlements(
+        @Param("token") String authToken,
+        UpdateDropEntitlementInput input
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropFulfillmentStatus.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropFulfillmentStatus.java
@@ -1,0 +1,6 @@
+package com.github.twitch4j.helix.domain;
+
+public enum DropFulfillmentStatus {
+    CLAIMED,
+    FULFILLED
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlement.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/DropsEntitlement.java
@@ -31,6 +31,16 @@ public class DropsEntitlement {
     private Instant timestamp;
 
     /**
+     * UTC timestamp in ISO format for when this entitlement was last updated.
+     */
+    private Instant updatedAt;
+
+    /**
+     * The fulfillment status of the entitlement as determined by the game developer.
+     */
+    private DropFulfillmentStatus fulfillmentStatus;
+
+    /**
      * Twitch User ID of the user who was granted the entitlement.
      */
     private String userId;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdateDropEntitlementInput.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdateDropEntitlementInput.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Singular;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpdateDropEntitlementInput {
+
+    /**
+     * The fulfillment status to assign to each of the enclosed entitlement ids.
+     */
+    private DropFulfillmentStatus fulfillmentStatus;
+
+    /**
+     * The unique identifiers of the entitlements to update.
+     */
+    @Singular
+    private List<String> entitlementIds;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdateEntitlementStatus.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdateEntitlementStatus.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.helix.domain;
+
+/**
+ * Status code applied to a set of entitlements for the update operation that can be used to indicate partial success.
+ */
+public enum UpdateEntitlementStatus {
+
+    /**
+     * Entitlement was successfully updated.
+     */
+    SUCCESS,
+
+    /**
+     * Invalid format for entitlement ID.
+     */
+    INVALID_ID,
+
+    /**
+     * Entitlement ID does not exist.
+     */
+    NOT_FOUND,
+
+    /**
+     * Entitlement is not owned by the organization or the user when called with a user OAuth token.
+     */
+    UNAUTHORIZED,
+
+    /**
+     * Indicates the entitlement update operation failed.
+     * Errors in the this state are expected to be be transient and should be retried later.
+     */
+    UPDATE_FAILED
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdatedDropEntitlements.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdatedDropEntitlements.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class UpdatedDropEntitlements {
+
+    /**
+     * Status code applied to a set of entitlements for the update operation that can be used to indicate partial success.
+     */
+    private UpdateEntitlementStatus status;
+
+    /**
+     * The unique identifiers of the entitlements for the specified status.
+     */
+    private List<String> ids;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdatedDropEntitlementsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UpdatedDropEntitlementsList.java
@@ -1,0 +1,44 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class UpdatedDropEntitlementsList {
+
+    /**
+     * The entitlement update statuses.
+     */
+    private List<UpdatedDropEntitlements> data;
+
+    @ToString.Exclude
+    @Getter(lazy = true)
+    private final Map<UpdateEntitlementStatus, Collection<String>> transformedData = transform(getData());
+
+    private static Map<UpdateEntitlementStatus, Collection<String>> transform(Collection<UpdatedDropEntitlements> rawData) {
+        final Map<UpdateEntitlementStatus, Collection<String>> map = new EnumMap<>(UpdateEntitlementStatus.class);
+
+        for (UpdatedDropEntitlements updated : rawData) {
+            map.merge(updated.getStatus(), new HashSet<>(updated.getIds()), (c1, c2) -> {
+                c1.addAll(c2);
+                return c1;
+            });
+        }
+
+        return Collections.unmodifiableMap(map);
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Implement `TwitchHelix#updateDropsEntitlements(String, UpdateDropEntitlementInput)`
* Add `fulfillment_status` and `updated_at` to `DropsEntitlement` response object
* Add `fulfillment_status` as a query parameter to `TwitchHelix#getDropsEntitlements` (and deprecate the old method without this parameter)

### Additional Information
https://dev.twitch.tv/docs/change-log
