### PR TITLE
docs: update soundtrack api javadoc by twitch revision

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -586,7 +586,7 @@ public interface TwitchHelix {
      * Gets channel information for users
      *
      * @param authToken Auth Token
-     * @param broadcasterIds IDs of the channels to be retrieved
+     * @param broadcasterIds IDs of the channels to be retrieved (up to 100)
      * @return ChannelInformationList
      */
     @RequestLine("GET /channels?broadcaster_id={broadcaster_id}")
@@ -637,6 +637,8 @@ public interface TwitchHelix {
 
     /**
      * Gets the Soundtrack track that the broadcaster is playing.
+     * <p>
+     * If the broadcaster is not playing a track, the endpoint returns HTTP status code 404 Not Found.
      *
      * @param authToken     App access token or User access token.
      * @param broadcasterId The ID of the broadcaster that’s playing a Soundtrack track.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackArtist.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackArtist.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.helix.domain;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
-import org.jetbrains.annotations.Nullable;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -11,9 +10,8 @@ public class SoundtrackArtist {
 
     /**
      * The ID of the Twitch user that created the track.
-     * Is null if a Twitch user didn't create the track.
+     * Is an empty string if a Twitch user didn't create the track.
      */
-    @Nullable
     private String creatorChannelId;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
@@ -13,12 +13,11 @@ public class SoundtrackCurrentTrackWrapper {
 
     /**
      * A list that contains the Soundtrack track that the broadcaster is playing.
-     * The list is empty if the broadcaster is not playing a track.
      */
     private List<SoundtrackCurrentTrack> data;
 
     /**
-     * @return the Soundtrack track that the broadcaster is playing or empty if the broadcaster is not playing a track.
+     * @return the Soundtrack track that the broadcaster is playing.
      */
     public Optional<SoundtrackCurrentTrack> getTrack() {
         if (data == null || data.isEmpty())


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Explicitly document max ids that can be passed in a single `getChannelInformation` call
* Clarify soundtrack api behavior when no track is playing

### Additional Information
2022-02-08 update @ https://dev.twitch.tv/docs/change-log
