### PR TITLE
feat: support new emote api url template fields

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
@@ -1,18 +1,22 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.helix.TwitchHelix;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -42,6 +46,24 @@ public class Emote {
      */
     @Nullable
     private String emoteSetId;
+
+    /**
+     * The formats that the emote is available in.
+     * <p>
+     * For example, if the emote is available only as a static PNG, the collection contains only {@link Format#STATIC}.
+     * But if it’s available as a static PNG and an animated GIF, the collection contains both {@link Format#STATIC} and {@link Format#ANIMATED}.
+     */
+    private List<Format> format;
+
+    /**
+     * The sizes that the emote is available in.
+     */
+    private List<Scale> scale;
+
+    /**
+     * The background themes that the emote is available in.
+     */
+    private List<Theme> themeMode;
 
     /**
      * User ID of the broadcaster who owns the emote.
@@ -209,6 +231,57 @@ public class Emote {
             MAPPINGS = Collections.unmodifiableMap(map);
         }
 
+    }
+
+    public enum Format {
+
+        /**
+         * Returns an animated GIF if available, otherwise, returns the static PNG.
+         */
+        @JsonEnumDefaultValue
+        DEFAULT,
+
+        /**
+         * Indicates a static PNG file is available for this emote.
+         */
+        STATIC,
+
+        /**
+         * Indicates an animated GIF is available for this emote.
+         */
+        ANIMATED
+
+    }
+
+    @RequiredArgsConstructor
+    public enum Scale {
+
+        /**
+         * A small version (28px x 28px) of the emote.
+         */
+        @JsonProperty("1.0")
+        SMALL("1.0"),
+
+        /**
+         * A medium version (56px x 56px) of the emote.
+         */
+        @JsonProperty("2.0")
+        MEDIUM("2.0"),
+
+        /**
+         * A large version (112px x 112px) of the emote.
+         */
+        @JsonProperty("2.0")
+        LARGE("2.0");
+
+        @Getter
+        private final String twitchString;
+
+    }
+
+    public enum Theme {
+        DARK,
+        LIGHT
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
@@ -271,8 +271,8 @@ public class Emote {
         /**
          * A large version (112px x 112px) of the emote.
          */
-        @JsonProperty("2.0")
-        LARGE("2.0");
+        @JsonProperty("3.0")
+        LARGE("3.0");
 
         @Getter
         private final String twitchString;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/EmoteList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/EmoteList.java
@@ -3,7 +3,9 @@ package com.github.twitch4j.helix.domain;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.NonNull;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 
@@ -11,7 +13,45 @@ import java.util.List;
 @Setter(AccessLevel.PRIVATE)
 public class EmoteList {
 
+    /**
+     * The emote data.
+     */
     @JsonProperty("data")
     private List<Emote> emotes;
+
+    /**
+     * A templated URL.
+     *
+     * @see <a href="https://dev.twitch.tv/docs/irc/emotes#cdn-template">Emote CDN URL format</a>
+     */
+    private String template;
+
+    /**
+     * Uses the values from id, format, scale, and theme_mode to replace the like-named placeholder strings in the templated URL to create a CDN (content delivery network) URL that you use to fetch the emote.
+     *
+     * @param id     The emote’s ID.
+     * @param format The format of the image to get.
+     * @param theme  The background theme of the emote.
+     * @param size   The size of the emote.
+     * @return the populated emote template url.
+     * @see #getTemplate()
+     */
+    public String getPopulatedTemplateUrl(@NonNull String id, @NonNull Emote.Format format, @NonNull Emote.Theme theme, @NonNull Emote.Scale size) {
+        return StringUtils.replaceEach(
+            getTemplate(),
+            new String[] {
+                "{{id}}",
+                "{{format}}",
+                "{{theme_mode}}",
+                "{{scale}}"
+            },
+            new String[] {
+                id,
+                format.toString().toLowerCase(),
+                theme.toString().toLowerCase(),
+                size.getTwitchString()
+            }
+        );
+    }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add template url to emote list
* Add fields to populate the template with to the emote objects themselves

### Additional Information
https://discuss.dev.twitch.tv/t/twitch-emotes-api-endpoints-now-include-an-image-template-string-and-image-options/33069
