### PR TITLE
refactor: don't block when polling ircCommandQueue

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -346,7 +346,7 @@ public class TwitchChat implements ITwitchChat {
                 String command = null;
                 try {
                     // Send the command
-                    command = ircCommandQueue.poll(this.chatQueueTimeout, TimeUnit.MILLISECONDS);
+                    command = ircCommandQueue.poll();
                     if (command == null) break;
                     sendTextToWebSocket(command, false);
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
Avoids the following exception from being logged on `ITwitchClient#close`:
```
[ERROR] c.g.t.chat.TwitchChat - Chat: Unexpected error in worker thread
java.lang.InterruptedException: null
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1668)
	at java.base/java.util.concurrent.ArrayBlockingQueue.poll(ArrayBlockingQueue.java:435)
	at com.github.twitch4j.chat.TwitchChat.lambda$new$0(TwitchChat.java:349)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
(the thread still shuts down gracefully, just the exception can appear spooky for a normal operation)

### Changes Proposed
* Do not block when polling `ircCommandQueue` for an element (so no more InterruptedException would be fired)

### Additional Information
`flushCommand` is called frequently enough that the blocking poll is not needed

&nbsp;

Thanks to `쩌리곰#3393` for reporting
