### PR TITLE
feat: implement soundtrack beta helix endpoints

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -653,6 +653,21 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets a Soundtrack playlist, which includes its list of tracks.
+     *
+     * @param authToken App access token or User access token.
+     * @param id        The ASIN of the Soundtrack playlist to get.
+     * @return SoundtrackPlaylistTracksWrapper
+     */
+    @Unofficial // beta
+    @RequestLine("GET /soundtrack/playlist?id={id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<SoundtrackPlaylistTracksWrapper> getSoundtrackPlaylist(
+        @Param("token") String authToken,
+        @Param("id") String id
+    );
+
+    /**
      * Gets a list of Soundtrack playlists.
      *
      * @param authToken App access token or User access token.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -638,6 +638,21 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets the Soundtrack track that the broadcaster is playing.
+     *
+     * @param authToken     App access token or User access token.
+     * @param broadcasterId The ID of the broadcaster that’s playing a Soundtrack track.
+     * @return SoundtrackCurrentTrackWrapper
+     */
+    @Unofficial // beta
+    @RequestLine("GET /soundtrack/current_track?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<SoundtrackCurrentTrackWrapper> getSoundtrackCurrentTrack(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
      * Starts a commercial on a specified channel
      *
      * @param authToken Auth Token (scope: channel:edit:commercial)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -653,6 +653,19 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets a list of Soundtrack playlists.
+     *
+     * @param authToken App access token or User access token.
+     * @return SoundtrackPlaylistMetadataList
+     */
+    @Unofficial // beta
+    @RequestLine("GET /soundtrack/playlists")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<SoundtrackPlaylistMetadataList> getSoundtrackPlaylists(
+        @Param("token") String authToken
+    );
+
+    /**
      * Starts a commercial on a specified channel
      *
      * @param authToken Auth Token (scope: channel:edit:commercial)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackAlbum.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackAlbum.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackAlbum {
+
+    /**
+     * The album’s ASIN (Amazon Standard Identification Number).
+     */
+    private String id;
+
+    /**
+     * The album’s name.
+     */
+    private String name;
+
+    /**
+     * A URL to the album’s cover art.
+     */
+    private String imageUrl;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackArtist.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackArtist.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackArtist {
+
+    /**
+     * The ID of the Twitch user that created the track.
+     * Is null if a Twitch user didn't create the track.
+     */
+    @Nullable
+    private String creatorChannelId;
+
+    /**
+     * The artist’s ASIN (Amazon Standard Identification Number).
+     */
+    private String id;
+
+    /**
+     * The artist’s name.
+     * This can be the band’s name or the solo artist’s name.
+     */
+    private String name;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrack.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrack.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackCurrentTrack {
+
+    /**
+     * The track that’s currently playing.
+     */
+    private SoundtrackTrack track;
+
+    /**
+     * The source of the track that’s currently playing.
+     * For example, a playlist or station.
+     */
+    private SoundtrackSource source;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
@@ -1,0 +1,29 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Optional;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackCurrentTrackWrapper {
+
+    /**
+     * A list that contains the Soundtrack track that the broadcaster is playing.
+     * The list is empty if the broadcaster is not playing a track.
+     */
+    private List<SoundtrackCurrentTrack> data;
+
+    /**
+     * @return the Soundtrack track that the broadcaster is playing or empty if the broadcaster is not playing a track.
+     */
+    public Optional<SoundtrackCurrentTrack> getTrack() {
+        if (data == null || data.isEmpty())
+            return Optional.empty();
+        return Optional.ofNullable(data.get(0));
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadata.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackPlaylistMetadata {
+
+    /**
+     * The playlist’s title.
+     */
+    private String title;
+
+    /**
+     * The playlist’s ASIN (Amazon Standard Identification Number).
+     */
+    private String id;
+
+    /**
+     * A URL to the playlist’s image art.
+     * Is empty if the playlist doesn't include art.
+     */
+    private String imageUrl;
+
+    /**
+     * A short description about the music that the playlist includes.
+     */
+    private String description;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadataList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadataList.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackPlaylistMetadataList {
+
+    /**
+     * The list of Soundtrack playlists.
+     */
+    @JsonProperty("data")
+    private List<SoundtrackPlaylistMetadata> playlists;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistTracks.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistTracks.java
@@ -1,0 +1,39 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackPlaylistTracks {
+
+    /**
+     * The playlist’s title.
+     */
+    private String title;
+
+    /**
+     * The playlist’s ASIN (Amazon Standard Identification Number).
+     */
+    private String id;
+
+    /**
+     * A URL to the playlist’s image art.
+     * Is empty if the playlist doesn't include art.
+     */
+    private String imageUrl;
+
+    /**
+     * A short description about the music that the playlist includes.
+     */
+    private String description;
+
+    /**
+     * The list of tracks in the playlist.
+     */
+    private List<SoundtrackTrack> catalogTracks;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistTracksWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistTracksWrapper.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Optional;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackPlaylistTracksWrapper {
+
+    /**
+     * A list that contains the single playlist you requested.
+     */
+    @JsonProperty("data")
+    private List<SoundtrackPlaylistTracks> playlists;
+
+    /**
+     * @return the single playlist you requested.
+     */
+    public Optional<SoundtrackPlaylistTracks> getPlaylist() {
+        if (playlists == null || playlists.isEmpty())
+            return Optional.empty();
+        return Optional.ofNullable(playlists.get(0));
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackSource.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackSource.java
@@ -1,0 +1,48 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackSource {
+
+    /**
+     * The playlist’s or station’s ASIN (Amazon Standard Identification Number).
+     */
+    private String id;
+
+    /**
+     * The type of content that id maps to.
+     */
+    private Type contentType;
+
+    /**
+     * The playlist’s or station’s title.
+     */
+    public String title;
+
+    /**
+     * A URL to the playlist’s or station’s image art.
+     */
+    private String imageUrl;
+
+    /**
+     * A URL to the playlist on Soundtrack.
+     * The string is empty if {@link #getContentType()} is {@link Type#STATION}.
+     */
+    private String soundtrackUrl;
+
+    /**
+     * A URL to the playlist on Spotify.
+     * The string is empty if {@link #getContentType()} is {@link Type#STATION}.
+     */
+    private String spotifyUrl;
+
+    public enum Type {
+        PLAYLIST,
+        STATION
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackTrack.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackTrack.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SoundtrackTrack {
+
+    /**
+     * The album that includes the track.
+     */
+    private SoundtrackAlbum album;
+
+    /**
+     * The artists included on the track.
+     */
+    private List<SoundtrackArtist> artists;
+
+    /**
+     * The duration of the track, in seconds.
+     */
+    private Integer duration;
+
+    /**
+     * The track’s ASIN (Amazon Standard Identification Number).
+     */
+    private String id;
+
+    /**
+     * The track’s title.
+     */
+    private String title;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#getSoundtrackCurrentTrack`
* Add `TwitchHelix#getSoundtrackPlaylist`
* Add `TwitchHelix#getSoundtrackPlaylists`

### Additional Information
Added on [2021-12-09](https://dev.twitch.tv/docs/change-log)
