### PR TITLE
feat: support user intro chat experiment

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -218,6 +218,11 @@ public class TwitchChatBuilder {
         // Initialize/Check EventManager
         eventManager = EventManagerUtils.validateOrInitializeEventManager(eventManager, defaultEventHandler);
 
+        // Initialize/Check CredentialManager
+        if (credentialManager == null) {
+            credentialManager = CredentialManagerBuilder.builder().build();
+        }
+
         // Register rate limits across the user id contained within the chat token
         final String userId;
         if (chatAccount == null) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -77,7 +77,6 @@ public class IRCEventHandler {
         eventManager.onEvent("twitch4j-chat-raid-trigger", IRCMessageEvent.class, this::onRaid);
         eventManager.onEvent("twitch4j-chat-unraid-trigger", IRCMessageEvent.class, this::onUnraid);
         eventManager.onEvent("twitch4j-chat-rewardgift-trigger", IRCMessageEvent.class, this::onRewardGift);
-        eventManager.onEvent("twitch4j-chat-ritual-trigger", IRCMessageEvent.class, this::onRitual);
         eventManager.onEvent("twitch4j-chat-delete-trigger", IRCMessageEvent.class, this::onMessageDeleteResponse);
         eventManager.onEvent("twitch4j-chat-userstate-trigger", IRCMessageEvent.class, this::onUserState);
         eventManager.onEvent("twitch4j-chat-globaluserstate-trigger", IRCMessageEvent.class, this::onGlobalUserState);
@@ -379,7 +378,10 @@ public class IRCEventHandler {
      * ChatChannel Ritual Event Parser: celebration of a shared viewer milestone
      *
      * @param event the {@link IRCMessageEvent} to be checked
+     * @see <a href="https://twitter.com/TwitchSupport/status/1481008324502073347">Shut down announcement</a>
+     * @deprecated no longer sent by twitch.
      */
+    @Deprecated
     public void onRitual(IRCMessageEvent event) {
         if ("USERNOTICE".equals(event.getCommandType()) && "ritual".equalsIgnoreCase(event.getTags().get("msg-id"))) {
             // Load Info

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -21,7 +21,6 @@ import java.util.Set;
  * This event gets called when a message is received in a channel.
  */
 @Value
-@Getter
 @EqualsAndHashCode(callSuper = false)
 public class ChannelMessageEvent extends AbstractChannelEvent implements ReplyableEvent {
 
@@ -128,6 +127,16 @@ public class ChannelMessageEvent extends AbstractChannelEvent implements Replyab
     @Unofficial
     public boolean isDesignatedFirstMessage() {
         return "1".equals(getMessageEvent().getTags().get("first-msg"));
+    }
+
+    /**
+     * @return whether this message constitutes the user's designated introduction.
+     * @apiNote This method is unofficial since the experiment is not officially documented in the irc guide.
+     * @see <a href="https://twitter.com/TwitchSupport/status/1481008097749573641">Twitch Announcement</a>
+     */
+    @Unofficial
+    public boolean isUserIntroduction() {
+        return "user-intro".equals(getMessageEvent().getTags().get("msg-id"));
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelStateEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelStateEvent.java
@@ -22,9 +22,10 @@ public class ChannelStateEvent extends AbstractChannelEvent {
         FOLLOWERS,
         R9K,
         @Unofficial
+        @Deprecated
         RITUALS,
         SLOW,
-        SUBSCRIBERS;
+        SUBSCRIBERS
     }
 
     private final Map<ChannelState, Object> states;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/RitualEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/RitualEvent.java
@@ -12,10 +12,14 @@ import lombok.Value;
  * <p>
  * Many channels have special rituals to celebrate viewer milestones when they are shared.
  * The rituals notice extends the sharing of these messages to other viewer milestones  (initially, a new viewer chatting for the first time).
+ *
+ * @see <a href="https://twitter.com/TwitchSupport/status/1481008324502073347">Shut down announcement</a>
+ * @deprecated no longer sent by twitch.
  */
 @Value
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
 public class RitualEvent extends AbstractChannelEvent {
     /**
      * The user involved in the ritual.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ChannelMessageEvent#isUserIntroduction`
* Deprecate `ChannelStateEvent#RITUALS`
* Deprecate `RitualEvent`
* No longer call `IRCEventHandler#onRitual` (since rituals are shut down, parsing for them is wasted computation)
* Ensure `TwitchChatBuilder.credentialManager` is not null (unrelated fix)

### Additional Information
https://twitter.com/TwitchSupport/status/1481008097749573641
https://twitter.com/TwitchSupport/status/1481008324502073347
