### PR TITLE
feat: identify first time chatters within ChannelMessageEvent

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -30,30 +30,30 @@ public class ChannelMessageEvent extends AbstractChannelEvent implements Replyab
      */
     private final IRCMessageEvent messageEvent;
 
-	/**
-	 * User
-	 */
-	private EventUser user;
+    /**
+     * User
+     */
+    private EventUser user;
 
-	/**
-	 * Message
-	 */
-	private String message;
+    /**
+     * Message
+     */
+    private String message;
 
-	/**
-	 * Permissions of the user
-	 */
-	private Set<CommandPermission> permissions;
+    /**
+     * Permissions of the user
+     */
+    private Set<CommandPermission> permissions;
 
     /**
      * The exact number of months the user has been a subscriber, or zero if not subscribed
      */
-	private int subscriberMonths;
+    private int subscriberMonths;
 
     /**
      * The tier at which the user is subscribed (prime is treated as 1), or zero if not subscribed
      */
-	private int subscriptionTier;
+    private int subscriptionTier;
 
     /**
      * Nonce
@@ -77,24 +77,24 @@ public class ChannelMessageEvent extends AbstractChannelEvent implements Replyab
     @Getter(lazy = true)
     ChatCrowdChant chantInfo = ChatCrowdChant.parse(getMessageEvent());
 
-	/**
-	 * Event Constructor
-	 *
-	 * @param channel     The channel that this event originates from.
+    /**
+     * Event Constructor
+     *
+     * @param channel      The channel that this event originates from.
      * @param messageEvent The raw message event
-	 * @param user        The user who triggered the event.
-	 * @param message     The plain text of the message.
-	 * @param permissions The permissions of the triggering user.
-	 */
-	public ChannelMessageEvent(EventChannel channel, IRCMessageEvent messageEvent, EventUser user, String message, Set<CommandPermission> permissions) {
-		super(channel);
+     * @param user         The user who triggered the event.
+     * @param message      The plain text of the message.
+     * @param permissions  The permissions of the triggering user.
+     */
+    public ChannelMessageEvent(EventChannel channel, IRCMessageEvent messageEvent, EventUser user, String message, Set<CommandPermission> permissions) {
+        super(channel);
         this.messageEvent = messageEvent;
-		this.user = user;
-		this.message = message;
-		this.permissions = permissions;
-		this.subscriberMonths = messageEvent.getSubscriberMonths().orElse(0);
-		this.subscriptionTier = messageEvent.getSubscriptionTier().orElse(0);
-	}
+        this.user = user;
+        this.message = message;
+        this.permissions = permissions;
+        this.subscriberMonths = messageEvent.getSubscriberMonths().orElse(0);
+        this.subscriptionTier = messageEvent.getSubscriptionTier().orElse(0);
+    }
 
     /**
      * @return whether "Highlight My Message" was redeemed for this event
@@ -121,10 +121,21 @@ public class ChannelMessageEvent extends AbstractChannelEvent implements Replyab
     }
 
     /**
+     * @return whether this is the user's first message in the channel.
+     * @apiNote This method is marked as unofficial since this tag does not appear in the irc guide.
+     * @see <a href="https://help.twitch.tv/s/article/first-time-chatter-highlight">Official documentation</a>
+     */
+    @Unofficial
+    public boolean isDesignatedFirstMessage() {
+        return "1".equals(getMessageEvent().getTags().get("first-msg"));
+    }
+
+    /**
      * @return the regions of the message that were flagged by AutoMod.
      */
     @Unofficial
     public List<AutoModFlag> getFlags() {
         return this.messageEvent.getFlags();
     }
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Implement `ChannelMessageEvent#isDesignatedFirstMessage`

### Additional Information
https://twitch.uservoice.com/forums/310201-chat/suggestions/43598730--test-first-participation-highlight-in-creator-mo
