### PR TITLE
chore(docs): Grouping packages into specific modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -185,6 +185,21 @@ tasks.register<Javadoc>("aggregateJavadoc") {
 		title = "${rootProject.name} (v${project.version})"
 		windowTitle = "${rootProject.name} (v${project.version})"
 		encoding = "UTF-8"
+		this as StandardJavadocDocletOptions
+		group("Common", "com.github.twitch4j.common*")
+		group("Auth", "com.github.twitch4j.auth*")
+		group("Chat", "com.github.twitch4j.chat*")
+		group("EventSub", "com.github.twitch4j.eventsub*")
+		group("GraphQL", "com.github.twitch4j.graphql*")
+		group("PubSub", "com.github.twitch4j.pubsub*")
+		group("Extensions API", "com.github.twitch4j.extensions*")
+		group("New API - Helix", "com.github.twitch4j.helix*")
+		group("Kraken API v5 (deprecated)", "com.github.twitch4j.kraken*")
+		group("Twitch Message Interface - API", "com.github.twitch4j.tmi*")
+		group("Core",
+			"com.github.twitch4j", "com.github.twitch4j.domain*",
+			"com.github.twitch4j.events*", "com.github.twitch4j.modules*"
+		)
 	}
 
 	source(subprojects.map { it.tasks.delombok.get() })


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

1. Aggregate packages into module specific name

### Additional Information

Gonna use this [example build](https://github.com/lenskit/lenskit/blob/master/gradle/javadoc.gradle#L64-L92) and leave this for review. Those changes are affected only for main javadoc website. All javadocs generated in the bundle to upload to central will not have it.
