### PR TITLE
fix: jackson bom -> api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ subprojects {
 		api(group = "org.slf4j", name = "slf4j-api", version = "1.7.32")
 
 		// Jackson BOM
-		implementation(platform("com.fasterxml.jackson:jackson-bom:2.12.4"))
+		api(platform("com.fasterxml.jackson:jackson-bom:2.12.4"))
 
 		// Test
 		testImplementation(platform("org.junit:junit-bom:5.7.2"))


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed

* resolves `Could not find com.fasterxml.jackson.datatype:jackson-datatype-jsr310:.`, see below.

### Additional Information

Issue was reported via discord, the jackson bom wasn't available in the compile classpath because of `implementation` and as such it used feign-jackson to resolve the databind version, but couldn't resolve jsr310.

```
i've ran into the same jackson-datatype-jsr310 dependency issue with gradle and twitch4j 1.5.0.

This can be reproduced with a simple build.gradle:
plugins {
    id 'java'
}

group = 'com.example'
version = '1.0'

sourceCompatibility = '1.8'

repositories {
    mavenCentral()
}

dependencies {
    api 'com.github.twitch4j:twitch4j:1.5.0'
}

and something to compile (src/main/java/com/example/Main.java):
package com.example;

public class Main {
    public static void main(String[] args) {
        System.out.println("test");
    }
}

Then build, e.g. with docker run --rm -v "$(pwd):/app" -w /app gradle:7.1.1 gradle build
gives the error:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find com.fasterxml.jackson.datatype:jackson-datatype-jsr310:.
     Required by:
         project : > com.github.twitch4j:twitch4j:1.5.0 > com.github.twitch4j:twitch4j-common:1.5.0
         project : > com.github.twitch4j:twitch4j:1.5.0 > com.github.twitch4j:twitch4j-eventsub-common:1.5.0
         project : > com.github.twitch4j:twitch4j:1.5.0 > com.github.twitch4j:twitch4j-pubsub:1.5.0
         project : > com.github.twitch4j:twitch4j:1.5.0 > com.github.twitch4j:twitch4j-extensions:1.5.0
         project : > com.github.twitch4j:twitch4j:1.5.0 > com.github.twitch4j:twitch4j-kraken:1.5.0
```