### PR TITLE
fix: store emote id as string in sub events over pubsub

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommerceMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommerceMessage.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -32,7 +34,22 @@ public class CommerceMessage {
         /**
          * The id for the emote being used
          */
-        private Integer id;
+        @JsonProperty("id")
+        private String emoteId;
+
+        /**
+         * @return the emote id as an integer, or null.
+         * @deprecated in favor of {@link #getEmoteId()}
+         */
+        @JsonIgnore
+        @Deprecated
+        public Integer getId() {
+            try {
+                return Integer.parseInt(getEmoteId());
+            } catch (Exception e) {
+                return null;
+            }
+        }
     }
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubGiftData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SubGiftData.java
@@ -8,7 +8,9 @@ public class SubGiftData {
     private Integer count;
     private SubscriptionPlan tier;
     private String userId;
+    private String userName;
+    private String displayName;
     private String channelId;
     private String uuid;
-    private String type;
+    private String type; // e.g., "mystery-gift-purchase"
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
```
com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `int` from String "emotesv2_01ad668a984f449ba9d950381638056a": not a valid `int` value
```

### Changes Proposed
* Make the emote id in pubsub commerce messages a string (in unbreaking fashion)
* Unrelated: add more fields for unofficial sub gift events over pubsub

### Additional Information
Thanks to `Doc#4444` for reporting
