### PR TITLE
fix: ensure gql builder event manager has default handler

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/EventManagerUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/EventManagerUtils.java
@@ -7,28 +7,23 @@ public class EventManagerUtils {
     /**
      * Validates the provided EventManager or initializes a new one
      *
-     * @param eventManager EventManager
+     * @param eventManager        EventManager
      * @param defaultEventHandler The default eventHandler class
      * @return EventManager
      */
-    public static EventManager validateOrInitializeEventManager(EventManager eventManager, @SuppressWarnings("rawtypes") Class defaultEventHandler) {
-        if (eventManager == null) {
-            EventManager newEM = initializeEventManager(defaultEventHandler);
-            validateEventManager(newEM);
-            return newEM;
-        } else {
-            validateEventManager(eventManager);
-            return eventManager;
-        }
+    public static EventManager validateOrInitializeEventManager(EventManager eventManager, Class<?> defaultEventHandler) {
+        EventManager em = eventManager != null ? eventManager : initializeEventManager(defaultEventHandler);
+        validateEventManager(em);
+        return em;
     }
 
     /**
-     *  Initializes a new EventManager instance.
+     * Initializes a new EventManager instance.
      *
      * @param defaultEventHandler The default eventHandler class
      * @return EventManager
      */
-    public static EventManager initializeEventManager(@SuppressWarnings("rawtypes") Class defaultEventHandler) {
+    public static EventManager initializeEventManager(Class<?> defaultEventHandler) {
         EventManager eventManager = new EventManager();
 
         eventManager.autoDiscovery();

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQLBuilder.java
@@ -27,7 +27,7 @@ public class TwitchGraphQLBuilder {
      * Event Manager
      */
     @With
-    private EventManager eventManager = new EventManager();
+    private EventManager eventManager = null;
 
     /**
      * EventManager


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Avoid runtime exception from validateEventManager when directly using `TwitchGraphQLBuilder`

### Changes Proposed
* Set default event manager as null so it can properly be created by `validateOrInitializeEventManager`
* minor cleanup in EventManagerUtils
