### PR TITLE
fix: remove control character suffix in action event message

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -92,14 +92,15 @@ public class IRCEventHandler {
                 // Load Info
                 EventChannel channel = event.getChannel();
                 EventUser user = event.getUser();
+                String message = event.getMessage().get();
 
                 // Dispatch Event
-                if(event.getMessage().get().startsWith("\u0001ACTION ")) {
+                if (message.startsWith("\u0001ACTION ") && message.endsWith("\u0001")) {
                     // Action
-                    eventManager.publish(new ChannelMessageActionEvent(channel, event, user, event.getMessage().get().substring(8), event.getClientPermissions()));
+                    eventManager.publish(new ChannelMessageActionEvent(channel, event, user, message.substring(8, message.length() - 1), event.getClientPermissions()));
                 } else {
                     // Regular Message
-                    eventManager.publish(new ChannelMessageEvent(channel, event, user, event.getMessage().get(), event.getClientPermissions()));
+                    eventManager.publish(new ChannelMessageEvent(channel, event, user, message, event.getClientPermissions()));
                 }
             }
         }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -70,10 +70,13 @@ public class ChannelMessageEvent extends AbstractChannelEvent implements Replyab
 
     /**
      * Information regarding any associated Crowd Chant for this message, if applicable.
+     *
+     * @deprecated <a href="https://twitter.com/TwitchSupport/status/1486036628523073539">Will be disabled on 2022-02-02</a>
      */
     @Nullable
     @Unofficial
     @Getter(lazy = true)
+    @Deprecated
     ChatCrowdChant chantInfo = ChatCrowdChant.parse(getMessageEvent());
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/util/ChatCrowdChant.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/ChatCrowdChant.java
@@ -18,9 +18,11 @@ import static com.github.twitch4j.chat.events.channel.IRCMessageEvent.NONCE_TAG_
  * Information regarding a Crowd Chant participation or initiation.
  *
  * @see <a href="https://twitch.uservoice.com/forums/310201-chat/suggestions/43451310--test-crowd-chant">Related Uservoice</a>
+ * @deprecated <a href="https://twitter.com/TwitchSupport/status/1486036628523073539">Will be disabled on 2022-02-02</a>
  */
 @Value
 @Unofficial
+@Deprecated
 public class ChatCrowdChant {
 
     public static final String CHANT_MSG_ID_TAG_NAME = "crowd-chant-parent-msg-id";
@@ -51,8 +53,10 @@ public class ChatCrowdChant {
      * Sends the same message in the same channel to participate in the Crowd Chant, with the proper chat tag.
      *
      * @param chat an authenticated TwitchChat instance.
+     * @deprecated <a href="https://twitter.com/TwitchSupport/status/1486036628523073539">Will be disabled on 2022-02-02</a>
      */
     @Unofficial
+    @Deprecated
     public void participate(ITwitchChat chat) {
         Map<String, Object> tags = new LinkedHashMap<>();
         tags.put(NONCE_TAG_NAME, CryptoUtils.generateNonce(32));


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove `\u0001` suffix on action event messages
* Deprecate `CrowdChantInfo` (unrelated)
