### PR TITLE
fix: add clear chat mod action to pubsub topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -204,6 +204,10 @@ public class ChatModerationAction {
          */
         UNTIMEOUT,
         /**
+         * The recent chat history was wiped
+         */
+        CLEAR,
+        /**
          * Chat message was deleted
          */
         DELETE,


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
`ChatModerationAction(type=chat_channel_moderation, moderationAction=null, args=null, createdBy=beatz41, createdByUserId=239088839, msgId=, targetUserId=, targetUserLogin=, fromAutomod=false, modType=CHANNEL)`

### Changes Proposed
* Add `CLEAR` to `ChatModerationAction.ModerationAction`

### Additional Information
Thanks to @beatzzz for reporting
