### PR TITLE
feat: include rituals and deprecate lang in ChannelStateEvent

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -565,6 +565,10 @@ public class IRCEventHandler {
                             states.put(ChannelStateEvent.ChannelState.R9K, uniqActive);
                             eventManager.publish(new Robot9000Event(channel, uniqActive));
                             break;
+                        case "rituals":
+                            boolean ritualsActive = "1".equals(v);
+                            states.put(ChannelStateEvent.ChannelState.RITUALS, ritualsActive);
+                            break;
                         case "slow":
                             long slowDelay = Long.parseLong(v);
                             states.put(ChannelStateEvent.ChannelState.SLOW, slowDelay);

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelStateEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelStateEvent.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -15,10 +16,13 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = false)
 public class ChannelStateEvent extends AbstractChannelEvent {
 	public enum ChannelState {
+	    @Deprecated
 		BROADCAST_LANG,
 		EMOTE,
 		FOLLOWERS,
 		R9K,
+        @Unofficial
+        RITUALS,
 		SLOW,
 		SUBSCRIBERS;
 	}
@@ -41,8 +45,7 @@ public class ChannelStateEvent extends AbstractChannelEvent {
 
 	public ChannelStateEvent(EventChannel channel, Map<ChannelState, Object> state) {
 		super(channel);
-		Map<ChannelState, Object> states = new HashMap<>();
-		states.putAll(state);
+        Map<ChannelState, Object> states = new HashMap<>(state);
 		this.states = Collections.unmodifiableMap(states);
 	}
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Deprecate broadcaster lang in roomstate as it hasn't been sent in years
* Add rituals to roomstate parsing, as it is included but undocumented
