### PR TITLE
chore: bump mockito to 4.3.1 and switch to the bom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,8 +138,7 @@ subprojects {
 		testImplementation(platform("org.junit:junit-bom:5.8.2"))
 		testImplementation(group = "org.junit.jupiter", name = "junit-jupiter")
 		// - Mocking
-		testImplementation(group = "org.mockito", name = "mockito-core", version = "4.2.0")
-		testImplementation(group = "org.mockito", name = "mockito-junit-jupiter", version = "4.2.0")
+		testImplementation(platform("org.mockito:mockito-bom:4.3.1"))
 		// - Await
 		testImplementation(group = "org.awaitility", name = "awaitility", version = "4.1.1")
 		// - Logging

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -12,6 +12,10 @@ dependencies {
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))
 	api(project(":twitch4j-auth"))
+
+	// Mocking
+	testImplementation(group = "org.mockito", name = "mockito-core")
+	testImplementation(group = "org.mockito", name = "mockito-junit-jupiter")
 }
 
 tasks.javadoc {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
With this change, dependabot should only make one PR for each mockito version bump

### Changes Proposed
* Switch to using new mockito bom format
* Bump mockito to 4.3.1

### Additional Information
Closes #520 and #521
