### PR TITLE
fix: parse new mod pubsub format for mod and vip actions

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -512,6 +513,23 @@ public class TwitchPubSub implements ITwitchPubSub {
                                     case "deny_unban_request":
                                         ModeratorUnbanRequestAction unbanRequestAction = TypeConvert.convertValue(msgData, ModeratorUnbanRequestAction.class);
                                         eventManager.publish(new ModUnbanRequestActionEvent(lastTopicIdentifier, unbanRequestAction));
+                                        break;
+
+                                    case "moderator_added":
+                                    case "moderator_removed":
+                                    case "vip_added":
+                                    case "vip_removed":
+                                        ChatModerationAction.ModerationAction act = "moderator_added".equals(type) ? ChatModerationAction.ModerationAction.MOD
+                                            : "moderator_removed".equals(type) ? ChatModerationAction.ModerationAction.UNMOD
+                                            : "vip_added".equals(type) ? ChatModerationAction.ModerationAction.VIP
+                                            : ChatModerationAction.ModerationAction.UNVIP;
+
+                                        String targetUserId = msgData.path("target_user_id").asText();
+                                        String targetUserName = msgData.path("target_user_login").asText();
+                                        String createdByUserId = msgData.path("created_by_user_id").asText();
+                                        String createdBy = msgData.path("created_by").asText();
+                                        ChatModerationAction action = new ChatModerationAction("chat_login_moderation", act, Collections.singletonList(targetUserName), createdBy, createdByUserId, "", targetUserId, targetUserName, false);
+                                        eventManager.publish(new ChatModerationEvent(lastTopicIdentifier, action));
                                         break;
 
                                     default:

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,6 +15,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatModerationAction {
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Closes #431 

### Changes Proposed
* Fire `ChatModerationEvent` for alternative message format of `mod`/`unmod`/`vip`/`unvip`

### Additional Information
More details: https://github.com/twitchdev/issues/issues/218#issuecomment-922212618
* There are scenarios where no pubsub message is sent when we would expect one
* There are scenarios where `ChatModerationEvent` will be fired more than once (because twitch can send both the traditional format and this new format)
