### PR TITLE
feat: implement the irc auth rate limit

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -136,6 +136,12 @@ public class TwitchChatBuilder {
     protected Bandwidth joinRateLimit = TwitchChatLimitHelper.USER_JOIN_LIMIT;
 
     /**
+     * Custom RateLimit for AUTH
+     */
+    @With
+    protected Bandwidth authRateLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
+
+    /**
      * Shared bucket for messages
      */
     @With
@@ -152,6 +158,12 @@ public class TwitchChatBuilder {
      */
     @With
     protected Bucket ircJoinBucket = null;
+
+    /**
+     * Shared bucket for auths
+     */
+    @With
+    protected Bucket ircAuthBucket = null;
 
     /**
      * Scheduler Thread Pool Executor
@@ -228,8 +240,11 @@ public class TwitchChatBuilder {
         if (ircJoinBucket == null)
             ircJoinBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.joinRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_JOIN_LIMIT, Collections.singletonList(joinRateLimit));
 
+        if (ircAuthBucket == null)
+            ircAuthBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
+
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -85,6 +85,12 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
     @Builder.Default
     protected Bandwidth joinRateLimit = TwitchChatLimitHelper.USER_JOIN_LIMIT;
 
+    /**
+     * Custom RateLimit for AUTH
+     */
+    @Builder.Default
+    protected Bandwidth authRateLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
+
     @Override
     public boolean sendMessage(String channel, String message, @Nullable Map<String, Object> tags) {
         return this.sendMessage(channel, channel, message, tags);
@@ -245,6 +251,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
                 .withChatRateLimit(chatRateLimit)
                 .withWhisperRateLimit(whisperRateLimit)
                 .withJoinRateLimit(joinRateLimit)
+                .withAuthRateLimit(authRateLimit)
                 .withAutoJoinOwnChannel(false) // user will have to manually send a subscribe call to enable whispers. this avoids duplicating whisper events
         ).build();
 

--- a/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
@@ -11,8 +11,6 @@ public enum TwitchLimitType {
 
     /**
      * How fast authentication attempts can be issued over IRC.
-     * <p>
-     * Note: this limit is <i>not</i> currently implemented elsewhere in the library.
      */
     CHAT_AUTH_LIMIT("irc-auth-limit"),
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -183,6 +182,12 @@ public class TwitchClientBuilder {
      */
     @With
     protected Bandwidth chatJoinLimit = TwitchChatLimitHelper.USER_JOIN_LIMIT;
+
+    /**
+     * Custom RateLimit for AUTH
+     */
+    @With
+    protected Bandwidth chatAuthLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
     /**
      * Wait time for taking items off chat queue in milliseconds. Default recommended
@@ -384,6 +389,7 @@ public class TwitchClientBuilder {
                 .withChatRateLimit(chatRateLimit)
                 .withWhisperRateLimit(chatWhisperLimit)
                 .withJoinRateLimit(chatJoinLimit)
+                .withAuthRateLimit(chatAuthLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -44,9 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -205,6 +203,12 @@ public class TwitchClientPoolBuilder {
      */
     @With
     protected Bandwidth chatJoinLimit = TwitchChatLimitHelper.USER_JOIN_LIMIT;
+
+    /**
+     * Custom RateLimit for AUTH
+     */
+    @With
+    protected Bandwidth chatAuthLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
     /**
      * Wait time for taking items off chat queue in milliseconds. Default recommended
@@ -405,6 +409,7 @@ public class TwitchClientPoolBuilder {
                 .chatRateLimit(chatRateLimit)
                 .whisperRateLimit(chatWhisperLimit)
                 .joinRateLimit(chatJoinLimit)
+                .authRateLimit(chatAuthLimit)
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
                 .maxSubscriptionsPerConnection(maxChannelsPerChatInstance)
@@ -426,6 +431,7 @@ public class TwitchClientPoolBuilder {
                 .withChatRateLimit(chatRateLimit)
                 .withWhisperRateLimit(chatWhisperLimit)
                 .withJoinRateLimit(chatJoinLimit)
+                .withAuthRateLimit(chatAuthLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Previously `AUTH`s were not ratelimited

### Changes Proposed
* Add `authRateLimit`/`ircAuthBucket` and don't open connections in `TwitchChat` until a limit token has been consumed (blocking)

### Additional Information
https://dev.twitch.tv/docs/irc/guide#rate-limits
