### PR TITLE
feat: add pubsub leaderboard time unit and video playback type

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -246,6 +246,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForChannelBitsLeaderboardAllTimeEvents(OAuth2Credential credential, String channelId) {
+        return listenForChannelBitsLeaderboardEvents(credential, channelId, "ALLTIME");
+    }
+
+    @Unofficial
     default PubSubSubscription listenForChannelBitsLeaderboardEvents(OAuth2Credential credential, String channelId, String timeAggregationUnit) {
         return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.bits-usage-by-channel-v1-" + channelId + "-" + timeAggregationUnit);
     }
@@ -267,6 +272,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForChannelSubLeaderboardAllTimeEvents(OAuth2Credential credential, String channelId) {
+        return listenForChannelSubLeaderboardEvents(credential, channelId, "ALLTIME");
+    }
+
+    @Unofficial
     default PubSubSubscription listenForChannelSubLeaderboardEvents(OAuth2Credential credential, String channelId, String timeAggregationUnit) {
         return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.sub-gifts-sent-" + channelId + "-" + timeAggregationUnit);
     }
@@ -279,6 +289,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     @Unofficial
     default PubSubSubscription listenForLeaderboardMonthlyEvents(OAuth2Credential credential, String channelId) {
         return listenForLeaderboardEvents(credential, channelId, "MONTH");
+    }
+
+    @Unofficial
+    default PubSubSubscription listenForLeaderboardAllTimeEvents(OAuth2Credential credential, String channelId) {
+        return listenForLeaderboardEvents(credential,  channelId, "ALLTIME");
     }
 
     @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -36,7 +36,8 @@ public class VideoPlaybackData {
         COMMERCIAL("commercial"),
         STREAM_DOWN("stream-down"),
         STREAM_UP("stream-up"),
-        VIEW_COUNT("viewcount");
+        VIEW_COUNT("viewcount"),
+        TOS_STRIKE("tos-strike");
 
         private final String type;
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ALLTIME` as a possible `timeAggregateUnit` for leaderboard (unofficial) pubsub
* Add tos strike as a possible video playback event type
