### PR TITLE
feat: add ability to obtain listen request from pubsub response event

### DIFF
--- a/pubsub/build.gradle.kts
+++ b/pubsub/build.gradle.kts
@@ -6,9 +6,6 @@ dependencies {
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
 
-	// Cache
-	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
-
 	// Annotations
 	api(group = "org.jetbrains", name = "annotations")
 

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/PubSubSubscription.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/PubSubSubscription.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.pubsub;
 
 import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
  * @see TwitchPubSub#unsubscribeFromTopic(PubSubSubscription)
  */
 @RequiredArgsConstructor
+@EqualsAndHashCode
 public class PubSubSubscription {
     @Getter(AccessLevel.PACKAGE)
     private final PubSubRequest request;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -113,7 +113,7 @@ public class TwitchPubSub implements ITwitchPubSub {
     /**
      * Command Queue
      */
-    protected final BlockingQueue<String> commandQueue = new ArrayBlockingQueue<>(200);
+    protected final BlockingQueue<String> commandQueue = new ArrayBlockingQueue<>(128);
 
     /**
      * Holds the subscribed topics in case we need to reconnect

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -748,7 +749,16 @@ public class TwitchPubSub implements ITwitchPubSub {
                             }
 
                         } else if (message.getType().equals(PubSubType.RESPONSE)) {
-                            eventManager.publish(new PubSubListenResponseEvent(message.getNonce(), message.getError()));
+                            Supplier<PubSubRequest> findListenRequest = () -> {
+                                for (PubSubRequest topic : subscribedTopics) {
+                                    if (topic != null && StringUtils.equals(message.getNonce(), topic.getNonce())) {
+                                        return topic;
+                                    }
+                                }
+                                return null;
+                            };
+
+                            eventManager.publish(new PubSubListenResponseEvent(message.getNonce(), message.getError(), findListenRequest));
 
                             // topic subscription success or failed, response to listen command
                             // System.out.println(message.toString());

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubListenResponseEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubListenResponseEvent.java
@@ -1,8 +1,14 @@
 package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.PubSubRequest;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Value;
+
+import java.util.Optional;
+import java.util.function.Supplier;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -17,6 +23,18 @@ public class PubSubListenResponseEvent extends TwitchEvent {
      * The error message associated with the request, or an empty string if there is no error.
      */
     String error;
+
+    @Getter(AccessLevel.PRIVATE)
+    Supplier<PubSubRequest> listenRequestSupplier;
+
+    /**
+     * @return the listen request associated with this response.
+     * @implNote The current implementation requires unique nonce's across requests (which is the default behavior for the listen methods provided by the library).
+     * @implSpec This method involves an O(n) operation where n <= 50, so it is best to only call it once when needed.
+     */
+    public Optional<PubSubRequest> getListenRequest() {
+        return Optional.ofNullable(listenRequestSupplier.get());
+    }
 
     public boolean hasError() {
         return error != null && error.length() > 0;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubListenResponseEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubListenResponseEvent.java
@@ -5,6 +5,7 @@ import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
 
 import java.util.Optional;
@@ -24,6 +25,7 @@ public class PubSubListenResponseEvent extends TwitchEvent {
      */
     String error;
 
+    @ToString.Exclude
     @Getter(AccessLevel.PRIVATE)
     Supplier<PubSubRequest> listenRequestSupplier;
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `PubSubListenResponseEvent#getListenRequest`

### Additional Information
Useful to determine which specific topic failed to listen
