### PR TITLE
fix: enable ws rfc ping for chat and pubsub

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -222,6 +222,12 @@ public class TwitchChatBuilder {
     private long chatJoinTimeout = 2000L;
 
     /**
+     * WebSocket RFC Ping Period in ms (0 = disabled)
+     */
+    @With
+    private int wsPingPeriod = 15_000;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch Chat Builder
@@ -275,7 +281,7 @@ public class TwitchChatBuilder {
             ircAuthBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout);
+        return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -95,6 +95,12 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
     @Builder.Default
     protected Bandwidth authRateLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
+    /**
+     * WebSocket RFC Ping Period in ms (0 = disabled)
+     */
+    @Builder.Default
+    protected int wsPingPeriod = 15_000;
+
     @Override
     public boolean sendMessage(String channel, String message, @Nullable Map<String, Object> tags) {
         return this.sendMessage(channel, channel, message, tags);
@@ -257,6 +263,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
                 .withJoinRateLimit(joinRateLimit)
                 .withAuthRateLimit(authRateLimit)
                 .withAutoJoinOwnChannel(false) // user will have to manually send a subscribe call to enable whispers. this avoids duplicating whisper events
+                .withWsPingPeriod(wsPingPeriod)
         ).build();
 
         // Reclaim channel headroom upon generic join failures

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -95,12 +95,6 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
     @Builder.Default
     protected Bandwidth authRateLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
-    /**
-     * WebSocket RFC Ping Period in ms (0 = disabled)
-     */
-    @Builder.Default
-    protected int wsPingPeriod = 15_000;
-
     @Override
     public boolean sendMessage(String channel, String message, @Nullable Map<String, Object> tags) {
         return this.sendMessage(channel, channel, message, tags);
@@ -263,7 +257,6 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
                 .withJoinRateLimit(joinRateLimit)
                 .withAuthRateLimit(authRateLimit)
                 .withAutoJoinOwnChannel(false) // user will have to manually send a subscribe call to enable whispers. this avoids duplicating whisper events
-                .withWsPingPeriod(wsPingPeriod)
         ).build();
 
         // Reclaim channel headroom upon generic join failures

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -140,6 +140,11 @@ public class TwitchPubSub implements ITwitchPubSub {
     private final Collection<String> botOwnerIds;
 
     /**
+     * WebSocket RFC Ping Period in ms (0 = disabled)
+     */
+    private final int wsPingPeriod;
+
+    /**
      * WebSocket Factory
      */
     protected final WebSocketFactory webSocketFactory;
@@ -177,11 +182,14 @@ public class TwitchPubSub implements ITwitchPubSub {
      * @param taskExecutor ScheduledThreadPoolExecutor
      * @param proxyConfig  ProxyConfig
      * @param botOwnerIds  Bot Owner IDs
+     * @param wsPingPeriod WebSocket Ping Period
      */
-    public TwitchPubSub(EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds) {
+    public TwitchPubSub(EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds, int wsPingPeriod) {
+        this.eventManager = eventManager;
         this.taskExecutor = taskExecutor;
         this.botOwnerIds = botOwnerIds;
-        this.eventManager = eventManager;
+        this.wsPingPeriod = wsPingPeriod;
+
         // register with serviceMediator
         this.eventManager.getServiceMediator().addService("twitch4j-pubsub", this);
 
@@ -339,6 +347,7 @@ public class TwitchPubSub implements ITwitchPubSub {
         try {
             // WebSocket
             this.webSocket = webSocketFactory.createSocket(WEB_SOCKET_SERVER);
+            this.webSocket.setPingInterval(wsPingPeriod);
 
             // WebSocket Listeners
             this.webSocket.clearListeners();

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -56,6 +56,12 @@ public class TwitchPubSubBuilder {
     private Collection<String> botOwnerIds = new HashSet<>();
 
     /**
+     * WebSocket RFC Ping Period in ms (0 = disabled)
+     */
+    @With
+    private int wsPingPeriod = 15_000;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch PubSub Builder
@@ -77,7 +83,7 @@ public class TwitchPubSubBuilder {
         // Initialize/Check EventManager
         eventManager = EventManagerUtils.validateOrInitializeEventManager(eventManager, defaultEventHandler);
 
-        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds);
+        return new TwitchPubSub(this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds, this.wsPingPeriod);
     }
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -264,6 +264,12 @@ public class TwitchClientBuilder {
     private Logger.Level feignLogLevel = Logger.Level.NONE;
 
     /**
+     * WebSocket RFC Ping Period in ms (0 = disabled)
+     */
+    @With
+    private int wsPingPeriod = 15_000;
+
+    /**
      * With a Bot Owner's User ID
      *
      * @param userId the user id
@@ -416,6 +422,7 @@ public class TwitchClientBuilder {
                 .withMaxJoinRetries(chatMaxJoinRetries)
                 .setBotOwnerIds(botOwnerIds)
                 .setCommandPrefixes(commandPrefixes)
+                .withWsPingPeriod(wsPingPeriod)
                 .build();
         }
 
@@ -427,6 +434,7 @@ public class TwitchClientBuilder {
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withProxyConfig(proxyConfig)
                 .setBotOwnerIds(botOwnerIds)
+                .withWsPingPeriod(wsPingPeriod)
                 .build();
         }
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -438,13 +438,13 @@ public class TwitchClientPoolBuilder {
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
                 .maxSubscriptionsPerConnection(maxChannelsPerChatInstance)
-                .wsPingPeriod(wsPingPeriod)
                 .advancedConfiguration(builder ->
                     builder.withCredentialManager(credentialManager)
                         .withChatQueueSize(chatQueueSize)
                         .withBaseUrl(chatServer)
                         .withChatQueueTimeout(chatQueueTimeout)
                         .withMaxJoinRetries(chatMaxJoinRetries)
+                        .withWsPingPeriod(wsPingPeriod)
                         .setCommandPrefixes(commandPrefixes)
                         .setBotOwnerIds(botOwnerIds)
                 )
@@ -477,13 +477,14 @@ public class TwitchClientPoolBuilder {
                 .eventManager(eventManager)
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
-                .advancedConfiguration(builder -> builder.setBotOwnerIds(botOwnerIds))
+                .advancedConfiguration(builder -> builder.withWsPingPeriod(wsPingPeriod).setBotOwnerIds(botOwnerIds))
                 .build();
         } else if (this.enablePubSub) {
             pubSub = TwitchPubSubBuilder.builder()
                 .withEventManager(eventManager)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withProxyConfig(proxyConfig)
+                .withWsPingPeriod(wsPingPeriod)
                 .setBotOwnerIds(botOwnerIds)
                 .build();
         }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -285,6 +285,12 @@ public class TwitchClientPoolBuilder {
     private Logger.Level feignLogLevel = Logger.Level.NONE;
 
     /**
+     * WebSocket RFC Ping Period in ms (0 = disabled)
+     */
+    @With
+    private int wsPingPeriod = 15_000;
+
+    /**
      * With a Bot Owner's User ID
      *
      * @param userId the user id
@@ -432,6 +438,7 @@ public class TwitchClientPoolBuilder {
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
                 .maxSubscriptionsPerConnection(maxChannelsPerChatInstance)
+                .wsPingPeriod(wsPingPeriod)
                 .advancedConfiguration(builder ->
                     builder.withCredentialManager(credentialManager)
                         .withChatQueueSize(chatQueueSize)
@@ -459,6 +466,7 @@ public class TwitchClientPoolBuilder {
                 .withMaxJoinRetries(chatMaxJoinRetries)
                 .setBotOwnerIds(botOwnerIds)
                 .setCommandPrefixes(commandPrefixes)
+                .withWsPingPeriod(wsPingPeriod)
                 .build();
         }
 


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
The Chat connection could end up stuck without reconnecting when losing internet access and not attempting to send any messages

### Changes Proposed
- enable websocket rfc ping with a default of 15s in chat and pubsub
- add the property wsPingPeriod to all relevant builders for customization

### Additional Information

Thanks to `Pocketpac` for reporting the issue