### PR TITLE
chore: deprecate extensions module

### DIFF
--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
@@ -18,7 +18,10 @@ import java.util.Map;
 
 /**
  * Twitch - Extensions API
+ *
+ * @deprecated will be shutdown by twitch in February 2022 - https://discuss.dev.twitch.tv/t/how-extensions-are-affected-by-the-legacy-twitch-api-v5-shutdown/32708
  */
+@Deprecated
 public interface TwitchExtensions {
 
     /**

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
@@ -22,11 +22,14 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Twitch API - Extensions
+ *
+ * @deprecated will be shutdown by twitch in February 2022 - https://discuss.dev.twitch.tv/t/how-extensions-are-affected-by-the-legacy-twitch-api-v5-shutdown/32708
  */
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Deprecated
 public class TwitchExtensionsBuilder {
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed

* extensions module can be deprecated (and removed in feb 2022)

### Additional Information
- https://discuss.dev.twitch.tv/t/how-extensions-are-affected-by-the-legacy-twitch-api-v5-shutdown/32708
- https://dev.twitch.tv/docs/extensions/reference
