### PR TITLE
feat: add broadcaster login to ChannelInformation

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
@@ -21,6 +21,11 @@ public class ChannelInformation {
     private String broadcasterId;
 
     /**
+     * Twitch User Login Name of this channel owner
+     */
+    private String broadcasterLogin;
+
+    /**
      * Twitch User Display Name of this channel owner
      */
     private String broadcasterName;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/551

### Changes Proposed

* Add `ChannelInformation#getBroadcasterLogin`

### Additional Information
https://dev.twitch.tv/docs/api/reference#get-channel-information (in example response but not documented return values)
