### PR TITLE
chore(deps): add a rich version constraint for databind 2.13.0

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -1,13 +1,12 @@
 dependencies {
-	// Credential Manager
-	api(group = "com.github.philippheuer.credentialmanager", name = "credentialmanager")
-	//testImplementation(group = "com.github.philippheuer.credentialmanager", name = "credentialmanager-ews", version = "0.1.1")
-
 	// Http Client
 	api(group = "com.squareup.okhttp3", name = "okhttp")
 
 	// Jackson
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
+
+	// Credential Manager
+	api(group = "com.github.philippheuer.credentialmanager", name = "credentialmanager")
 }
 
 publishing.publications.withType<MavenPublication> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,14 @@ subprojects {
 
 			// Hystrix
 			api(group = "com.netflix.hystrix", name = "hystrix-core", version = "1.5.18")
+
+			// rich version declarations
+			add("api", "com.fasterxml.jackson.core:jackson-databind") {
+				version {
+					require("2.12.0")
+					prefer("2.13.0")
+				}
+			}
 		}
 
 		// Apache Commons

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,10 +89,12 @@ subprojects {
 			api(group = "com.netflix.hystrix", name = "hystrix-core", version = "1.5.18")
 
 			// rich version declarations
-			add("api", "com.fasterxml.jackson.core:jackson-databind") {
-				version {
-					require("2.12.0")
-					prefer("2.13.0")
+			listOf("com.fasterxml.jackson.core:jackson-annotations", "com.fasterxml.jackson.core:jackson-core", "com.fasterxml.jackson.core:jackson-databind", "com.fasterxml.jackson.datatype:jackson-datatype-jsr310").forEach { dep ->
+				add("api", dep) {
+					version {
+						strictly("[2.12,3[")
+						prefer("2.13.0")
+					}
 				}
 			}
 		}

--- a/twitch4j/build.gradle.kts
+++ b/twitch4j/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
 
 	// Cache
 	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+
+	// Jackson
+	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
 }
 
 publishing.publications.withType<MavenPublication> {


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

<!-- Uncomment this section if this PR is related to any issues.
### Issues Fixed 
* [Issue #1]

 -->

### Changes Proposed

* adds a rich version constraint for jackson databind (require 2.12.0+, prefer 2.13.0)

### Additional Information

Docs: https://docs.gradle.org/current/userguide/rich_versions.html