### PR TITLE
feat: add more chat and prediction related gql queries

### DIFF
--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchActivePredictions.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchActivePredictions.graphql
@@ -1,0 +1,36 @@
+query fetchActivePredictions($channelId: ID!) {
+	channel(id: $channelId) {
+		activePredictionEvents {
+			createdAt
+			createdBy {
+				... on User {
+					id
+					displayName
+					login
+				}
+			}
+			id
+			outcomes {
+				color
+				id
+				title
+				topPredictors {
+					id
+					points
+					predictedAt
+					updatedAt
+					user {
+						id
+						displayName
+						login
+					}
+				}
+				totalPoints
+				totalUsers
+			}
+			predictionWindowSeconds
+			status
+			title
+		}
+	}
+}

--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchBanStatus.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchBanStatus.graphql
@@ -1,0 +1,18 @@
+query fetchBanStatus($channelID: ID!, $userID: ID!) {
+	chatRoomBanStatus(channelID: $channelID, userID: $userID) {
+		bannedUser {
+			id
+			login
+			displayName
+		}
+		createdAt
+		expiresAt
+		isPermanent
+		moderator {
+			id
+			login
+			displayName
+		}
+		reason
+	}
+}

--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchChatHistory.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchChatHistory.graphql
@@ -1,0 +1,100 @@
+query fetchChatHistory($channelID: ID!, $userID: ID!, $after: Cursor, $first: Int = 100, $order: SortOrder = DESC, $includeMessageCount: Boolean = true, $includeTargetedActions: Boolean = true, $includeAutoModCaughtMessages: Boolean = true) {
+	user(id: $channelID) {
+		modLogs {
+			messagesBySender(senderID: $userID, first: $first, after: $after, order: $order, includeMessageCount: $includeMessageCount, includeTargetedActions: $includeTargetedActions, includeAutoModCaughtMessages: $includeAutoModCaughtMessages) {
+				edges {
+					cursor
+					node {
+						... on AutoModCaughtMessage {
+							category
+							id
+							modLogsMessage {
+								content {
+									fragments {
+										content {
+											... on AutoMod {
+												topics {
+													type
+													weight
+												}
+											}
+										}
+										text
+									}
+									text
+								}
+								id
+								sender {
+									id
+									login
+									displayName
+								}
+								sentAt
+							}
+							resolvedAt
+							resolver {
+								id
+								login
+								displayName
+							}
+							status
+						}
+						... on ModLogsMessage {
+							content {
+								fragments {
+									content {
+										... on AutoMod {
+											topics {
+												type
+												weight
+											}
+										}
+									}
+									text
+								}
+								text
+							}
+							id
+							sender {
+								id
+								login
+								displayName
+							}
+							sentAt
+						}
+						... on ModLogsTargetedModActionsEntry {
+							action
+							channel {
+								id
+								login
+								displayName
+							}
+							details {
+								bannedAt
+								durationSeconds
+								expiresAt
+								reason
+							}
+							id
+							target {
+								id
+								login
+								displayName
+							}
+							timestamp
+							user {
+								id
+								login
+								displayName
+							}
+						}
+					}
+				}
+				messageCount
+				pageInfo {
+					hasNextPage
+				}
+			}
+		}
+	}
+}

--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchChatters.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchChatters.graphql
@@ -1,0 +1,22 @@
+query fetchChatters($login: String!) {
+	channel(name: $login) {
+		chatters {
+			broadcasters {
+				login
+			}
+			staff {
+				login
+			}
+			vips {
+				login
+			}
+			moderators {
+				login
+			}
+			viewers {
+				login
+			}
+			count
+		}
+	}
+}

--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchLockedPredictions.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchLockedPredictions.graphql
@@ -1,0 +1,44 @@
+query fetchLockedPredictions($channelId: ID!) {
+	channel(id: $channelId) {
+		lockedPredictionEvents {
+			createdAt
+			createdBy {
+				... on User {
+					id
+					displayName
+					login
+				}
+			}
+			id
+			lockedAt
+			lockedBy {
+				... on User {
+					id
+					displayName
+					login
+				}
+			}
+			outcomes {
+				color
+				id
+				title
+				topPredictors {
+					id
+					points
+					predictedAt
+					updatedAt
+					user {
+						id
+						displayName
+						login
+					}
+				}
+				totalPoints
+				totalUsers
+			}
+			predictionWindowSeconds
+			status
+			title
+		}
+	}
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
@@ -143,6 +143,10 @@ public class TwitchGraphQL {
         });
     }
 
+    public CommandFetchBanStatus fetchBanStatus(OAuth2Credential auth, String channelId, String userId) {
+        return new CommandFetchBanStatus(getApolloClient(auth), channelId, userId);
+    }
+
     public CommandAddChannelBlockedTerm addChannelBlockedTerm(OAuth2Credential auth, String channelId, Boolean isModEditable, List<String> phrases) {
         return new CommandAddChannelBlockedTerm(getApolloClient(auth), channelId, isModEditable, phrases);
     }

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
@@ -239,6 +239,10 @@ public class TwitchGraphQL {
         return new CommandCreatePrediction(getApolloClient(auth), input);
     }
 
+    public CommandFetchActivePredictions fetchActivePredictions(OAuth2Credential auth, String channelId) {
+        return new CommandFetchActivePredictions(getApolloClient(auth), channelId);
+    }
+
     public CommandFetchPrediction fetchPrediction(OAuth2Credential auth, String predictionEventId) {
         return new CommandFetchPrediction(getApolloClient(auth), predictionEventId);
     }

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
@@ -159,6 +159,10 @@ public class TwitchGraphQL {
         return new CommandDeleteChannelPermittedTerm(getApolloClient(auth), channelId, phrases);
     }
 
+    public CommandFetchChatHistory fetchChatHistory(OAuth2Credential auth, String channelId, String userId, String after) {
+        return new CommandFetchChatHistory(getApolloClient(auth), channelId, userId, after);
+    }
+
     public CommandFetchChatters fetchChatters(OAuth2Credential auth, String channelLogin) {
         return new CommandFetchChatters(getApolloClient(auth), channelLogin);
     }

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
@@ -243,6 +243,10 @@ public class TwitchGraphQL {
         return new CommandFetchActivePredictions(getApolloClient(auth), channelId);
     }
 
+    public CommandFetchLockedPredictions fetchLockedPredictions(OAuth2Credential auth, String channelId) {
+        return new CommandFetchLockedPredictions(getApolloClient(auth), channelId);
+    }
+
     public CommandFetchPrediction fetchPrediction(OAuth2Credential auth, String predictionEventId) {
         return new CommandFetchPrediction(getApolloClient(auth), predictionEventId);
     }

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
@@ -159,6 +159,10 @@ public class TwitchGraphQL {
         return new CommandDeleteChannelPermittedTerm(getApolloClient(auth), channelId, phrases);
     }
 
+    public CommandFetchChatters fetchChatters(OAuth2Credential auth, String channelLogin) {
+        return new CommandFetchChatters(getApolloClient(auth), channelLogin);
+    }
+
     public CommandCreateClip createClip(OAuth2Credential auth, String channelId, Double offsetSeconds, String broadcastId, String videoId) {
         return new CommandCreateClip(getApolloClient(auth), channelId, offsetSeconds, broadcastId, videoId);
     }

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
@@ -7,6 +7,7 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.EventManagerUtils;
+import com.netflix.config.ConfigurationManager;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -97,6 +98,11 @@ public class TwitchGraphQLBuilder {
     public TwitchGraphQL build() {
         log.debug("GraphQL: Initializing Module ...");
         log.warn("GraphQL: GraphQL is a experimental module not intended for third-party use, please take care as some features might break unannounced.");
+
+        // Hystrix
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", timeout);
+
+        // GQL
         TwitchGraphQL client = new TwitchGraphQL(baseUrl, userAgent, eventManager, clientId, defaultFirstPartyToken, proxyConfig, enableBatching, timeout);
 
         // Initialize/Check EventManager

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchActivePredictions.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchActivePredictions.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchActivePredictionsQuery;
+import lombok.NonNull;
+
+public class CommandFetchActivePredictions extends BaseCommand<FetchActivePredictionsQuery.Data> {
+    private final String channelId;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelId    The id of the channel to fetch active predictions of
+     */
+    public CommandFetchActivePredictions(@NonNull ApolloClient apolloClient, @NonNull String channelId) {
+        super(apolloClient);
+        this.channelId = channelId;
+    }
+
+    @Override
+    protected ApolloCall<FetchActivePredictionsQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchActivePredictionsQuery.builder()
+                .channelId(channelId)
+                .build()
+        );
+    }
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchBanStatus.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchBanStatus.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchBanStatusQuery;
+import lombok.NonNull;
+
+public class CommandFetchBanStatus extends BaseCommand<FetchBanStatusQuery.Data> {
+    private final String channelId;
+    private final String userId;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelId    Channel ID
+     * @param userId       User ID
+     */
+    public CommandFetchBanStatus(@NonNull ApolloClient apolloClient, @NonNull String channelId, @NonNull String userId) {
+        super(apolloClient);
+        this.channelId = channelId;
+        this.userId = userId;
+    }
+
+    @Override
+    protected ApolloCall<FetchBanStatusQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchBanStatusQuery.builder()
+                .channelID(channelId)
+                .userID(userId)
+                .build()
+        );
+    }
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchChatHistory.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchChatHistory.java
@@ -1,0 +1,39 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchChatHistoryQuery;
+import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CommandFetchChatHistory extends BaseCommand<FetchChatHistoryQuery.Data> {
+    private final String channelId;
+    private final String userId;
+    private final String after;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelId    Channel ID
+     * @param userId       User ID
+     * @param after        Optional cursor for pagination
+     */
+    public CommandFetchChatHistory(@NonNull ApolloClient apolloClient, @NonNull String channelId, @NonNull String userId, @Nullable String after) {
+        super(apolloClient);
+        this.channelId = channelId;
+        this.userId = userId;
+        this.after = after;
+    }
+
+    @Override
+    protected ApolloCall<FetchChatHistoryQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchChatHistoryQuery.builder()
+                .channelID(channelId)
+                .userID(userId)
+                .after(after)
+                .build()
+        );
+    }
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchChatters.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchChatters.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchChattersQuery;
+import lombok.NonNull;
+
+public class CommandFetchChatters extends BaseCommand<FetchChattersQuery.Data> {
+    private final String channelLogin;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelLogin The name of the channel to get the connected chatters of
+     */
+    public CommandFetchChatters(@NonNull ApolloClient apolloClient, @NonNull String channelLogin) {
+        super(apolloClient);
+        this.channelLogin = channelLogin;
+    }
+
+    @Override
+    protected ApolloCall<FetchChattersQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchChattersQuery.builder()
+                .login(channelLogin)
+                .build()
+        );
+    }
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchLockedPredictions.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchLockedPredictions.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchLockedPredictionsQuery;
+import lombok.NonNull;
+
+public class CommandFetchLockedPredictions extends BaseCommand<FetchLockedPredictionsQuery.Data> {
+    private final String channelId;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelId    The id of the channel to fetch locked predictions of
+     */
+    public CommandFetchLockedPredictions(@NonNull ApolloClient apolloClient, @NonNull String channelId) {
+        super(apolloClient);
+        this.channelId = channelId;
+    }
+
+    @Override
+    protected ApolloCall<FetchLockedPredictionsQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchLockedPredictionsQuery.builder()
+                .channelId(channelId)
+                .build()
+        );
+    }
+}

--- a/graphql/src/test/java/com/github/twitch4j/graphql/TwitchGraphQLTest.java
+++ b/graphql/src/test/java/com/github/twitch4j/graphql/TwitchGraphQLTest.java
@@ -1,7 +1,9 @@
 package com.github.twitch4j.graphql;
 
 import com.github.philippheuer.events4j.core.EventManager;
+import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.common.TwitchTestUtils;
+import com.github.twitch4j.common.util.EventManagerUtils;
 import com.github.twitch4j.graphql.internal.FollowMutation;
 import com.github.twitch4j.graphql.internal.UnfollowMutation;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +23,7 @@ public class TwitchGraphQLTest {
     @BeforeAll
     public static void buildTwitch4J() {
         // external event manager (for shared module usage - streamlabs4j)
-        EventManager eventManager = new EventManager();
+        EventManager eventManager = EventManagerUtils.initializeEventManager(SimpleEventHandler.class);
 
         // construct twitchClient
         graphQLClient = TwitchGraphQLBuilder.builder()

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -245,6 +245,12 @@ public class TwitchClientPoolBuilder {
     private OAuth2Credential defaultAuthToken = null;
 
     /**
+     * Default First-Party OAuth Token for GraphQL calls
+     */
+    @With
+    private OAuth2Credential defaultFirstPartyToken = null;
+
+    /**
      * Proxy Configuration
      */
     @With
@@ -452,6 +458,7 @@ public class TwitchClientPoolBuilder {
         if (this.enableGraphQL) {
             graphql = TwitchGraphQLBuilder.builder()
                 .withEventManager(eventManager)
+                .withDefaultFirstPartyToken(defaultFirstPartyToken)
                 .withProxyConfig(proxyConfig)
                 .withTimeout(timeout)
                 .build();


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement `fetchBanStatus`, `fetchChatHistory`, `fetchChatters`, `fetchActivePredictions`, `fetchLockedPredictions`
* Properly apply `timeout`
* Add `defaultFirstPartyToken` to `TwitchClientPoolBuilder`

### Additional Information
Previously, `timeoutInMilliseconds` was set to `1000` by default
