### PR TITLE
feat: add broadcaster and creator names to Clip object

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Clip.java
@@ -30,8 +30,14 @@ public class Clip {
     /** User ID of the stream from which the clip was created. */
     private String broadcasterId;
 
-    /** ID of the user who created the clip. */
+    /** User display name of the stream from which the clip was created. */
+    private String broadcasterName;
+
+    /** Display name of the user who created the clip. */
     private String creatorId;
+
+    /** Display name of the user who created the clip. */
+    private String creatorName;
 
     /** ID of the video from which the clip was created. */
     private String videoId;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `Clip#getBroadcasterName`
* Add `Clip#getCreatorName`

### Additional Information
Was added at some point to [Get Clips](https://dev.twitch.tv/docs/api/reference#get-clips) without an entry on the official [changelog](https://dev.twitch.tv/docs/change-log)
