### PR TITLE
feat: add unofficial notice tags for vips and channel verification settings

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat.enums;
 
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
+import com.github.twitch4j.common.annotation.Unofficial;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -309,6 +310,12 @@ public enum NoticeTag {
     MSG_BAD_CHARACTERS,
 
     /**
+     * Your message was not sent because your email address is banned from this channel.
+     */
+    @Unofficial
+    MSG_BANNED_EMAIL_ALIAS,
+
+    /**
      * Your message was not sent because your account is not in good standing in this channel.
      */
     MSG_CHANNEL_BLOCKED,
@@ -367,6 +374,12 @@ public enum NoticeTag {
      * Your message wasn&#039;t posted due to conflicts with the channel&#039;s moderation settings.
      */
     MSG_REJECTED_MANDATORY,
+
+    /**
+     * A verified phone number is required to chat in this channel. Please visit https://www.twitch.tv/settings/security to verify your phone number.
+     */
+    @Unofficial
+    MSG_REQUIRES_VERIFIED_PHONE_NUMBER,
 
     /**
      * The room was not found.

--- a/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
@@ -77,6 +77,7 @@ public enum NoticeTag {
     /**
      * You cannot ban global moderator &lt;user&gt;. Please email support@twitch.tv if a global moderator is being abusive.
      */
+    @Deprecated
     BAD_BAN_GLOBAL_MOD,
 
     /**
@@ -103,6 +104,12 @@ public enum NoticeTag {
      * You cannot delete the broadcaster&#039;s messages.
      */
     BAD_DELETE_MESSAGE_BROADCASTER,
+
+    /**
+     * Failed to delete message.
+     */
+    @Unofficial
+    BAD_DELETE_MESSAGE_ERROR,
 
     /**
      * You cannot delete messages from another moderator &lt;user&gt;.
@@ -177,6 +184,7 @@ public enum NoticeTag {
     /**
      * You cannot timeout global moderator &lt;user&gt;. Please email support@twitch.tv if a global moderator is being abusive.
      */
+    @Deprecated
     BAD_TIMEOUT_GLOBAL_MOD,
 
     /**
@@ -208,6 +216,36 @@ public enum NoticeTag {
      * &lt;user&gt; is not a moderator of this channel.
      */
     BAD_UNMOD_MOD,
+
+    /**
+     * &lt;user&gt; is not a VIP of this channel.
+     */
+    @Unofficial
+    BAD_UNVIP_GRANTEE_NOT_VIP,
+
+    /**
+     * Unable to add VIP. Visit the Achievements page on your dashboard to learn how to unlock this feature.
+     */
+    @Unofficial
+    BAD_VIP_ACHIEVEMENT_INCOMPLETE,
+
+    /**
+     * &lt;user&gt; is already a VIP of this channel.
+     */
+    @Unofficial
+    BAD_VIP_GRANTEE_ALREADY_VIP,
+
+    /**
+     * &lt;user&gt; is banned in this channel. You must unban this user before granting VIP status.
+     */
+    @Unofficial
+    BAD_VIP_GRANTEE_BANNED,
+
+    /**
+     * Unable to add VIP. Visit the Achievements page on your dashboard to learn how to unlock additional VIP slots.
+     */
+    @Unofficial
+    BAD_VIP_MAX_VIPS_REACHED,
 
     /**
      * &lt;user&gt; is now banned from this channel.
@@ -432,6 +470,12 @@ public enum NoticeTag {
     NO_PERMISSION,
 
     /**
+     * This channel does not have any VIPs.
+     */
+    @Unofficial
+    NO_VIPS,
+
+    /**
      * This room is no longer in r9k mode.
      */
     R9K_OFF,
@@ -565,6 +609,12 @@ public enum NoticeTag {
      * &lt;user&gt; is no longer timed out in this channel.
      */
     UNTIMEOUT_SUCCESS,
+
+    /**
+     * You have removed &lt;user&gt; as a VIP of this channel.
+     */
+    @Unofficial
+    UNVIP_SUCCESS,
 
     /**
      * Usage: “/ban &lt;username&gt; [reason]” Permanently prevent a user from chatting. Reason is optional and will be shown to the target and other moderators. Use “/unban” to remove a ban.
@@ -706,6 +756,30 @@ public enum NoticeTag {
      * Usage: “/untimeout &lt;username&gt;” Removes a timeout on a user.
      */
     USAGE_UNTIMEOUT,
+
+    /**
+     * Usage: “/vip &lt;username&gt;” Grant VIP status to a user. Use “/vips” to list the moderators of this channel.
+     */
+    @Unofficial
+    USAGE_VIP,
+
+    /**
+     * Usage: “/vips” Lists the VIPs of this channel.
+     */
+    @Unofficial
+    USAGE_VIPS,
+
+    /**
+     * You have added &lt;user&gt; as a VIP of this channel.
+     */
+    @Unofficial
+    VIP_SUCCESS,
+
+    /**
+     * The VIPs of this channel are: &lt;list of users&gt;.
+     */
+    @Unofficial
+    VIPS_SUCCESS,
 
     /**
      * You have been banned from sending whispers.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add unofficial chat verification notice tags
* Add unofficial vip chat notice tags
* Refactor `IRCEventHandler` to utilize `NoticeTag` (and fire `MessageDeleteError` event in more cases)

### Additional Information

Thanks to Alca and Syzuna for message samples with the new verification notices

VIP notice info: https://twitch.uservoice.com/forums/310213-developers/suggestions/39848266-msg-id-tags-page-outdated-incorrect
