### PR TITLE
fix: ensure first ever follower triggers FollowEvent

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -248,11 +248,11 @@ public class TwitchClientHelper implements AutoCloseable {
             HystrixCommand<FollowList> commandGetFollowers = twitchHelix.getFollowers(null, null, channelId, null, MAX_LIMIT);
             try {
                 ChannelCache currentChannelCache = channelInformation.get(channelId, s -> new ChannelCache());
-                Instant lastFollowDate = null;
+                Instant lastFollowDate = currentChannelCache.getLastFollowCheck();
 
                 boolean nextRequestCanBeImmediate = false;
 
-                if (currentChannelCache.getLastFollowCheck() != null) {
+                if (lastFollowDate != null) {
                     FollowList executionResult = commandGetFollowers.execute();
                     List<Follow> followList = executionResult.getFollows();
                     followBackoff.get().reset(); // API call was successful
@@ -293,7 +293,7 @@ public class TwitchClientHelper implements AutoCloseable {
                 if (currentChannelCache.getLastFollowCheck() == null) {
                     // only happens if the user doesn't have any followers at all
                     currentChannelCache.setLastFollowCheck(Instant.now());
-                } else {
+                } else if (lastFollowDate != null) {
                     // tracks the date of the latest follow to identify new ones later on
                     currentChannelCache.setLastFollowCheck(lastFollowDate);
                 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* For the very first follower of a channel (follow count goes from 0 to 1), `ChannelFollowCountUpdateEvent` will fire but a corresponding `FollowEvent` may not

### Changes Proposed
* Minor adjustment to `lastFollowDate` logic in `TwitchClientHelper` so that `follow.getFollowedAtInstant().isAfter(currentChannelCache.getLastFollowCheck())` does not evaluate to false for the very first follower

### Additional Information
Thanks to @DenalidTX for reporting
