### PR TITLE
fix: update InboundHostEvent with latest twitch pattern

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -513,11 +513,12 @@ public class IRCEventHandler {
 
     public void onInboundHostEvent(IRCMessageEvent event) {
         if ("PRIVMSG".equals(event.getCommandType()) && "jtv".equals(event.getClientName().orElse(null)) && event.getChannelName().isPresent() && event.getRawTags().isEmpty()) {
-            final String hostMessageSuffix = " is now hosting you.";
+            final String hostMessage = " is now hosting you";
             event.getMessage()
+                .map(msg -> msg.indexOf(hostMessage))
+                .filter(index -> index > 0)
+                .map(index -> event.getMessage().get().substring(0, index))
                 .map(String::trim)
-                .filter(msg -> msg.endsWith(hostMessageSuffix))
-                .map(msg -> msg.substring(0, msg.length() - hostMessageSuffix.length()))
                 .ifPresent(hostName -> eventManager.publish(new InboundHostEvent(event.getChannelName().get(), hostName)));
         }
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Inbound host messages now have the suffix `is now hosting you for up to %d viewers.` so the current approach would stop firing the event

### Changes Proposed
* Fire `InboundHostEvent` again by loosening the string matching
