### PR TITLE
feat: implement official creator goals api

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -18,6 +18,7 @@ public enum TwitchScopes {
     HELIX_CHANNEL_COMMERCIALS_EDIT("channel:edit:commercial"),
     HELIX_CHANNEL_EXTENSION_MANAGE("channel:manage:extensions"),
     HELIX_CHANNEL_EDITORS_READ("channel:read:editors"),
+    HELIX_CHANNEL_GOALS_READ("channel:read:goals"),
     HELIX_CHANNEL_HYPE_TRAIN_READ("channel:read:hype_train"),
     HELIX_CHANNEL_POLLS_MANAGE("channel:manage:polls"),
     HELIX_CHANNEL_POLLS_READ("channel:read:polls"),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CreatorGoalsCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CreatorGoalsCondition.java
@@ -1,0 +1,15 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * @see <a href="https://dev.twitch.tv/docs/eventsub/eventsub-reference#goals-condition">Official docs</a>
+ */
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class CreatorGoalsCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+/**
+ * The type of goal.
+ */
+public enum GoalType {
+
+    /**
+     * The goal is to increase followers.
+     */
+    @JsonAlias("follower")
+    FOLLOWERS,
+
+    /**
+     * The goal is to increase subscriptions.
+     */
+    @JsonAlias("subscription")
+    SUBSCRIPTIONS
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsBeginEvent.java
@@ -1,0 +1,8 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CreatorGoalsBeginEvent extends CreatorGoalsEvent {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsEndEvent.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CreatorGoalsEndEvent extends CreatorGoalsEvent {
+
+    /**
+     * A Boolean value that indicates whether the broadcaster achieved their goal.
+     * Is true if the goal was achieved; otherwise, false.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_achieved")
+    private Boolean isAchieved;
+
+    /**
+     * The UTC timestamp in RFC 3339 format, which indicates when the broadcaster ended the goal.
+     */
+    private Instant endedAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsEvent.java
@@ -1,0 +1,63 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.GoalType;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+/**
+ * @see <a href="https://dev.twitch.tv/docs/eventsub/eventsub-reference#goals-event">Official docs</a>
+ */
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public abstract class CreatorGoalsEvent extends EventSubChannelEvent {
+
+    /**
+     * An ID that identifies this event.
+     */
+    private String id;
+
+    /**
+     * The type of goal.
+     */
+    private GoalType type;
+
+    /**
+     * A description of the goal, if specified.
+     * <p>
+     * The description may contain a maximum of 40 characters.
+     */
+    private String description;
+
+    /**
+     * The current value.
+     * <p>
+     * If the goal is to increase followers, this field is set to the current number of followers.
+     * This number increases with new followers and decreases if users unfollow the channel.
+     * <p>
+     * For subscriptions, current_amount is increased and decreased by the points value associated with the subscription tier.
+     * For example, if a tier-two subscription is worth 2 points, current_amount is increased or decreased by 2, not 1.
+     */
+    private Integer currentAmount;
+
+    /**
+     * The goal’s target value.
+     * <p>
+     * For example, if the broadcaster has 200 followers before creating the goal, and their goal is to double that number, this field is set to 400.
+     */
+    private Integer targetAmount;
+
+    /**
+     * The UTC timestamp in RFC 3339 format, which indicates when the broadcaster created the goal.
+     */
+    private Instant startedAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsProgressEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/CreatorGoalsProgressEvent.java
@@ -1,0 +1,8 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CreatorGoalsProgressEvent extends CreatorGoalsEvent {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelGoalBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelGoalBeginType.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.CreatorGoalsCondition;
+import com.github.twitch4j.eventsub.events.CreatorGoalsBeginEvent;
+
+/**
+ * Notifies the subscriber when the specified broadcaster begins a goal.
+ * <p>
+ * NOTE: It’s possible to receive the Begin event after receiving Progress events.
+ * <p>
+ * Authorization: Requires a user OAuth access token with scope set to channel:read:goals.
+ */
+public class ChannelGoalBeginType implements SubscriptionType<CreatorGoalsCondition, CreatorGoalsCondition.CreatorGoalsConditionBuilder<?, ?>, CreatorGoalsBeginEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.goal.begin";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public CreatorGoalsCondition.CreatorGoalsConditionBuilder<?, ?> getConditionBuilder() {
+        return CreatorGoalsCondition.builder();
+    }
+
+    @Override
+    public Class<CreatorGoalsBeginEvent> getEventClass() {
+        return CreatorGoalsBeginEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelGoalEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelGoalEndType.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.CreatorGoalsCondition;
+import com.github.twitch4j.eventsub.events.CreatorGoalsEndEvent;
+
+/**
+ * Notifies the subscriber when the specified broadcaster ends a goal.
+ * <p>
+ * Authorization: Requires a user OAuth access token with scope set to channel:read:goals.
+ */
+public class ChannelGoalEndType implements SubscriptionType<CreatorGoalsCondition, CreatorGoalsCondition.CreatorGoalsConditionBuilder<?, ?>, CreatorGoalsEndEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.goal.end";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public CreatorGoalsCondition.CreatorGoalsConditionBuilder<?, ?> getConditionBuilder() {
+        return CreatorGoalsCondition.builder();
+    }
+
+    @Override
+    public Class<CreatorGoalsEndEvent> getEventClass() {
+        return CreatorGoalsEndEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelGoalProgressType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelGoalProgressType.java
@@ -1,0 +1,36 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.CreatorGoalsCondition;
+import com.github.twitch4j.eventsub.events.CreatorGoalsProgressEvent;
+
+/**
+ * Notifies the subscriber when progress is made towards the specified broadcaster’s goal.
+ * Progress could be positive (added followers) or negative (lost followers).
+ * <p>
+ * NOTE: It’s possible to receive Progress events before receiving the Begin event.
+ * <p>
+ * Authorization: Requires a user OAuth access token with scope set to channel:read:goals.
+ */
+public class ChannelGoalProgressType implements SubscriptionType<CreatorGoalsCondition, CreatorGoalsCondition.CreatorGoalsConditionBuilder<?, ?>, CreatorGoalsProgressEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.goal.progress";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public CreatorGoalsCondition.CreatorGoalsConditionBuilder<?, ?> getConditionBuilder() {
+        return CreatorGoalsCondition.builder();
+    }
+
+    @Override
+    public Class<CreatorGoalsProgressEvent> getEventClass() {
+        return CreatorGoalsProgressEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -15,6 +15,9 @@ public class SubscriptionTypes {
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelCheerType CHANNEL_CHEER;
     public final ChannelFollowType CHANNEL_FOLLOW;
+    public final ChannelGoalBeginType CHANNEL_GOAL_BEGIN;
+    public final ChannelGoalProgressType CHANNEL_GOAL_PROGRESS;
+    public final ChannelGoalEndType CHANNEL_GOAL_END;
     public final ChannelModeratorAddType CHANNEL_MODERATOR_ADD;
     public final ChannelModeratorRemoveType CHANNEL_MODERATOR_REMOVE;
     public final ChannelPointsCustomRewardAddType CHANNEL_POINTS_CUSTOM_REWARD_ADD;
@@ -56,6 +59,9 @@ public class SubscriptionTypes {
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHEER = new ChannelCheerType(),
                 CHANNEL_FOLLOW = new ChannelFollowType(),
+                CHANNEL_GOAL_BEGIN = new ChannelGoalBeginType(),
+                CHANNEL_GOAL_PROGRESS = new ChannelGoalProgressType(),
+                CHANNEL_GOAL_END = new ChannelGoalEndType(),
                 CHANNEL_MODERATOR_ADD = new ChannelModeratorAddType(),
                 CHANNEL_MODERATOR_REMOVE = new ChannelModeratorRemoveType(),
                 CHANNEL_POINTS_CUSTOM_REWARD_ADD = new ChannelPointsCustomRewardAddType(),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -677,6 +677,25 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets the broadcaster’s list of active goals.
+     * <p>
+     * Use this to get the current progress of each goal.
+     * <p>
+     * NOTE: Although the API currently supports only one goal, you should write your application to support one or more goals.
+     *
+     * @param authToken     User access token from the broadcaster with the channel:read:goals scope.
+     * @param broadcasterId The ID of the broadcaster that created the goals.
+     * @return CreatorGoalsList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_GOALS_READ
+     */
+    @RequestLine("GET /goals?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<CreatorGoalsList> getCreatorGoals(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
      * Gets the information of the most recent Hype Train of the given channel ID.
      * After 5 days, if no Hype Train has been active, the endpoint will return an empty response
      *

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreatorGoal.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreatorGoal.java
@@ -1,0 +1,71 @@
+package com.github.twitch4j.helix.domain;
+
+import com.github.twitch4j.eventsub.domain.GoalType;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class CreatorGoal {
+
+    /**
+     * An ID that uniquely identifies this goal.
+     */
+    private String id;
+
+    /**
+     * An ID that uniquely identifies the broadcaster.
+     */
+    private String broadcasterId;
+
+    /**
+     * The broadcaster’s display name.
+     */
+    private String broadcasterName;
+
+    /**
+     * The broadcaster’s user handle.
+     */
+    private String broadcasterLogin;
+
+    /**
+     * The type of goal.
+     */
+    private GoalType type;
+
+    /**
+     * A description of the goal, if specified.
+     * <p>
+     * The description may contain a maximum of 40 characters.
+     */
+    private String description;
+
+    /**
+     * The current value.
+     * <p>
+     * If the goal is to increase followers, this field is set to the current number of followers.
+     * This number increases with new followers and decreases if users unfollow the channel.
+     * <p>
+     * For subscriptions, current_amount is increased and decreased by the points value associated with the subscription tier.
+     * For example, if a tier-two subscription is worth 2 points, current_amount is increased or decreased by 2, not 1.
+     */
+    private Integer currentAmount;
+
+    /**
+     * The goal’s target value.
+     * <p>
+     * For example, if the broadcaster has 200 followers before creating the goal, and their goal is to double that number, this field is set to 400.
+     */
+    private Integer targetAmount;
+
+    /**
+     * The UTC timestamp in RFC 3339 format, which indicates when the broadcaster created the goal.
+     */
+    private Instant createdAt;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreatorGoalsList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CreatorGoalsList.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class CreatorGoalsList {
+
+    @JsonProperty("data")
+    private List<CreatorGoal> goals;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* `@JsonAlias` is partially driven by https://github.com/twitchdev/issues/issues/505

### Changes Proposed
* Implement `TwitchHelix#getCreatorGoals(String, String)`
* Add EventSub Creator Goals Begin/Progress/End types

### Additional Information
https://dev.twitch.tv/docs/api/goals
