### PR TITLE
feat: add builder to modify custom reward setting objects

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomReward.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomReward.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.eventsub.domain.Reward;
@@ -8,11 +9,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.With;
 import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import org.jetbrains.annotations.Nullable;
 
@@ -150,6 +153,9 @@ public class CustomReward {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @SuperBuilder(toBuilder = true)
+    @Jacksonized
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
     public static class MaxPerStreamSetting extends Setting {
@@ -159,6 +165,9 @@ public class CustomReward {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @SuperBuilder(toBuilder = true)
+    @Jacksonized
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
     public static class MaxPerUserPerStreamSetting extends Setting {
@@ -168,6 +177,9 @@ public class CustomReward {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @SuperBuilder(toBuilder = true)
+    @Jacksonized
     @EqualsAndHashCode(callSuper = true)
     @ToString(callSuper = true)
     public static class GlobalCooldownSetting extends Setting {
@@ -177,7 +189,11 @@ public class CustomReward {
     @Data
     @Setter(AccessLevel.PRIVATE)
     @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @SuperBuilder(toBuilder = true)
+    @Jacksonized
     public static class Setting {
+        @Getter(onMethod_ = { @JsonIgnore }) // avoid serializing both "is_enabled" and "enabled" from this single variable
         @Accessors(fluent = true)
         @JsonProperty("is_enabled")
         private Boolean isEnabled;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Was not able to create/update custom rewards' setting objects (i.e., `max_per_stream_setting`, `max_per_user_per_stream_setting`, and `global_cooldown_setting`) easily. Thanks to `vojay#0001` for reporting.

### Changes Proposed
* Add `@SuperBuilder` to these setting objects

### Additional Information
Went with `@SuperBuilder` to properly work with inheritance (e.g., `@With` & `@AllArgsConstructor` alone were problematic) and avoid modifying internal state (e.g., `@Setter(AccessLevel.PUBLIC)`). 
