### PR TITLE
feat: add new points field to SubscriptionList

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SubscriptionList.java
@@ -24,4 +24,12 @@ public class SubscriptionList {
      */
     private Integer total;
 
+    /**
+     * The current number of subscriber points earned by this broadcaster.
+     * <p>
+     * Points are based on the subscription tier of each user that subscribes to this broadcaster.
+     * For example, a Tier 1 subscription is worth 1 point, Tier 2 is worth 2 points, and Tier 3 is worth 6 points.
+     */
+    private Integer points;
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `SubscriptionList#getPoints`

### Additional Information
2021-10-01: `Add the points field to the Get Broadcaster Subscriptions response. This field provides the current number of subscriber points earned by this broadcaster.` https://dev.twitch.tv/docs/change-log
