### PR TITLE
refactor: allow chat limit specification in more builders

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -220,13 +220,13 @@ public class TwitchChatBuilder {
         }
 
         if (ircMessageBucket == null)
-            ircMessageBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.chatRateLimit) : TwitchLimitRegistry.INSTANCE.getOrInitializeBucket(userId, TwitchLimitType.CHAT_MESSAGE_LIMIT, Collections.singletonList(chatRateLimit));
+            ircMessageBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.chatRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_MESSAGE_LIMIT, Collections.singletonList(chatRateLimit));
 
         if (ircWhisperBucket == null)
-            ircWhisperBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.whisperRateLimit) : TwitchLimitRegistry.INSTANCE.getOrInitializeBucket(userId, TwitchLimitType.CHAT_WHISPER_LIMIT, Arrays.asList(whisperRateLimit));
+            ircWhisperBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.whisperRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_WHISPER_LIMIT, Arrays.asList(whisperRateLimit));
 
         if (ircJoinBucket == null)
-            ircJoinBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.joinRateLimit) : TwitchLimitRegistry.INSTANCE.getOrInitializeBucket(userId, TwitchLimitType.CHAT_JOIN_LIMIT, Collections.singletonList(joinRateLimit));
+            ircJoinBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.joinRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_JOIN_LIMIT, Collections.singletonList(joinRateLimit));
 
         log.debug("TwitchChat: Initializing Module ...");
         return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds);

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat;
 
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.chat.enums.NoticeTag;
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
@@ -8,7 +9,6 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.pool.TwitchModuleConnectionPool;
 import com.github.twitch4j.common.util.ChatReply;
 import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.Bucket;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
@@ -18,10 +18,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -252,8 +250,8 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
         ).build();
 
         // Reclaim channel headroom upon a ban
-        chat.getEventManager().onEvent("twitch4j-chat-pool-ban-tracker", ChannelNoticeEvent.class, e -> {
-            if (automaticallyPartOnBan && "msg_banned".equals(e.getMsgId())) {
+        chat.getEventManager().onEvent(threadPrefix + "ban-tracker", ChannelNoticeEvent.class, e -> {
+            if (automaticallyPartOnBan && NoticeTag.MSG_BANNED.toString().equals(e.getMsgId())) {
                 unsubscribe(e.getChannel().getName());
             }
         });

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -3,9 +3,12 @@ package com.github.twitch4j.chat;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.pool.TwitchModuleConnectionPool;
 import com.github.twitch4j.common.util.ChatReply;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
@@ -15,8 +18,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -63,6 +68,38 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
      */
     @Builder.Default
     protected final boolean automaticallyPartOnBan = false;
+
+    /**
+     * Whether chat connections should share rate limit buckets based on their respective bandwidth specifications.
+     * In particular, this results in a single message bucket, single whisper bucket, and a single join bucket being shared.
+     * This should be enabled when not using the connection pool in anonymous mode (i.e., a chatAccount is specified).
+     */
+    @Builder.Default
+    protected final boolean shareRateLimitBuckets = false;
+
+    /**
+     * Custom RateLimit for ChatMessages
+     */
+    @Builder.Default
+    protected List<Bandwidth> chatRateLimit = Collections.singletonList(TwitchChatLimitHelper.USER_MESSAGE_LIMIT);
+
+    /**
+     * Custom RateLimit for Whispers
+     */
+    @Builder.Default
+    protected List<Bandwidth> whisperRateLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT;
+
+    /**
+     * Custom RateLimit for JOIN/PART
+     */
+    @Builder.Default
+    protected List<Bandwidth> joinRateLimit = Collections.singletonList(TwitchChatLimitHelper.USER_JOIN_LIMIT);
+
+    private final AtomicReference<Bucket> ircMessageBucket = new AtomicReference<>();
+
+    private final AtomicReference<Bucket> ircWhisperBucket = new AtomicReference<>();
+
+    private final AtomicReference<Bucket> ircJoinBucket = new AtomicReference<>();
 
     @Override
     public boolean sendMessage(String channel, String message, @Unofficial @Nullable Map<String, Object> tags) {
@@ -222,6 +259,9 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
                 .withEventManager(getConnectionEventManager())
                 .withScheduledThreadPoolExecutor(getExecutor(threadPrefix + RandomStringUtils.random(4, true, true), TwitchChat.REQUIRED_THREAD_COUNT))
                 .withProxyConfig(proxyConfig.get())
+                .withIrcMessageBucket(getBucket(ircMessageBucket, chatRateLimit, shareRateLimitBuckets))
+                .withIrcWhisperBucket(getBucket(ircWhisperBucket, whisperRateLimit, shareRateLimitBuckets))
+                .withIrcJoinBucket(getBucket(ircJoinBucket, joinRateLimit, shareRateLimitBuckets))
                 .withAutoJoinOwnChannel(false) // user will have to manually send a subscribe call to enable whispers. this avoids duplicating whisper events
         ).build();
 
@@ -268,6 +308,11 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
         saturatedConnections.forEach(retrieve);
         unsaturatedConnections.keySet().forEach(retrieve);
         return Collections.unmodifiableMap(aggregated);
+    }
+
+    private static Bucket getBucket(AtomicReference<Bucket> storedBucket, Iterable<Bandwidth> limits, boolean share) {
+        if (!share) return TwitchChatLimitHelper.createBucket(limits);
+        return storedBucket.updateAndGet(bucket -> bucket != null ? bucket : TwitchChatLimitHelper.createBucket(limits));
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/util/TwitchChatLimitHelper.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/TwitchChatLimitHelper.java
@@ -41,6 +41,8 @@ public class TwitchChatLimitHelper {
 
     /**
      * Users (not bots)
+     * <p>
+     * Note: this does <i>not</i> implement the target user count restriction.
      */
     public final List<Bandwidth> USER_WHISPER_LIMIT = Collections.unmodifiableList(
         Arrays.asList(
@@ -51,6 +53,8 @@ public class TwitchChatLimitHelper {
 
     /**
      * Known bots
+     * <p>
+     * Note: this does <i>not</i> implement the target user count restriction.
      */
     public final List<Bandwidth> KNOWN_WHISPER_LIMIT = Collections.unmodifiableList(
         Arrays.asList(
@@ -61,6 +65,10 @@ public class TwitchChatLimitHelper {
 
     /**
      * Verified bots
+     * <p>
+     * Note: this does <i>not</i> implement the target user count restriction.
+     * <p>
+     * Note: this only applies to legacy verified bots (pre July 2021)
      */
     public final List<Bandwidth> VERIFIED_WHISPER_LIMIT = Collections.unmodifiableList(
         Arrays.asList(

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -16,6 +16,9 @@ dependencies {
 	// Websocket (for common proxy settings)
 	compileOnly(group = "com.neovisionaries", name = "nv-websocket-client")
 
+	// Rate-limit buckets for registry
+	compileOnly(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core")
+
 	// Twitch4J Modules
 	api(project(":auth"))
 }

--- a/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
@@ -1,7 +1,30 @@
 package com.github.twitch4j.common.enums;
 
+/**
+ * The types of rate-limits imposed by Twitch.
+ */
 public enum TwitchLimitType {
+
+    /**
+     * How fast authentication attempts can be issued over IRC.
+     * <p>
+     * Note: this limit is <i>not</i> currently implemented elsewhere in the library.
+     */
+    CHAT_AUTH_LIMIT,
+
+    /**
+     * How fast channel join attempts can be issued over IRC.
+     */
     CHAT_JOIN_LIMIT,
+
+    /**
+     * How fast messages can be issued over IRC.
+     */
     CHAT_MESSAGE_LIMIT,
+
+    /**
+     * How fast private messages can be issued over IRC.
+     */
     CHAT_WHISPER_LIMIT
+
 }

--- a/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
@@ -1,0 +1,7 @@
+package com.github.twitch4j.common.enums;
+
+public enum TwitchLimitType {
+    CHAT_JOIN_LIMIT,
+    CHAT_MESSAGE_LIMIT,
+    CHAT_WHISPER_LIMIT
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchLimitRegistry.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchLimitRegistry.java
@@ -5,7 +5,9 @@ import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.Bucket4j;
 import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.IncompatibleConfigurationException;
 import io.github.bucket4j.local.LocalBucketBuilder;
+import lombok.NonNull;
 
 import java.util.Collections;
 import java.util.EnumMap;
@@ -14,13 +16,37 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * This singleton facilitates sharing of key rate-limit buckets by user and limit type.
+ * <p>
+ * For example:
+ * <pre>
+ * {@code TwitchLimitRegistry.getInstance().setLimit(
+ *         "149223493",
+ *         TwitchLimitType.CHAT_MESSAGE_LIMIT,
+ *         Collections.singletonList(TwitchChatLimitHelper.MOD_MESSAGE_LIMIT)
+ *     );
+ * }
+ * </pre>
+ */
 public enum TwitchLimitRegistry {
 
+    /**
+     * The single thread-safe instance of the limit registry.
+     */
     INSTANCE;
 
     private final Map<String, Map<TwitchLimitType, Bucket>> limits = new ConcurrentHashMap<>();
 
-    public void setLimit(String userId, TwitchLimitType limitType, List<Bandwidth> limit) {
+    /**
+     * Attempts to set a user's bucket for a specific rate-limit.
+     *
+     * @param userId    the id of the user whose rate limit is being specified.
+     * @param limitType the type of rate-limit that is being configured.
+     * @param limit     the bandwidths that are applicable for this user and rate limit type.
+     * @throws IncompatibleConfigurationException if overriding an old limit that is incompatible with the new configuration
+     */
+    public void setLimit(@NonNull String userId, @NonNull TwitchLimitType limitType, @NonNull List<Bandwidth> limit) {
         getBucketsByUser(userId).compute(limitType, (l, bucket) -> {
             if (bucket != null) {
                 bucket.replaceConfiguration(new BucketConfiguration(limit));
@@ -31,11 +57,27 @@ public enum TwitchLimitRegistry {
         });
     }
 
-    public Optional<Bucket> getBucket(String userId, TwitchLimitType limitType) {
+    /**
+     * Obtains the {@link Bucket} for a user and rate limit type, if it has been registered.
+     *
+     * @param userId    the id of the user whose rate limit bucket is being requested.
+     * @param limitType the type of rate limit that is being queried.
+     * @return the shared rate limit bucket for this user and limit type, in an optional wrapper
+     */
+    @NonNull
+    public Optional<Bucket> getBucket(@NonNull String userId, @NonNull TwitchLimitType limitType) {
         return Optional.ofNullable(limits.get(userId)).map(buckets -> buckets.get(limitType));
     }
 
-    public Bucket getOrInitializeBucket(String userId, TwitchLimitType limitType, List<Bandwidth> limit) {
+    /**
+     * Obtains or creates the {@link Bucket} for a certain user and rate limit type.
+     *
+     * @param userId    the id of the user in question.
+     * @param limitType the type of rate limit in question.
+     * @param limit     the default bandwidth settings for this user and rate limit type.
+     * @return the shared rate limit bucket for this user and limit type
+     */
+    public Bucket getOrInitializeBucket(@NonNull String userId, @NonNull TwitchLimitType limitType, @NonNull List<Bandwidth> limit) {
         return getBucketsByUser(userId).computeIfAbsent(limitType, l -> constructBucket(limit));
     }
 
@@ -47,6 +89,13 @@ public enum TwitchLimitRegistry {
         LocalBucketBuilder builder = Bucket4j.builder();
         limits.forEach(builder::addLimit);
         return builder.build();
+    }
+
+    /**
+     * @return the single thread-safe instance of the limit registry.
+     */
+    public static TwitchLimitRegistry getInstance() {
+        return INSTANCE;
     }
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchLimitRegistry.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchLimitRegistry.java
@@ -1,0 +1,52 @@
+package com.github.twitch4j.common.util;
+
+import com.github.twitch4j.common.enums.TwitchLimitType;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.local.LocalBucketBuilder;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public enum TwitchLimitRegistry {
+
+    INSTANCE;
+
+    private final Map<String, Map<TwitchLimitType, Bucket>> limits = new ConcurrentHashMap<>();
+
+    public void setLimit(String userId, TwitchLimitType limitType, List<Bandwidth> limit) {
+        getBucketsByUser(userId).compute(limitType, (l, bucket) -> {
+            if (bucket != null) {
+                bucket.replaceConfiguration(new BucketConfiguration(limit));
+                return bucket;
+            }
+
+            return constructBucket(limit);
+        });
+    }
+
+    public Optional<Bucket> getBucket(String userId, TwitchLimitType limitType) {
+        return Optional.ofNullable(limits.get(userId)).map(buckets -> buckets.get(limitType));
+    }
+
+    public Bucket getOrInitializeBucket(String userId, TwitchLimitType limitType, List<Bandwidth> limit) {
+        return getBucketsByUser(userId).computeIfAbsent(limitType, l -> constructBucket(limit));
+    }
+
+    private Map<TwitchLimitType, Bucket> getBucketsByUser(String userId) {
+        return limits.computeIfAbsent(userId, s -> Collections.synchronizedMap(new EnumMap<>(TwitchLimitType.class)));
+    }
+
+    private static Bucket constructBucket(List<Bandwidth> limits) {
+        LocalBucketBuilder builder = Bucket4j.builder();
+        limits.forEach(builder::addLimit);
+        return builder.build();
+    }
+
+}

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -172,7 +172,7 @@ public class TwitchClientBuilder {
      * Custom RateLimit for Whispers
      */
     @With
-    protected List<Bandwidth> chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT;
+    protected Bandwidth[] chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT.toArray(new Bandwidth[2]);
 
     /**
      * Custom RateLimit for JOIN/PART
@@ -372,7 +372,7 @@ public class TwitchClientBuilder {
                 .withChatAccount(chatAccount)
                 .withChatQueueSize(chatQueueSize)
                 .withChatRateLimit(chatRateLimit)
-                .withWhisperRateLimit(chatWhisperLimit.toArray(new Bandwidth[0]))
+                .withWhisperRateLimit(chatWhisperLimit)
                 .withJoinRateLimit(chatJoinLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -9,6 +9,7 @@ import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.auth.TwitchAuth;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.TwitchChatBuilder;
+import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.util.EventManagerUtils;
@@ -32,9 +33,9 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -165,7 +166,19 @@ public class TwitchClientBuilder {
      * Custom RateLimit for ChatMessages
      */
     @With
-    protected Bandwidth chatRateLimit = Bandwidth.simple(20, Duration.ofSeconds(30));
+    protected Bandwidth chatRateLimit = TwitchChatLimitHelper.USER_MESSAGE_LIMIT;
+
+    /**
+     * Custom RateLimit for Whispers
+     */
+    @With
+    protected List<Bandwidth> chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT;
+
+    /**
+     * Custom RateLimit for JOIN/PART
+     */
+    @With
+    protected Bandwidth chatJoinLimit = TwitchChatLimitHelper.USER_JOIN_LIMIT;
 
     /**
      * Wait time for taking items off chat queue in milliseconds. Default recommended
@@ -359,6 +372,8 @@ public class TwitchClientBuilder {
                 .withChatAccount(chatAccount)
                 .withChatQueueSize(chatQueueSize)
                 .withChatRateLimit(chatRateLimit)
+                .withWhisperRateLimit(chatWhisperLimit.toArray(new Bandwidth[0]))
+                .withJoinRateLimit(chatJoinLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -194,7 +194,7 @@ public class TwitchClientPoolBuilder {
      * Custom RateLimit for Whispers
      */
     @With
-    protected List<Bandwidth> chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT;
+    protected Bandwidth[] chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT.toArray(new Bandwidth[2]);
 
     /**
      * Custom RateLimit for JOIN/PART
@@ -400,10 +400,9 @@ public class TwitchClientPoolBuilder {
             chat = TwitchChatConnectionPool.builder()
                 .eventManager(eventManager)
                 .chatAccount(() -> chatAccount)
-                .chatRateLimit(Collections.singletonList(chatRateLimit))
+                .chatRateLimit(chatRateLimit)
                 .whisperRateLimit(chatWhisperLimit)
-                .joinRateLimit(Collections.singletonList(chatJoinLimit))
-                .shareRateLimitBuckets(shareChatRateLimitBuckets)
+                .joinRateLimit(chatJoinLimit)
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
                 .maxSubscriptionsPerConnection(maxChannelsPerChatInstance)
@@ -423,7 +422,7 @@ public class TwitchClientPoolBuilder {
                 .withChatAccount(chatAccount)
                 .withChatQueueSize(chatQueueSize)
                 .withChatRateLimit(chatRateLimit)
-                .withWhisperRateLimit(chatWhisperLimit.toArray(new Bandwidth[0]))
+                .withWhisperRateLimit(chatWhisperLimit)
                 .withJoinRateLimit(chatJoinLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -203,14 +203,6 @@ public class TwitchClientPoolBuilder {
     protected Bandwidth chatJoinLimit = TwitchChatLimitHelper.USER_JOIN_LIMIT;
 
     /**
-     * Whether chat connections should share rate limit buckets based on their respective bandwidth specifications.
-     * In particular, this results in a single message bucket, single whisper bucket, and a single join bucket being shared.
-     * This should be enabled when the pools is not used in anonymous mode (i.e., a chatAccount is specified).
-     */
-    @With
-    protected boolean shareChatRateLimitBuckets = false;
-
-    /**
      * Wait time for taking items off chat queue in milliseconds. Default recommended
      */
     @With


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Create `TwitchLimitRegistry` for people to specify elevated rate-limit bandwidths for specific user id's
* Ensure chat message/join/whisper default limit can be configured in each relevant builder
* In TwitchChatBuilder, obtain the shared rate-limit buckets from `TwitchLimitRegistry`

### Additional Information
Recently twitch actually started enforcing it's irc JOIN ratelimit (rather strictly). As a result, there has been more demand to be able to easily override the default non-message ratelimits (e.g., to set a lower limit than the default to avoid network oddities making it appear that a small ratelimit violation occurred from twitch's perspective). Also, the bot verification process has started again so more folks may want to easily specify their updated ratelimits.
