### PR TITLE
chore: deprecate helix webhooks due to twitch announcement

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1552,9 +1552,11 @@ public interface TwitchHelix {
      * @param after    Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
      * @param limit    Number of values to be returned when getting videos by user or game ID. Limit: 100. Default: 20.
      * @return WebhookSubscriptionList
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
     @RequestLine("GET /webhooks/subscriptions?after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
+    @Deprecated
     HystrixCommand<WebhookSubscriptionList> getWebhookSubscriptions(
         @Param("token") String authToken,
         @Param("after") String after,
@@ -1580,9 +1582,11 @@ public interface TwitchHelix {
      *
      * @see <a href="https://dev.twitch.tv/docs/api/webhooks-guid/">Twitch Webhooks Guide</a>
      * @return The response from the server
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
     @RequestLine("POST /webhooks/hub")
     @Headers({"Authorization: Bearer {token}", "content-type: application/json"})
+    @Deprecated
     HystrixCommand<Response> requestWebhookSubscription(
         WebhookRequest request, // POJO as first arg is assumed by feign to be body if no @Body annotation
         @Param("token") String authToken

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscription.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscription.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class WebhookSubscription {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/WebhookSubscriptionList.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class WebhookSubscriptionList {
 
     @JsonProperty("data")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookNotification.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookNotification.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class WebhookNotification {
 
     private Map<String, Object> data;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookRequest.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/domain/WebhookRequest.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 
 @Data
 @AllArgsConstructor
+@Deprecated
 public class WebhookRequest {
 
     public static final String MODE_SUBSCRIBE = "subscribe";

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ChannelBanTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ChannelBanTopic.java
@@ -38,7 +38,9 @@ public class ChannelBanTopic extends TwitchWebhookTopic<ModeratorEventList> {
      *
      * @param broadcasterId Required. The ID of the channel for which to monitor ban events.
      * @param userId Optional. Specifies the user ID of the moderator added or removed.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public ChannelBanTopic(@NonNull String broadcasterId, String userId) {
         super(
             PATH,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ChannelSubscriptionTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ChannelSubscriptionTopic.java
@@ -58,7 +58,9 @@ public class ChannelSubscriptionTopic extends TwitchWebhookTopic<SubscriptionEve
      *
      * @param broadcasterId Required. User ID of the broadcaster. Must match the User ID in the Bearer token.
      * @param userId        Optional. ID of the subscribed user. Currently only one user_id at a time can be queried.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public ChannelSubscriptionTopic(@NonNull String broadcasterId, String userId) {
         this(broadcasterId, userId, null, null);
     }
@@ -74,7 +76,9 @@ public class ChannelSubscriptionTopic extends TwitchWebhookTopic<SubscriptionEve
      * @param userId        Optional. ID of the subscribed user.
      * @param gifterId      Optional. ID of the user who gifted the sub. Returns an empty string for non-gifts, "274598607" for anonymous gifts
      * @param gifterName    Optional. Display name of the user who gifted the sub. Returns an empty string for non-gifts, "AnAnonymousGifter" for anonymous gifts
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public ChannelSubscriptionTopic(@NonNull String broadcasterId, String userId, String gifterId, String gifterName) {
         super(
             PATH,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ExtensionTransactionsTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ExtensionTransactionsTopic.java
@@ -30,7 +30,9 @@ public class ExtensionTransactionsTopic extends TwitchWebhookTopic<ExtensionTran
      * Sends a notification when a new transaction is created for an extension.
      *
      * @param extensionId Required. The ID of the extension to listen to for transactions.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public ExtensionTransactionsTopic(@NonNull String extensionId) {
         super(
             PATH,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/FollowsTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/FollowsTopic.java
@@ -38,7 +38,9 @@ public class FollowsTopic extends TwitchWebhookTopic<FollowList> {
      *
      * @param fromId Optional. Specifies the user who starts following someone.
      * @param toId Optional. Specifies the user who has a new follower.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public FollowsTopic(String fromId, String toId) {
         super(
             PATH,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/HypeTrainTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/HypeTrainTopic.java
@@ -23,7 +23,9 @@ public class HypeTrainTopic extends TwitchWebhookTopic<HypeTrainEventList> {
      * Notifies upon active hype train events
      *
      * @param broadcasterId User ID of the broadcaster
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public HypeTrainTopic(@NonNull String broadcasterId) {
         super(PATH, HypeTrainEventList.class, mapParameters(broadcasterId));
         this.broadcasterId = broadcasterId;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ModeratorChangeTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/ModeratorChangeTopic.java
@@ -38,7 +38,9 @@ public class ModeratorChangeTopic extends TwitchWebhookTopic<ModeratorEventList>
      *
      * @param broadcasterId Required. Specifies the user ID of the broadcaster.
      * @param userId Optional. Specifies the user ID of the moderator added or removed.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public ModeratorChangeTopic(@NonNull String broadcasterId, String userId) {
         super(
             PATH,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/StreamsTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/StreamsTopic.java
@@ -29,7 +29,9 @@ public class StreamsTopic extends TwitchWebhookTopic<StreamList> {
      * Notifies when a stream changes; e.g., stream goes online or offline, the stream title changes, or the game changes.
      *
      * @param userId Specifies the user whose stream is monitored.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public StreamsTopic(@NonNull String userId) {
         super(
             PATH,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/TwitchWebhookTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/TwitchWebhookTopic.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+@Deprecated
 @EqualsAndHashCode
 public abstract class TwitchWebhookTopic<T> {
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/UsersTopic.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/webhooks/topics/UsersTopic.java
@@ -31,7 +31,9 @@ public class UsersTopic extends TwitchWebhookTopic<UserList> {
      * This web hook requires the user:read:email OAuth scope, to get notifications of email changes.
      *
      * @param userId Required. Specifies the user whose data is monitored.
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152">Will be decommissioned after 2021-09-16 in favor of EventSub</a>
      */
+    @Deprecated
     public UsersTopic(@NonNull String userId) {
         super(
             PATH,


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate WebSub

### Additional Information
https://discuss.dev.twitch.tv/t/deprecation-of-websub-based-webhooks/32152
