### PR TITLE
fix: make commandPrefixes non-final in builders

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -279,13 +279,13 @@ public class TwitchChat implements ITwitchChat {
      * @param maxJoinRetries                 Maximum join retries per channel
      * @param chatJoinTimeout                Minimum milliseconds to wait after a join attempt
      */
-    public TwitchChat(EventManager eventManager, CredentialManager credentialManager, OAuth2Credential chatCredential, String baseUrl, boolean sendCredentialToThirdPartyHost, List<String> commandPrefixes, Integer chatQueueSize, Bucket ircMessageBucket, Bucket ircWhisperBucket, Bucket ircJoinBucket, Bucket ircAuthBucket, ScheduledThreadPoolExecutor taskExecutor, long chatQueueTimeout, ProxyConfig proxyConfig, boolean autoJoinOwnChannel, boolean enableMembershipEvents, Collection<String> botOwnerIds, boolean removeChannelOnJoinFailure, int maxJoinRetries, long chatJoinTimeout) {
+    public TwitchChat(EventManager eventManager, CredentialManager credentialManager, OAuth2Credential chatCredential, String baseUrl, boolean sendCredentialToThirdPartyHost, Collection<String> commandPrefixes, Integer chatQueueSize, Bucket ircMessageBucket, Bucket ircWhisperBucket, Bucket ircJoinBucket, Bucket ircAuthBucket, ScheduledThreadPoolExecutor taskExecutor, long chatQueueTimeout, ProxyConfig proxyConfig, boolean autoJoinOwnChannel, boolean enableMembershipEvents, Collection<String> botOwnerIds, boolean removeChannelOnJoinFailure, int maxJoinRetries, long chatJoinTimeout) {
         this.eventManager = eventManager;
         this.credentialManager = credentialManager;
         this.chatCredential = chatCredential;
         this.baseUrl = baseUrl;
         this.sendCredentialToThirdPartyHost = sendCredentialToThirdPartyHost;
-        this.commandPrefixes = commandPrefixes;
+        this.commandPrefixes = new ArrayList<>(commandPrefixes);
         this.botOwnerIds = botOwnerIds;
         this.ircCommandQueue = new ArrayBlockingQueue<>(chatQueueSize, true);
         this.ircMessageBucket = ircMessageBucket;

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -23,12 +23,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 /**
@@ -110,7 +109,9 @@ public class TwitchChatBuilder {
     /**
      * IRC Command Handlers
      */
-    protected final List<String> commandPrefixes = new ArrayList<>();
+    @Setter
+    @Accessors(chain = true)
+    protected Set<String> commandPrefixes = new HashSet<>();
 
     /**
      * Size of the ChatQueue

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -124,7 +124,7 @@ public class TwitchClientBuilder {
     /**
      * IRC Command Handlers
      */
-    protected final Set<String> commandPrefixes = new HashSet<>();
+    protected Set<String> commandPrefixes = new HashSet<>();
 
     /**
      * Enabled: PubSub
@@ -412,10 +412,10 @@ public class TwitchClientBuilder {
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)
-                .withCommandTriggers(commandPrefixes)
                 .withProxyConfig(proxyConfig)
-                .setBotOwnerIds(botOwnerIds)
                 .withMaxJoinRetries(chatMaxJoinRetries)
+                .setBotOwnerIds(botOwnerIds)
+                .setCommandPrefixes(commandPrefixes)
                 .build();
         }
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -139,7 +139,7 @@ public class TwitchClientPoolBuilder {
     /**
      * IRC Command Handlers
      */
-    protected final Set<String> commandPrefixes = new HashSet<>();
+    protected Set<String> commandPrefixes = new HashSet<>();
 
     /**
      * Enabled: PubSub
@@ -438,7 +438,7 @@ public class TwitchClientPoolBuilder {
                         .withBaseUrl(chatServer)
                         .withChatQueueTimeout(chatQueueTimeout)
                         .withMaxJoinRetries(chatMaxJoinRetries)
-                        .withCommandTriggers(commandPrefixes)
+                        .setCommandPrefixes(commandPrefixes)
                         .setBotOwnerIds(botOwnerIds)
                 )
                 .build();
@@ -455,10 +455,10 @@ public class TwitchClientPoolBuilder {
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)
-                .withCommandTriggers(commandPrefixes)
                 .withProxyConfig(proxyConfig)
                 .withMaxJoinRetries(chatMaxJoinRetries)
                 .setBotOwnerIds(botOwnerIds)
+                .setCommandPrefixes(commandPrefixes)
                 .build();
         }
 

--- a/twitch4j/src/test/java/com/github/twitch4j/TwitchClientTest.java
+++ b/twitch4j/src/test/java/com/github/twitch4j/TwitchClientTest.java
@@ -9,8 +9,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -32,6 +34,19 @@ public class TwitchClientTest {
             .withEnableKraken(true)
             .withEnableChat(false)
             .build();
+    }
+
+    @Test
+    @DisplayName("Ensure builder calls don't reset command triggers")
+    public void buildCommandPrefix() {
+        TwitchClientBuilder b1 = TwitchClientBuilder.builder().withEnableChat(true);
+        assertTrue(b1.getCommandPrefixes().isEmpty());
+
+        TwitchClientBuilder b2 = b1.withCommandTrigger("!");
+        assertEquals(1, b2.getCommandPrefixes().size());
+
+        TwitchClientBuilder b3 = b2.withEnablePubSub(true);
+        assertEquals(1, b3.getCommandPrefixes().size());
     }
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
Since `commandPrefixes` as marked as final, it was not included in `@AllArgsConstructor`. As a result, `@With` calls were not copying this field to new instances. Thus, after calling `withCommandTrigger`, other builder `withX` calls would result in `commandPrefixes` being reset to an empty collection.

### Changes Proposed
* Make `commandPrefixes` non-final (so it is added to the builder private constructor)
* Make `commandPrefixes` a `Set` in `TwitchChatBuilder` to avoid dupes (in `TwitchChat` it is stored as a `List` for faster iteration)
* Use `setCommandPrefixes` to reduce collection operations (e.g. `addAll`)

### Additional Information
Thanks to `Hiya#3921` for reporting
