### PR TITLE
feat: add more unofficial fields for pubsub hype trains

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductorUser.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConductorUser.java
@@ -5,4 +5,7 @@ import lombok.Data;
 @Data
 public class HypeTrainConductorUser {
     private String id;
+    private String login;
+    private String displayName;
+    private String profileImageUrl;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainConfig.java
@@ -22,6 +22,9 @@ public class HypeTrainConfig {
     private String calloutEmoteId;
     private String calloutEmoteToken;
     private String themeColor;
+    private Boolean useCreatorColor;
+    private String primaryHexColor;
+    private Boolean usePersonalizedSettings;
     private Boolean hasConductorBadges;
 
     @Data


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* `HypeTrainConductorUser` and `HypeTrainConfig` now are sent with more info by twitch
