### PR TITLE
feat: retry failed joins in irc with exponential backoff

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,12 @@ subprojects {
 		// Test
 		testImplementation(platform("org.junit:junit-bom:5.8.2"))
 		testImplementation(group = "org.junit.jupiter", name = "junit-jupiter")
+		// - Mocking
+		testImplementation(group = "org.mockito", name = "mockito-core", version = "4.2.0")
+		testImplementation(group = "org.mockito", name = "mockito-junit-jupiter", version = "4.2.0")
+		// - Await
+		testImplementation(group = "org.awaitility", name = "awaitility", version = "4.1.1")
+		// - Logging
 		testImplementation(group = "ch.qos.logback", name = "logback-classic", version = "1.2.10")
 	}
 

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
 	// Rate Limiting
 	api(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core")
 
+	// Cache
+	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))
 	api(project(":twitch4j-auth"))

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -409,7 +409,7 @@ public class TwitchChat implements ITwitchChat {
                         } else if (removeChannelOnJoinFailure && removeCurrentChannel(name)) {
                             eventManager.publish(new ChannelJoinFailureEvent(name, ChannelJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
                         } else {
-                            log.debug("Chat connection exhausted retries when attempting to join channel: {}", name);
+                            log.warn("Chat connection exhausted retries when attempting to join channel: {}", name);
                         }
                     }
                 })

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -405,7 +405,7 @@ public class TwitchChat implements ITwitchChat {
                                 if (currentChannels.contains(name)) {
                                     issueJoin(name, attempts + 1);
                                 }
-                            }, initialWait * (1L << (attempts + 1)), TimeUnit.MILLISECONDS); // exponential backoff (pow2 optimization)
+                            }, initialWait * (1L << (Math.min(attempts, 16) + 1)), TimeUnit.MILLISECONDS); // exponential backoff (pow2 optimization)
                         } else if (removeChannelOnJoinFailure && removeCurrentChannel(name)) {
                             eventManager.publish(new ChannelJoinFailureEvent(name, ChannelJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
                         } else {

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -16,7 +16,7 @@ import com.github.twitch4j.chat.events.CommandEvent;
 import com.github.twitch4j.chat.events.IRCEventHandler;
 import com.github.twitch4j.chat.events.channel.ChannelMessageEvent;
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
-import com.github.twitch4j.chat.events.channel.ChannelRemovedPostJoinFailureEvent;
+import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.ChannelStateEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.chat.events.channel.UserStateEvent;
@@ -407,7 +407,7 @@ public class TwitchChat implements ITwitchChat {
                                 }
                             }, initialWait * (1L << (attempts + 1)), TimeUnit.MILLISECONDS); // exponential backoff (pow2 optimization)
                         } else if (removeChannelOnJoinFailure && removeCurrentChannel(name)) {
-                            eventManager.publish(new ChannelRemovedPostJoinFailureEvent(name, ChannelRemovedPostJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
+                            eventManager.publish(new ChannelJoinFailureEvent(name, ChannelJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
                         } else {
                             log.debug("Chat connection exhausted retries when attempting to join channel: {}", name);
                         }
@@ -430,8 +430,8 @@ public class TwitchChat implements ITwitchChat {
             String name = e.getChannel().getName();
             NoticeTag type = e.getType();
             if (removeChannelOnJoinFailure && banNotices.contains(type) && removeCurrentChannel(name)) {
-                ChannelRemovedPostJoinFailureEvent.Reason reason = type == NoticeTag.MSG_BANNED ? ChannelRemovedPostJoinFailureEvent.Reason.USER_BANNED : ChannelRemovedPostJoinFailureEvent.Reason.CHANNEL_SUSPENDED;
-                eventManager.publish(new ChannelRemovedPostJoinFailureEvent(name, reason));
+                ChannelJoinFailureEvent.Reason reason = type == NoticeTag.MSG_BANNED ? ChannelJoinFailureEvent.Reason.USER_BANNED : ChannelJoinFailureEvent.Reason.CHANNEL_SUSPENDED;
+                eventManager.publish(new ChannelJoinFailureEvent(name, reason));
             }
         });
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -209,7 +209,7 @@ public class TwitchChatBuilder {
      * Set to zero or a negative value to disable this feature.
      */
     @With
-    private int maxJoinRetries = 3;
+    private int maxJoinRetries = 7;
 
     /**
      * Initialize the builder

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -6,7 +6,7 @@ import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
-import com.github.twitch4j.chat.events.channel.ChannelRemovedPostJoinFailureEvent;
+import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.common.config.ProxyConfig;
@@ -199,7 +199,7 @@ public class TwitchChatBuilder {
     /**
      * Whether join failures should result in removal from current channels.
      *
-     * @see ChannelRemovedPostJoinFailureEvent
+     * @see ChannelJoinFailureEvent
      */
     @With
     private boolean removeChannelOnJoinFailure = false;

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -196,6 +196,13 @@ public class TwitchChatBuilder {
     private boolean enableMembershipEvents = true;
 
     /**
+     * The maximum number of retries to make for joining each channel, with exponential backoff.
+     * Set to zero or a negative value to disable this feature.
+     */
+    @With
+    private int maxJoinRetries = 3;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Chat Builder
@@ -244,7 +251,7 @@ public class TwitchChatBuilder {
             ircAuthBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.maxJoinRetries);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -212,6 +212,15 @@ public class TwitchChatBuilder {
     private int maxJoinRetries = 7;
 
     /**
+     * The amount of milliseconds to wait after queuing a JOIN before classifying the attempt as a failure.
+     * <p>
+     * If this value is configured too low, the chat instance could mistake a successfully joined channel for a failure.
+     * This can be especially problematic when removeChannelOnJoinFailure has been set to true.
+     */
+    @With
+    private long chatJoinTimeout = 2000L;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Chat Builder
@@ -260,7 +269,7 @@ public class TwitchChatBuilder {
             ircAuthBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -6,6 +6,7 @@ import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
+import com.github.twitch4j.chat.events.channel.ChannelRemovedPostJoinFailureEvent;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.common.config.ProxyConfig;
@@ -196,6 +197,14 @@ public class TwitchChatBuilder {
     private boolean enableMembershipEvents = true;
 
     /**
+     * Whether join failures should result in removal from current channels.
+     *
+     * @see ChannelRemovedPostJoinFailureEvent
+     */
+    @With
+    private boolean removeChannelOnJoinFailure = false;
+
+    /**
      * The maximum number of retries to make for joining each channel, with exponential backoff.
      * Set to zero or a negative value to disable this feature.
      */
@@ -251,7 +260,7 @@ public class TwitchChatBuilder {
             ircAuthBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.maxJoinRetries);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.chat;
 
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.chat.enums.NoticeTag;
+import com.github.twitch4j.chat.events.channel.ChannelRemovedPostJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
@@ -254,6 +255,9 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
                 .withAuthRateLimit(authRateLimit)
                 .withAutoJoinOwnChannel(false) // user will have to manually send a subscribe call to enable whispers. this avoids duplicating whisper events
         ).build();
+
+        // Reclaim channel headroom upon generic join failures
+        chat.getEventManager().onEvent(threadPrefix + "join-fail-tracker", ChannelRemovedPostJoinFailureEvent.class, e -> unsubscribe(e.getChannelName()));
 
         // Reclaim channel headroom upon a ban
         chat.getEventManager().onEvent(threadPrefix + "ban-tracker", ChannelNoticeEvent.class, e -> {

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -64,7 +64,10 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
      * Whether chat connections should automatically part from channels they have been banned from.
      * This is useful for reclaiming subscription headroom so a minimal number of chat instances are running.
      * By default false so that a chat instance can (eventually) reconnect if a unban occurs.
+     *
+     * @deprecated use removeChannelOnJoinFailure via advancedConfiguration instead.
      */
+    @Deprecated
     @Builder.Default
     protected final boolean automaticallyPartOnBan = false;
 

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -2,7 +2,7 @@ package com.github.twitch4j.chat;
 
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.chat.enums.NoticeTag;
-import com.github.twitch4j.chat.events.channel.ChannelRemovedPostJoinFailureEvent;
+import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
@@ -257,7 +257,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
         ).build();
 
         // Reclaim channel headroom upon generic join failures
-        chat.getEventManager().onEvent(threadPrefix + "join-fail-tracker", ChannelRemovedPostJoinFailureEvent.class, e -> unsubscribe(e.getChannelName()));
+        chat.getEventManager().onEvent(threadPrefix + "join-fail-tracker", ChannelJoinFailureEvent.class, e -> unsubscribe(e.getChannelName()));
 
         // Reclaim channel headroom upon a ban
         chat.getEventManager().onEvent(threadPrefix + "ban-tracker", ChannelNoticeEvent.class, e -> {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelJoinFailureEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelJoinFailureEvent.java
@@ -7,7 +7,7 @@ import lombok.Value;
  * resulting in removal from the instance's current channels.
  */
 @Value
-public class ChannelRemovedPostJoinFailureEvent {
+public class ChannelJoinFailureEvent {
 
     /**
      * The name of the channel that the chat instance was unable to join.

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelRemovedPostJoinFailureEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelRemovedPostJoinFailureEvent.java
@@ -1,0 +1,49 @@
+package com.github.twitch4j.chat.events.channel;
+
+import lombok.Value;
+
+/**
+ * A chat instance failed to join (or stay joined to) a channel AND removeChannelOnJoinFailure was enabled,
+ * resulting in removal from the instance's current channels.
+ */
+@Value
+public class ChannelRemovedPostJoinFailureEvent {
+
+    /**
+     * The name of the channel that the chat instance was unable to join.
+     */
+    String channelName;
+
+    /**
+     * The inferred reason for the join failure.
+     */
+    Reason reason;
+
+    // Note: NoticeTag.MSG_ROOM_NOT_FOUND is (unfortunately) never sent by twitch, so haven't bothered including logic for it
+    public enum Reason {
+
+        /**
+         * The chat instance was unable to join the channel, exhausting maxJoinRetries.
+         * Since removeChannelOnJoinFailure was enabled, the channel was removed.
+         * <p>
+         * This can occur when the channel simply does not exist or the user was already banned from the channel.
+         */
+        RETRIES_EXHAUSTED,
+
+        /**
+         * The chat user was banned from an initially successfully joined channel.
+         * <p>
+         * Twitch does not send this state upon initially joining a channel, if the user is already banned.
+         */
+        USER_BANNED,
+
+        /**
+         * The channel was suspended, so further chat messages cannot be received.
+         * <p>
+         * This can be sent upon initial join (if the channel was already suspended) or even after a successful initial join (the channel was not initially suspended).
+         */
+        CHANNEL_SUSPENDED
+
+    }
+
+}

--- a/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
@@ -2,7 +2,7 @@ package com.github.twitch4j.chat;
 
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
-import com.github.twitch4j.chat.events.channel.ChannelRemovedPostJoinFailureEvent;
+import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -84,7 +84,7 @@ public class ChatJoinRetryTest {
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // should see a ChannelRemovedPostJoinFailureEvent and entry should have expired
-        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelRemovedPostJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelRemovedPostJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
+        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
         Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after it expired");
         Assertions.assertFalse(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should be gone from currentChannels after retries have been exhausted");
 
@@ -139,7 +139,7 @@ public class ChatJoinRetryTest {
         Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the ban notice");
 
         // should have received an event about the removal of the channel
-        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelRemovedPostJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelRemovedPostJoinFailureEvent.Reason.USER_BANNED));
+        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.USER_BANNED));
         Assertions.assertFalse(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should be gone from currentChannels after the ban notice");
 
         // cleanup
@@ -166,7 +166,7 @@ public class ChatJoinRetryTest {
         Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the channel suspension notice");
 
         // should have received an event about the removal of the channel
-        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelRemovedPostJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelRemovedPostJoinFailureEvent.Reason.CHANNEL_SUSPENDED));
+        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.CHANNEL_SUSPENDED));
         Assertions.assertFalse(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should be gone from currentChannels after the channel suspension notice");
 
         // cleanup
@@ -193,7 +193,7 @@ public class ChatJoinRetryTest {
         Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the channel suspension notice");
 
         // should have received an event about the removal of the channel
-        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelRemovedPostJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelRemovedPostJoinFailureEvent.Reason.CHANNEL_SUSPENDED));
+        verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.CHANNEL_SUSPENDED));
         Assertions.assertFalse(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should be gone from currentChannels after the channel suspension notice");
 
         // cleanup

--- a/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import com.github.twitch4j.chat.util.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -55,6 +56,7 @@ public class ChatJoinRetryTest {
         // join channel and wait for the command to be processed
         twitchChat.joinChannel(FAKE_CHANNEL_NAME);
         verify(twitchChat, timeout(1_000)).issueJoin(FAKE_CHANNEL_NAME, 0);
+        TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
@@ -79,6 +81,7 @@ public class ChatJoinRetryTest {
         // join channel and wait for the command to be processed
         twitchChat.joinChannel(FAKE_CHANNEL_NAME);
         verify(twitchChat, timeout(1_000)).issueJoin(FAKE_CHANNEL_NAME, 0);
+        TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
@@ -101,6 +104,7 @@ public class ChatJoinRetryTest {
         // join channel and wait for the command to be processed
         twitchChat.joinChannel(FAKE_CHANNEL_NAME);
         verify(twitchChat, timeout(1_000)).issueJoin(FAKE_CHANNEL_NAME, 0);
+        TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
@@ -128,6 +132,7 @@ public class ChatJoinRetryTest {
         // join channel and wait for the command to be processed
         twitchChat.joinChannel(FAKE_CHANNEL_NAME);
         verify(twitchChat, timeout(1_000)).issueJoin(FAKE_CHANNEL_NAME, 0);
+        TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
@@ -155,6 +160,7 @@ public class ChatJoinRetryTest {
         // join channel and wait for the command to be processed
         twitchChat.joinChannel(FAKE_CHANNEL_NAME);
         verify(twitchChat, timeout(1_000)).issueJoin(FAKE_CHANNEL_NAME, 0);
+        TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
@@ -182,6 +188,7 @@ public class ChatJoinRetryTest {
         // join channel and wait for the command to be processed
         twitchChat.joinChannel(FAKE_CHANNEL_NAME);
         verify(twitchChat, timeout(1_000)).issueJoin(FAKE_CHANNEL_NAME, 0);
+        TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
         Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");

--- a/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
@@ -23,9 +23,6 @@ public class ChatJoinRetryTest {
     private static final String FAKE_CHANNEL_NAME = "twitch4jtestchannelthatisnotreall"; // should exceed the max account length to make sure no such account can be created
 
     private static TwitchChat getChatInstance(int maxRetries, boolean removeChannelOnJoinFailure) {
-        // helper property to reduce the duration of test executions
-        TwitchChat.initialWaitOverwrite = 100;
-
         // spy on EventManager
         EventManager eventManager = new EventManager();
         eventManager.autoDiscovery();
@@ -37,6 +34,7 @@ public class ChatJoinRetryTest {
                 .withEventManager(Mockito.spy(eventManager))
                 .withRemoveChannelOnJoinFailure(removeChannelOnJoinFailure)
                 .withMaxJoinRetries(maxRetries)
+                .withChatJoinTimeout(100L) // reduce the duration of test executions
                 .build()
         );
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -196,6 +196,13 @@ public class TwitchClientBuilder {
     private long chatQueueTimeout = 1000L;
 
     /**
+     * The maximum number of retries to make for joining each channel, with exponential backoff.
+     * Set to zero or a negative value to disable this feature.
+     */
+    @With
+    private int chatMaxJoinRetries = 3;
+
+    /**
      * Sets the default server used for chat
      * <p>
      * Defaults to TwitchChat.TWITCH_WEB_SOCKET_SERVER, you can use TwitchChat.FDGT_TEST_SOCKET_SERVER for testing
@@ -396,6 +403,7 @@ public class TwitchClientBuilder {
                 .withCommandTriggers(commandPrefixes)
                 .withProxyConfig(proxyConfig)
                 .setBotOwnerIds(botOwnerIds)
+                .withMaxJoinRetries(chatMaxJoinRetries)
                 .build();
         }
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -200,7 +200,7 @@ public class TwitchClientBuilder {
      * Set to zero or a negative value to disable this feature.
      */
     @With
-    private int chatMaxJoinRetries = 3;
+    private int chatMaxJoinRetries = 7;
 
     /**
      * Sets the default server used for chat

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -217,6 +217,13 @@ public class TwitchClientPoolBuilder {
     private long chatQueueTimeout = 1000L;
 
     /**
+     * The maximum number of retries to make for joining each channel, with exponential backoff.
+     * Set to zero or a negative value to disable this feature.
+     */
+    @With
+    private int chatMaxJoinRetries = 3;
+
+    /**
      * Sets the default server used for chat
      * <p>
      * Defaults to TwitchChat.TWITCH_WEB_SOCKET_SERVER, you can use TwitchChat.FDGT_TEST_SOCKET_SERVER for testing
@@ -418,6 +425,7 @@ public class TwitchClientPoolBuilder {
                         .withChatQueueSize(chatQueueSize)
                         .withBaseUrl(chatServer)
                         .withChatQueueTimeout(chatQueueTimeout)
+                        .withMaxJoinRetries(chatMaxJoinRetries)
                         .withCommandTriggers(commandPrefixes)
                         .setBotOwnerIds(botOwnerIds)
                 )
@@ -437,6 +445,7 @@ public class TwitchClientPoolBuilder {
                 .withChatQueueTimeout(chatQueueTimeout)
                 .withCommandTriggers(commandPrefixes)
                 .withProxyConfig(proxyConfig)
+                .withMaxJoinRetries(chatMaxJoinRetries)
                 .setBotOwnerIds(botOwnerIds)
                 .build();
         }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -221,7 +221,7 @@ public class TwitchClientPoolBuilder {
      * Set to zero or a negative value to disable this feature.
      */
     @With
-    private int chatMaxJoinRetries = 3;
+    private int chatMaxJoinRetries = 7;
 
     /**
      * Sets the default server used for chat


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Should help with phantom joined channels

### Changes Proposed
* On initial join attempt, put channel name in `joinAttemptsByChannelName`
* On successful join, remove channel name from `joinAttemptsByChannelName`
* If entry expires from `joinAttemptsByChannelName`, the join failed. Try again with exponential backoff (if maximum retries has not been reached)

* Add `removeChannelOnJoinFailure` option to `TwitchChat(Builder)`. Upon such a removal, fire `ChannelRemovedPostJoinFailureEvent`
* Add `maxJoinRetries` to builders

### Additional Information
https://github.com/ben-manes/caffeine/wiki/Removal
