### PR TITLE
feat: add the new_subscription creator goals type

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
@@ -15,8 +15,16 @@ public enum GoalType {
 
     /**
      * The goal is to increase subscriptions.
+     * This type shows the net increase or decrease in subscriptions.
      */
     @JsonAlias("subscription")
-    SUBSCRIPTIONS
+    SUBSCRIPTIONS,
+
+    /**
+     * The goal is to increase subscriptions.
+     * This type shows only the net increase in subscriptions (it does not account for users that stopped subscribing since the goal's inception).
+     */
+    @JsonAlias("new_subscription")
+    NEW_SUBSCRIPTIONS
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatorGoal.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatorGoal.java
@@ -19,7 +19,8 @@ public class CreatorGoal {
 
     public enum Type {
         FOLLOWERS,
-        SUB_POINTS
+        SUB_POINTS,
+        NEW_SUB_POINTS
     }
 
     public enum State {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add the `new_subscription` creator goals type to helix/eventsub (in unofficial pubsub it's called `NEW_SUB_POINTS`)

### Additional Information
https://dev.twitch.tv/docs/change-log
