### PR TITLE
chore: deprecate helix user view count and hype train id query param

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1088,24 +1088,46 @@ public interface TwitchHelix {
 
     /**
      * Gets the information of the most recent Hype Train of the given channel ID.
-     * After 5 days, if no Hype Train has been active, the endpoint will return an empty response
+     * After 5 days, if no Hype Train has been active, the endpoint will return an empty response.
      *
-     * @param authToken Auth Token (scope: channel:read:hype_train)
+     * @param authToken     User Auth Token (scope: channel:read:hype_train)
      * @param broadcasterId User ID of the broadcaster (required)
-     * @param limit Maximum number of objects to return. Maximum: 100. Default: 1. (optional)
-     * @param id The id of the wanted event, if known. (optional)
-     * @param after Cursor for forward pagination (optional)
+     * @param limit         Maximum number of objects to return. Maximum: 100. Default: 1. (optional)
+     * @param after         Cursor for forward pagination (optional)
      * @return HypeTrainEventList
      */
-    @RequestLine("GET /hypetrain/events?broadcaster_id={broadcaster_id}&first={first}&id={id}&after={after}")
+    @RequestLine("GET /hypetrain/events?broadcaster_id={broadcaster_id}&first={first}&after={after}&cursor={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<HypeTrainEventList> getHypeTrainEvents(
         @Param("token") String authToken,
         @Param("broadcaster_id") String broadcasterId,
         @Param("first") Integer limit,
-        @Param("id") String id,
         @Param("after") String after
     );
+
+    /**
+     * Gets the information of the most recent Hype Train of the given channel ID.
+     * After 5 days, if no Hype Train has been active, the endpoint will return an empty response.
+     *
+     * @param authToken     User Auth Token (scope: channel:read:hype_train)
+     * @param broadcasterId User ID of the broadcaster (required)
+     * @param limit         Maximum number of objects to return. Maximum: 100. Default: 1. (optional)
+     * @param id            The id of the wanted event, if known. This field has been deprecated by twitch and has no effect. (optional)
+     * @param after         Cursor for forward pagination (optional)
+     * @return HypeTrainEventList
+     * @see <a href="https://discuss.dev.twitch.tv/t/get-hype-train-events-api-endpoint-id-query-parameter-deprecation/37613">id parameter deprecation announcement</a>
+     * @deprecated Use {@link #getHypeTrainEvents(String, String, Integer, String)} instead (no id argument)
+     */
+    @Deprecated
+    default HystrixCommand<HypeTrainEventList> getHypeTrainEvents(
+        String authToken,
+        String broadcasterId,
+        Integer limit,
+        @SuppressWarnings("unused") String id,
+        String after
+    ) {
+        return this.getHypeTrainEvents(authToken, broadcasterId, limit, after);
+    }
 
     @RequestLine("GET /ingests")
     HystrixCommand<IngestServerList> getIngestServers(URI baseUrl);

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/User.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/User.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 
@@ -39,7 +40,13 @@ public class User {
     /** URL of the user’s offline image. */
     private String offlineImageUrl;
 
-    /** Total number of views of the user’s channel. */
+    /**
+     * Total number of views of the user’s channel.
+     *
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/get-users-api-endpoint-view-count-deprecation/37777">This field will contain stale data beginning April 15, 2022, and will eventually no longer be populated due to Twitch changes.</a>
+     */
+    @Nullable
+    @Deprecated
     private Integer viewCount;
 
     /** User’s email address. Returned if the request includes the user:read:email scope. */

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/HypeTrainServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/HypeTrainServiceTest.java
@@ -19,7 +19,7 @@ public class HypeTrainServiceTest {
     @Test
     @DisplayName("Get Hype Train Events")
     public void getHypeTrainEvents() {
-        List<HypeTrainEvent> resultList = TestUtils.getTwitchHelixClient().getHypeTrainEvents(TestUtils.getCredential().getAccessToken(), TWITCH_USER_ID, null, null, null).execute().getEvents();
+        List<HypeTrainEvent> resultList = TestUtils.getTwitchHelixClient().getHypeTrainEvents(TestUtils.getCredential().getAccessToken(), TWITCH_USER_ID, null, null).execute().getEvents();
         Assertions.assertTrue(resultList.isEmpty()); // no hype trains available on this account
     }
 

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/ModerationServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/ModerationServiceTest.java
@@ -4,11 +4,9 @@ import com.github.twitch4j.helix.TestUtils;
 import com.github.twitch4j.helix.domain.AutomodEnforceCheck;
 import com.github.twitch4j.helix.domain.AutomodEnforceCheckList;
 import com.github.twitch4j.helix.domain.AutomodEnforceStatus;
-import com.github.twitch4j.helix.domain.BannedEvent;
 import com.github.twitch4j.helix.domain.BannedUser;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,17 +25,6 @@ public class ModerationServiceTest extends AbstractEndpointTest {
         List<BannedUser> results = TestUtils.getTwitchHelixClient().getBannedUsers(TestUtils.getCredential().getAccessToken(), TWITCH_USER_ID, null, null, null, null)
             .execute()
             .getResults();
-
-        Assertions.assertNotNull(results);
-    }
-
-    @Test
-    @Disabled
-    @DisplayName("Get Banned Events")
-    public void getBannedEvents() {
-        List<BannedEvent> results = TestUtils.getTwitchHelixClient().getBannedEvents(TestUtils.getCredential().getAccessToken(), TWITCH_USER_ID, null, null, null)
-            .execute()
-            .getEvents();
 
         Assertions.assertNotNull(results);
     }

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
@@ -65,18 +65,6 @@ public class UsersServiceTest extends AbstractEndpointTest {
         });
     }
 
-    @Test
-    @DisplayName("Create User Follows")
-    public void createFollow() {
-        TestUtils.getTwitchHelixClient().createFollow(TestUtils.getCredential().getAccessToken(), twitchUserId, "12826", false).execute();
-    }
-
-    @Test
-    @DisplayName("Delete User Follows")
-    public void deleteFollow() {
-        TestUtils.getTwitchHelixClient().deleteFollow(TestUtils.getCredential().getAccessToken(), twitchUserId, "12826").execute();
-    }
-
     /**
      * Update user description
      */

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/WebhooksServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/WebhooksServiceTest.java
@@ -1,16 +1,18 @@
 package com.github.twitch4j.helix.endpoints;
 
-import com.github.twitch4j.helix.domain.WebhookSubscriptionList;
-import com.github.twitch4j.helix.webhooks.domain.WebhookRequest;
-import com.github.twitch4j.helix.webhooks.topics.StreamsTopic;
-import feign.Response;
+import com.github.twitch4j.eventsub.EventSubTransport;
+import com.github.twitch4j.eventsub.EventSubTransportMethod;
+import com.github.twitch4j.eventsub.subscriptions.SubscriptionTypes;
+import com.github.twitch4j.helix.TestUtils;
+import com.github.twitch4j.helix.domain.EventSubSubscriptionList;
+import com.netflix.hystrix.HystrixCommand;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static com.github.twitch4j.helix.TestUtils.sleepFor;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -21,32 +23,28 @@ public class WebhooksServiceTest extends AbstractEndpointTest {
     private static String twitchUserId = "149223493";
 
     @Test
-    @DisplayName("Request a Stream Changed webhook subscription and verify using Get Webhook Subscriptions")
+    @DisplayName("Request a Stream Online EventSub webhook subscription and verify using Get EventSub Subscriptions")
     @Disabled
     public void getStreams() {
-        WebhookRequest request = new WebhookRequest(
-            System.getenv("CALLBACK_URL"),
-            WebhookRequest.MODE_SUBSCRIBE,
-            new StreamsTopic(twitchUserId),
-            120,
-            null
-        );
+        EventSubTransport transport = EventSubTransport.builder()
+            .method(EventSubTransportMethod.WEBHOOK)
+            .callback(System.getenv("CALLBACK_URL"))
+            .secret("twitch4j-is-not-a-good-secret")
+            .build();
 
-        Response response = testUtils.getTwitchHelixClient().requestWebhookSubscription(
-            request,
-            System.getenv("APP_ACCESS_TOKEN")
-        ).execute();
-        assertTrue(response.status() >= 200 && response.status() < 300, "Response was: " + response.toString());
-
-        sleepFor(30 * 1000);
-
-        WebhookSubscriptionList subList = testUtils.getTwitchHelixClient().getWebhookSubscriptions(
+        HystrixCommand<EventSubSubscriptionList> createCommand = TestUtils.getTwitchHelixClient().createEventSubSubscription(
             System.getenv("APP_ACCESS_TOKEN"),
+            SubscriptionTypes.STREAM_ONLINE.prepareSubscription(b -> b.broadcasterUserId(twitchUserId).build(), transport)
+        );
+        assertDoesNotThrow(createCommand::execute, "Failed to create EventSub subscription");
+
+        EventSubSubscriptionList subList = TestUtils.getTwitchHelixClient().getEventSubSubscriptions(
+            System.getenv("APP_ACCESS_TOKEN"),
+            null,
             null,
             null
         ).execute();
-        assertTrue(subList.getSubscriptions().size() > 0, "Sub list size was " + subList.getSubscriptions().size());
-
+        assertTrue(subList.getTotal() > 0, "Sub list size was " + subList.getTotal());
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate `User#getViewCount`
* Deprecate `TwitchHelix#getHypeTrainEvents(String, String, Integer, String, String)`
* Remove tests for decommissioned endpoints (and convert webhook tests from websub to eventsub)

### Additional Information
https://discuss.dev.twitch.tv/t/get-hype-train-events-api-endpoint-id-query-parameter-deprecation/37613
https://discuss.dev.twitch.tv/t/get-users-api-endpoint-view-count-deprecation/37777
