### PR TITLE
fix: json unwrap custom reward settings on serialization

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -6,6 +6,8 @@ import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.util.ThreadUtils;
 import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.helix.domain.CustomReward;
+import com.github.twitch4j.helix.interceptor.CustomRewardEncodeMixIn;
 import com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor;
 import com.github.twitch4j.helix.interceptor.TwitchHelixDecoder;
 import com.github.twitch4j.helix.interceptor.TwitchHelixHttpClient;
@@ -123,6 +125,7 @@ public class TwitchHelixBuilder {
 
         // Jackson ObjectMapper
         ObjectMapper mapper = TypeConvert.getObjectMapper();
+        ObjectMapper serializer = mapper.copy().addMixIn(CustomReward.class, CustomRewardEncodeMixIn.class);
 
         // Create HttpClient with proxy
         okhttp3.OkHttpClient.Builder clientBuilder = new okhttp3.OkHttpClient.Builder();
@@ -137,7 +140,7 @@ public class TwitchHelixBuilder {
         TwitchHelixClientIdInterceptor interceptor = new TwitchHelixClientIdInterceptor(this);
         return HystrixFeign.builder()
             .client(new TwitchHelixHttpClient(new OkHttpClient(clientBuilder.build()), scheduledThreadPoolExecutor, interceptor, timeout))
-            .encoder(new JacksonEncoder(mapper))
+            .encoder(new JacksonEncoder(serializer))
             .decoder(new TwitchHelixDecoder(mapper, interceptor))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomReward.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CustomReward.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -12,7 +13,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 import lombok.With;
 import lombok.experimental.Accessors;
 import lombok.experimental.SuperBuilder;
@@ -156,47 +156,61 @@ public class CustomReward {
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     @SuperBuilder(toBuilder = true)
     @Jacksonized
-    @EqualsAndHashCode(callSuper = true)
-    @ToString(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     public static class MaxPerStreamSetting extends Setting {
-        private Integer maxPerStream;
-    }
 
-    @Data
-    @Setter(AccessLevel.PRIVATE)
-    @NoArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @SuperBuilder(toBuilder = true)
-    @Jacksonized
-    @EqualsAndHashCode(callSuper = true)
-    @ToString(callSuper = true)
-    public static class MaxPerUserPerStreamSetting extends Setting {
-        private Integer maxPerUserPerStream;
-    }
-
-    @Data
-    @Setter(AccessLevel.PRIVATE)
-    @NoArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @SuperBuilder(toBuilder = true)
-    @Jacksonized
-    @EqualsAndHashCode(callSuper = true)
-    @ToString(callSuper = true)
-    public static class GlobalCooldownSetting extends Setting {
-        private Integer globalCooldownSeconds;
-    }
-
-    @Data
-    @Setter(AccessLevel.PRIVATE)
-    @NoArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @SuperBuilder(toBuilder = true)
-    @Jacksonized
-    public static class Setting {
-        @Getter(onMethod_ = { @JsonIgnore }) // avoid serializing both "is_enabled" and "enabled" from this single variable
+        @Getter(onMethod_ = { @JsonIgnore })
         @Accessors(fluent = true)
-        @JsonProperty("is_enabled")
+        @JsonAlias("is_enabled")
+        @JsonProperty("is_max_per_stream_enabled")
         private Boolean isEnabled;
+
+        private Integer maxPerStream;
+
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @SuperBuilder(toBuilder = true)
+    @Jacksonized
+    @EqualsAndHashCode(callSuper = false)
+    public static class MaxPerUserPerStreamSetting extends Setting {
+
+        @Getter(onMethod_ = { @JsonIgnore })
+        @Accessors(fluent = true)
+        @JsonAlias("is_enabled")
+        @JsonProperty("is_max_per_user_per_stream_enabled")
+        private Boolean isEnabled;
+
+        private Integer maxPerUserPerStream;
+
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @SuperBuilder(toBuilder = true)
+    @Jacksonized
+    @EqualsAndHashCode(callSuper = false)
+    public static class GlobalCooldownSetting extends Setting {
+
+        @Getter(onMethod_ = { @JsonIgnore })
+        @Accessors(fluent = true)
+        @JsonAlias("is_enabled")
+        @JsonProperty("is_global_cooldown_enabled")
+        private Boolean isEnabled;
+
+        private Integer globalCooldownSeconds;
+
+    }
+
+    @NoArgsConstructor
+    @SuperBuilder(toBuilder = true)
+    public static abstract class Setting {
+        abstract Boolean isEnabled();
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/CustomRewardEncodeMixIn.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/CustomRewardEncodeMixIn.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.helix.interceptor;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.github.twitch4j.helix.domain.CustomReward;
+
+public interface CustomRewardEncodeMixIn {
+
+    @JsonUnwrapped
+    CustomReward.MaxPerStreamSetting getMaxPerStreamSetting();
+
+    @JsonUnwrapped
+    CustomReward.MaxPerUserPerStreamSetting getMaxPerUserPerStreamSetting();
+
+    @JsonUnwrapped
+    CustomReward.GlobalCooldownSetting getGlobalCooldownSetting();
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/CustomRewardEncodeMixIn.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/CustomRewardEncodeMixIn.java
@@ -3,6 +3,15 @@ package com.github.twitch4j.helix.interceptor;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.github.twitch4j.helix.domain.CustomReward;
 
+/**
+ * When serializing {@link CustomReward} for
+ * {@link com.github.twitch4j.helix.TwitchHelix#createCustomReward(String, String, CustomReward)} or
+ * {@link com.github.twitch4j.helix.TwitchHelix#updateCustomReward(String, String, String, CustomReward)},
+ * Twitch requires MaxPerStreamSetting, MaxPerUserPerStreamSetting, and GlobalCooldownSetting
+ * to be sent unwrapped (i.e., in the root of the object).
+ * <p>
+ * This departs from how CustomReward is to be deserialized, which motivates this MixIn.
+ */
 public interface CustomRewardEncodeMixIn {
 
     @JsonUnwrapped


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Fixes #501 

### Changes Proposed
* Apply `@JsonUnwrapped` to `CustomReward`'s `MaxPerStreamSetting`, `MaxPerUserPerStreamSetting`, and `GlobalCooldownSetting` on serialization
