### PR TITLE
feat: add new fields to helix banned routes

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedEvent.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 
@@ -79,6 +80,27 @@ public class BannedEvent {
          * When the timeout expires, if applicable
          */
         private Instant expiresAt;
+
+        /**
+         * The reason for the ban if provided by the moderator.
+         */
+        @Nullable
+        private String reason;
+
+        /**
+         * User ID of the moderator who initiated the ban.
+         */
+        private String moderatorId;
+
+        /**
+         * Login name of the moderator who initiated the ban.
+         */
+        private String moderatorLogin;
+
+        /**
+         * Display name of the moderator who initiated the ban.
+         */
+        private String moderatorName;
     }
 
     public enum EventType {

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUser.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUser.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 
@@ -32,4 +33,25 @@ public class BannedUser {
      * Timestamp for timeouts, empty for bans
      */
     private Instant expiresAt;
+
+    /**
+     * The reason for the ban if provided by the moderator.
+     */
+    @Nullable
+    private String reason;
+
+    /**
+     * User ID of the moderator who initiated the ban.
+     */
+    private String moderatorId;
+
+    /**
+     * Login name of the moderator who initiated the ban.
+     */
+    private String moderatorLogin;
+
+    /**
+     * Display name of the moderator who initiated the ban.
+     */
+    private String moderatorName;
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* `BannedEvent` and `BannedUser` now include `reason`, `moderatorId`, `moderatorLogin`, `moderatorName` fields

### Additional Information
https://dev.twitch.tv/docs/change-log
