### PR TITLE
fix: add more status enums for pubsub polls

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import lombok.Data;
 
 import java.time.Instant;
@@ -76,6 +77,10 @@ public class PollData {
     public enum Status {
         ACTIVE,
         COMPLETED,
-        ARCHIVED
+        ARCHIVED,
+        TERMINATED,
+        MODERATED,
+        @JsonEnumDefaultValue
+        INVALID
     }
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
`java.lang.IllegalArgumentException: Cannot deserialize value of type 'com.github.twitch4j.pubsub.domain.PollData$Status' from String "TERMINATED": not one of the values accepted for Enum class: [ARCHIVED, COMPLETED, ACTIVE]`

### Changes Proposed
* Add more states to `PollData.Status` (unofficial pubsub)

### Additional Information
Thanks to `applesaph` for reporting
