### PR TITLE
feat: add unofficial chatrooms user pubsub topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -406,7 +406,6 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
-    @Deprecated
     default PubSubSubscription listenForUserChatroomEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "chatrooms-user-v1." + userId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -539,6 +539,23 @@ public class TwitchPubSub implements ITwitchPubSub {
                                         log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
                                         break;
                                 }
+                            } else if ("chatrooms-user-v1".equals(topicName) && topicParts.length > 1) {
+                                final String userId = topicParts[1];
+                                switch (type) {
+                                    case "channel_banned_alias_restriction_update":
+                                        final AliasRestrictionUpdateData aliasData = TypeConvert.convertValue(msgData, AliasRestrictionUpdateData.class);
+                                        eventManager.publish(new AliasRestrictionUpdateEvent(userId, aliasData));
+                                        break;
+
+                                    case "user_moderation_action":
+                                        final UserModerationActionData actionData = TypeConvert.convertValue(msgData, UserModerationActionData.class);
+                                        eventManager.publish(new UserModerationActionEvent(userId, actionData));
+                                        break;
+
+                                    default:
+                                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                                        break;
+                                }
                             } else if ("following".equals(topicName) && topicParts.length > 1) {
                                 final FollowingData data = TypeConvert.jsonToObject(rawMessage, FollowingData.class);
                                 eventManager.publish(new FollowingEvent(lastTopicIdentifier, data));

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AliasRestrictionUpdateData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AliasRestrictionUpdateData.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Unofficial
+public class AliasRestrictionUpdateData {
+
+    @Accessors(fluent = true)
+    @JsonProperty("user_is_restricted")
+    private Boolean isRestricted;
+
+    @JsonAlias("ChannelID")
+    private String channelId;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UserModerationActionData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UserModerationActionData.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Unofficial
+public class UserModerationActionData {
+
+    private String action;
+    private String targetId;
+    private String channelId;
+
+    public boolean isBan() {
+        return "ban".equals(action);
+    }
+
+    public boolean isUnban() {
+        return "unban".equals(action);
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -31,6 +31,11 @@ public class VideoPlaybackData {
      */
     private Integer length;
 
+    /**
+     * Sent when {@link #getType()} is {@link Type#COMMERCIAL}.
+     */
+    private Boolean scheduled;
+
     @RequiredArgsConstructor
     public enum Type {
         COMMERCIAL("commercial"),

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/AliasRestrictionUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/AliasRestrictionUpdateEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.AliasRestrictionUpdateData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class AliasRestrictionUpdateEvent extends TwitchEvent {
+    String userId;
+    AliasRestrictionUpdateData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserModerationActionEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserModerationActionEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.UserModerationActionData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UserModerationActionEvent extends TwitchEvent {
+    String userId;
+    UserModerationActionData data;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement `chatrooms-user-v1.<user-id>` unofficial pubsub topic to track user bans/unbans
* Add `scheduled` flag to `VideoPlaybackData` (unrelated)

### Additional Information
With irc changes, this is the only way to get real-time channel ban/unban events for an individual user
