### PR TITLE
feat: add more fields to unofficial community points pubsub

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GlobalCooldown.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GlobalCooldown.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -22,6 +23,7 @@ public class GlobalCooldown {
     /**
      * The cooldown in seconds.
      */
+    @JsonAlias("global_cooldown_seconds")
     private Integer seconds;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerStream.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerStream.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -22,6 +23,7 @@ public class MaxPerStream {
     /**
      * The max per stream limit.
      */
+    @JsonAlias("max_per_stream")
     private Integer value;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerUserPerStream.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/MaxPerUserPerStream.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -22,6 +23,7 @@ public class MaxPerUserPerStream {
     /**
      * The max per user per stream limit.
      */
+    @JsonAlias("max_per_user_per_stream")
     private Integer value;
 
 }

--- a/pubsub/build.gradle.kts
+++ b/pubsub/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 	api(group = "org.jetbrains", name = "annotations")
 
 	// Twitch4J Modules
+	api(project(":eventsub-common"))
 	api(project(":common"))
 	api(project(":auth"))
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -578,6 +578,11 @@ public class TwitchPubSub implements ITwitchPubSub {
                                         final ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
                                         eventManager.publish(new RewardRedeemedEvent(Instant.parse(msgData.path("timestamp").asText()), redemption));
                                         break;
+                                    case "community-goal-contribution":
+                                        CommunityGoalContribution goal = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
+                                        Instant instant = Instant.parse(msgData.path("timestamp").textValue());
+                                        eventManager.publish(new UserCommunityGoalContributionEvent(lastTopicIdentifier, instant, goal));
+                                        break;
                                     case "global-last-viewed-content-updated":
                                     case "channel-last-viewed-content-updated":
                                         // unimportant

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsRedemption.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.github.twitch4j.common.annotation.Unofficial;
 import lombok.Data;
 
 @Data
@@ -39,5 +40,8 @@ public class ChannelPointsRedemption {
 	 * reward redemption status, will be FULFILLED if a user skips the reward queue, UNFULFILLED otherwise
 	 */
 	private String status;
+
+	@Unofficial
+	private String cursor;
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -1,7 +1,11 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.GlobalCooldown;
+import com.github.twitch4j.eventsub.domain.MaxPerUserPerStream;
 import lombok.Data;
+
+import java.time.Instant;
 
 @Data
 public class ChannelPointsReward {
@@ -22,6 +26,10 @@ public class ChannelPointsReward {
 	private MaxPerStream maxPerStream;
 	private Boolean shouldRedemptionsSkipRequestQueue;
 	private String updatedForIndicatorAt;
+	private MaxPerUserPerStream maxPerUserPerStream;
+	private GlobalCooldown globalCooldown;
+	private Integer redemptionsRedeemedCurrentStream;
+	private Instant cooldownExpiresAt;
 
 	@Data
 	public static class Image {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommunityPointsGoal.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommunityPointsGoal.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -8,6 +9,10 @@ import lombok.experimental.Accessors;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -37,7 +42,7 @@ public class CommunityPointsGoal {
     /**
      * The type of community points goal.
      * <p>
-     * For example: "BOOST"
+     * For example: "BOOST", "CREATOR"
      */
     private String goalType;
 
@@ -47,5 +52,25 @@ public class CommunityPointsGoal {
      * For example: "STARTED"
      */
     private String status;
+
+    public Type getParsedType() {
+        return Type.MAPPINGS.getOrDefault(getGoalType(), Type.UNKNOWN);
+    }
+
+    public Status getParsedStatus() {
+        return Status.MAPPINGS.getOrDefault(getStatus(), Status.UNKNOWN);
+    }
+
+    public enum Type {
+        BOOST, CREATOR, @JsonEnumDefaultValue UNKNOWN;
+
+        static final Map<String, Type> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+    }
+
+    public enum Status {
+        ARCHIVED, ENDED, FULFILLED, STARTED, @JsonEnumDefaultValue UNKNOWN, UNSTARTED;
+
+        static final Map<String, Status> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+    }
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserCommunityGoalContributionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserCommunityGoalContributionEvent.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.CommunityGoalContribution;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class UserCommunityGoalContributionEvent extends TwitchEvent {
+    String userId;
+    Instant timestamp;
+    CommunityGoalContribution contribution;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add unofficial `ChannelPointsRedemption` `cursor`
* More fields for pubsub's `ChannelPointsReward`
* More library-assisted parsing of enums in `CommunityPointsGoal`
* Also fire `UserCommunityGoalContributionEvent`

### Additional Information
This PR also makes `eventsub-common` a dependency of the `pubsub` module (though this isn't strictly necessary)
