### PR TITLE
feat: comply with undocumented helix rate limits

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -12,6 +12,7 @@ import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.enums.TwitchLimitType;
+import com.github.twitch4j.common.util.BucketUtils;
 import com.github.twitch4j.common.util.EventManagerUtils;
 import com.github.twitch4j.common.util.ThreadUtils;
 import com.github.twitch4j.common.util.TwitchLimitRegistry;
@@ -269,16 +270,16 @@ public class TwitchChatBuilder {
         }
 
         if (ircMessageBucket == null)
-            ircMessageBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.chatRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_MESSAGE_LIMIT, Collections.singletonList(chatRateLimit));
+            ircMessageBucket = userId == null ? BucketUtils.createBucket(this.chatRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_MESSAGE_LIMIT, Collections.singletonList(chatRateLimit));
 
         if (ircWhisperBucket == null)
-            ircWhisperBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.whisperRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_WHISPER_LIMIT, Arrays.asList(whisperRateLimit));
+            ircWhisperBucket = userId == null ? BucketUtils.createBucket(this.whisperRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_WHISPER_LIMIT, Arrays.asList(whisperRateLimit));
 
         if (ircJoinBucket == null)
-            ircJoinBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.joinRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_JOIN_LIMIT, Collections.singletonList(joinRateLimit));
+            ircJoinBucket = userId == null ? BucketUtils.createBucket(this.joinRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_JOIN_LIMIT, Collections.singletonList(joinRateLimit));
 
         if (ircAuthBucket == null)
-            ircAuthBucket = userId == null ? TwitchChatLimitHelper.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
+            ircAuthBucket = userId == null ? BucketUtils.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
 
         log.debug("TwitchChat: Initializing Module ...");
         return new TwitchChat(this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod);

--- a/chat/src/main/java/com/github/twitch4j/chat/util/TwitchChatLimitHelper.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/TwitchChatLimitHelper.java
@@ -1,9 +1,9 @@
 package com.github.twitch4j.chat.util;
 
 import com.github.twitch4j.common.enums.TwitchLimitType;
+import com.github.twitch4j.common.util.BucketUtils;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
-import io.github.bucket4j.local.LocalBucketBuilder;
 import lombok.experimental.UtilityClass;
 
 import java.time.Duration;
@@ -103,24 +103,34 @@ public class TwitchChatLimitHelper {
      */
     public final Bandwidth VERIFIED_AUTH_LIMIT = Bandwidth.simple(200, Duration.ofSeconds(10)).withId(AUTH_BANDWIDTH_ID);
 
+    /**
+     * @param limit bandwidth
+     * @return bucket
+     * @deprecated in favor of BucketUtils
+     */
+    @Deprecated
     public Bucket createBucket(Bandwidth limit) {
-        return Bucket.builder().addLimit(limit).build();
+        return BucketUtils.createBucket(limit);
     }
 
+    /**
+     * @param limits bandwidths
+     * @return bucket
+     * @deprecated in favor of BucketUtils
+     */
+    @Deprecated
     public Bucket createBucket(Bandwidth... limits) {
-        LocalBucketBuilder builder = Bucket.builder();
-        for (Bandwidth limit : limits) {
-            builder.addLimit(limit);
-        }
-        return builder.build();
+        return BucketUtils.createBucket(limits);
     }
 
+    /**
+     * @param limits bandwidths
+     * @return bucket
+     * @deprecated in favor of BucketUtils
+     */
+    @Deprecated
     public Bucket createBucket(Iterable<Bandwidth> limits) {
-        LocalBucketBuilder builder = Bucket.builder();
-        for (Bandwidth limit : limits) {
-            builder.addLimit(limit);
-        }
-        return builder.build();
+        return BucketUtils.createBucket(limits);
     }
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/util/BucketUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/BucketUtils.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.common.util;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.local.LocalBucketBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -16,7 +17,8 @@ public class BucketUtils {
      * @param limit the bandwidth
      * @return the bucket
      */
-    public static Bucket createBucket(Bandwidth limit) {
+    @NotNull
+    public static Bucket createBucket(@NotNull Bandwidth limit) {
         return Bucket.builder().addLimit(limit).build();
     }
 
@@ -26,7 +28,8 @@ public class BucketUtils {
      * @param limits the bandwidths
      * @return the bucket
      */
-    public static Bucket createBucket(Bandwidth... limits) {
+    @NotNull
+    public static Bucket createBucket(@NotNull Bandwidth... limits) {
         LocalBucketBuilder builder = Bucket.builder();
         for (Bandwidth limit : limits) {
             builder.addLimit(limit);
@@ -40,7 +43,8 @@ public class BucketUtils {
      * @param limits the bandwidths
      * @return the bucket
      */
-    public static Bucket createBucket(Iterable<Bandwidth> limits) {
+    @NotNull
+    public static Bucket createBucket(@NotNull Iterable<Bandwidth> limits) {
         LocalBucketBuilder builder = Bucket.builder();
         for (Bandwidth limit : limits) {
             builder.addLimit(limit);
@@ -58,7 +62,8 @@ public class BucketUtils {
      * @param call     task that requires a bucket point
      * @return the future result of the call
      */
-    public static <T> CompletableFuture<T> scheduleAgainstBucket(Bucket bucket, ScheduledExecutorService executor, Callable<T> call) {
+    @NotNull
+    public static <T> CompletableFuture<T> scheduleAgainstBucket(@NotNull Bucket bucket, @NotNull ScheduledExecutorService executor, @NotNull Callable<T> call) {
         if (bucket.tryConsume(1L))
             return CompletableFuture.supplyAsync(new SneakySupplier<>(call));
 
@@ -75,7 +80,8 @@ public class BucketUtils {
      * @param action   runnable that requires a bucket point
      * @return a future to track completion progress
      */
-    public static CompletableFuture<Void> scheduleAgainstBucket(Bucket bucket, ScheduledExecutorService executor, Runnable action) {
+    @NotNull
+    public static CompletableFuture<Void> scheduleAgainstBucket(@NotNull Bucket bucket, @NotNull ScheduledExecutorService executor, @NotNull Runnable action) {
         if (bucket.tryConsume(1L))
             return CompletableFuture.runAsync(action);
 

--- a/common/src/main/java/com/github/twitch4j/common/util/BucketUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/BucketUtils.java
@@ -1,0 +1,85 @@
+package com.github.twitch4j.common.util;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.local.LocalBucketBuilder;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class BucketUtils {
+
+    /**
+     * Creates a bucket with the specified bandwidth.
+     *
+     * @param limit the bandwidth
+     * @return the bucket
+     */
+    public static Bucket createBucket(Bandwidth limit) {
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    /**
+     * Creates a bucket with the specified bandwidths.
+     *
+     * @param limits the bandwidths
+     * @return the bucket
+     */
+    public static Bucket createBucket(Bandwidth... limits) {
+        LocalBucketBuilder builder = Bucket.builder();
+        for (Bandwidth limit : limits) {
+            builder.addLimit(limit);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Creates a bucket with the specified bandwidths.
+     *
+     * @param limits the bandwidths
+     * @return the bucket
+     */
+    public static Bucket createBucket(Iterable<Bandwidth> limits) {
+        LocalBucketBuilder builder = Bucket.builder();
+        for (Bandwidth limit : limits) {
+            builder.addLimit(limit);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Performs the callable after a token has been consumed from the bucket using the executor.
+     * <p>
+     * Note: ExecutionException should be inspected if the passed action can throw an exception.
+     *
+     * @param bucket   rate limit bucket
+     * @param executor scheduled executor service for async calls
+     * @param call     task that requires a bucket point
+     * @return the future result of the call
+     */
+    public static <T> CompletableFuture<T> scheduleAgainstBucket(Bucket bucket, ScheduledExecutorService executor, Callable<T> call) {
+        if (bucket.tryConsume(1L))
+            return CompletableFuture.supplyAsync(new SneakySupplier<>(call));
+
+        return bucket.asScheduler().consume(1L, executor).thenApplyAsync(v -> new SneakySupplier<>(call).get());
+    }
+
+    /**
+     * Runs the action after a token has been consumed from the bucket using the executor.
+     * <p>
+     * Note: while the executor is used to consume the bucket token, the action is performed on the fork-join common pool, by default.
+     *
+     * @param bucket   rate limit bucket
+     * @param executor scheduled executor service for async calls
+     * @param action   runnable that requires a bucket point
+     * @return a future to track completion progress
+     */
+    public static CompletableFuture<Void> scheduleAgainstBucket(Bucket bucket, ScheduledExecutorService executor, Runnable action) {
+        if (bucket.tryConsume(1L))
+            return CompletableFuture.runAsync(action);
+
+        return bucket.asScheduler().consume(1L, executor).thenRunAsync(action);
+    }
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/SneakySupplier.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/SneakySupplier.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.common.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
@@ -19,6 +20,7 @@ public final class SneakySupplier<T> implements Supplier<T> {
     /**
      * The action to compute the supplied value, possibly throwing an exception.
      */
+    @NotNull
     private final Callable<T> callable;
 
     @Override

--- a/common/src/main/java/com/github/twitch4j/common/util/SneakySupplier.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/SneakySupplier.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.common.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/**
+ * A supplier that can sneakily throw exceptions.
+ * <p>
+ * This class should be used sparingly (to avoid hackiness) and carefully (to ensure bubbled exceptions are properly handled).
+ *
+ * @param <T> the return type of values provided by the supplier
+ */
+@RequiredArgsConstructor
+public final class SneakySupplier<T> implements Supplier<T> {
+
+    /**
+     * The action to compute the supplied value, possibly throwing an exception.
+     */
+    private final Callable<T> callable;
+
+    @Override
+    @SneakyThrows
+    public T get() {
+        return callable.call();
+    }
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchLimitRegistry.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchLimitRegistry.java
@@ -5,7 +5,6 @@ import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.TokensInheritanceStrategy;
-import io.github.bucket4j.local.LocalBucketBuilder;
 import lombok.NonNull;
 
 import java.util.Collections;
@@ -51,7 +50,7 @@ public enum TwitchLimitRegistry {
                 return bucket;
             }
 
-            return constructBucket(limit);
+            return BucketUtils.createBucket(limit);
         });
     }
 
@@ -76,17 +75,11 @@ public enum TwitchLimitRegistry {
      * @return the shared rate limit bucket for this user and limit type
      */
     public Bucket getOrInitializeBucket(@NonNull String userId, @NonNull TwitchLimitType limitType, @NonNull List<Bandwidth> limit) {
-        return getBucketsByUser(userId).computeIfAbsent(limitType, l -> constructBucket(limit));
+        return getBucketsByUser(userId).computeIfAbsent(limitType, l -> BucketUtils.createBucket(limit));
     }
 
     private Map<TwitchLimitType, Bucket> getBucketsByUser(String userId) {
         return limits.computeIfAbsent(userId, s -> Collections.synchronizedMap(new EnumMap<>(TwitchLimitType.class)));
-    }
-
-    private static Bucket constructBucket(List<Bandwidth> limits) {
-        LocalBucketBuilder builder = Bucket.builder();
-        limits.forEach(builder::addLimit);
-        return builder.build();
     }
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -174,7 +174,7 @@ public class TwitchHelixBuilder {
             .decoder(new TwitchHelixDecoder(mapper, interceptor))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)
-            .errorDecoder(new TwitchHelixErrorDecoder(new JacksonDecoder()))
+            .errorDecoder(new TwitchHelixErrorDecoder(new JacksonDecoder(), interceptor))
             .requestInterceptor(interceptor)
             .options(new Request.Options(timeout / 3, TimeUnit.MILLISECONDS, timeout, TimeUnit.MILLISECONDS, true))
             .retryer(new Retryer.Default(500, timeout, 2))

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -23,6 +23,7 @@ import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Refill;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -55,7 +56,7 @@ public class TwitchHelixBuilder {
     /**
      * @see <a href="https://dev.twitch.tv/docs/api/guide#rate-limits">Helix Rate Limit Reference</a>
      */
-    public static final Bandwidth DEFAULT_BANDWIDTH = Bandwidth.simple(800, Duration.ofMinutes(1));
+    public static final Bandwidth DEFAULT_BANDWIDTH = Bandwidth.classic(800, Refill.greedy(600, Duration.ofMinutes(1)));
 
     /**
      * Client Id

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -81,7 +81,7 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
                 if (template.path().endsWith("/moderation/bans")) {
                     String channelId = template.queries().get("broadcaster_id").iterator().next();
                     Bucket modBucket = interceptor.getModerationBucket(channelId);
-                    modBucket.consumeIgnoringRateLimits(Math.max(modBucket.tryConsumeAsMuchAsPossible(), 1));
+                    modBucket.consumeIgnoringRateLimits(Math.max(modBucket.tryConsumeAsMuchAsPossible(), 1)); // intentionally go negative to induce a pause
                 }
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -12,7 +12,6 @@ import feign.Response;
 import feign.RetryableException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
-import io.github.bucket4j.Bucket;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
@@ -80,8 +79,7 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
                 RequestTemplate template = response.request().requestTemplate();
                 if (template.path().endsWith("/moderation/bans")) {
                     String channelId = template.queries().get("broadcaster_id").iterator().next();
-                    Bucket modBucket = interceptor.getModerationBucket(channelId);
-                    modBucket.consumeIgnoringRateLimits(Math.max(modBucket.tryConsumeAsMuchAsPossible(), 1)); // intentionally go negative to induce a pause
+                    interceptor.getRateLimitTracker().markDepletedBanBucket(channelId);
                 }
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -17,6 +17,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 @Slf4j
@@ -56,8 +57,8 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
     public Exception decode(String methodKey, Response response) {
         Exception ex;
 
-        try {
-            String responseBody = response.body() == null ? "" : IOUtils.toString(response.body().asInputStream(), StandardCharsets.UTF_8.name());
+        try (InputStream is = response.body() == null ? null : response.body().asInputStream()) {
+            String responseBody = is == null ? "" : IOUtils.toString(is, StandardCharsets.UTF_8);
 
             if (response.status() == 401) {
                 ex = new UnauthorizedException()

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SendPubSubMessageInput.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SendPubSubMessageInput.java
@@ -42,7 +42,7 @@ public class SendPubSubMessageInput {
 
     /**
      * Strings for valid PubSub targets.
-     * Valid values: "broadcast", "global", "whisper-<user-id>"
+     * Valid values: "broadcast", "global", "{@literal whisper-<user-id>}"
      */
     @Singular
     @JsonProperty("target")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixClientIdInterceptor.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixClientIdInterceptor.java
@@ -179,7 +179,7 @@ public class TwitchHelixClientIdInterceptor implements RequestInterceptor {
         return buckets.get(key, k -> Bucket.builder().addLimit(this.apiRateLimit).build());
     }
 
-    protected Bucket getModerationBucket(String channelId) {
+    public Bucket getModerationBucket(String channelId) {
         return bansByChannelId.get(channelId, k -> Bucket.builder().addLimit(BANS_BANDWIDTH).build());
     }
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixClientIdInterceptor.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixClientIdInterceptor.java
@@ -1,21 +1,10 @@
 package com.github.twitch4j.helix.interceptor;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
-import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
-import com.github.twitch4j.helix.TwitchHelixBuilder;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import io.github.bucket4j.Bandwidth;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Injects ClientId Header, the User Agent and other common headers into each API Request
@@ -27,64 +16,21 @@ public class TwitchHelixClientIdInterceptor implements RequestInterceptor {
     public static final String BEARER_PREFIX = "Bearer ";
 
     /**
-     * Reference to the Client Builder
+     * User Agent
      */
-    private final TwitchHelixBuilder twitchAPIBuilder;
-
-    /**
-     * Helix Rate Limit
-     */
-    @Getter(AccessLevel.PROTECTED)
-    private final Bandwidth apiRateLimit;
-
-    /**
-     * Helix Rate Limit Tracker
-     */
-    @Getter
-    private final TwitchHelixRateLimitTracker rateLimitTracker;
-
-    /**
-     * Reference to the twitch identity provider
-     */
-    @Setter
-    private TwitchIdentityProvider twitchIdentityProvider;
+    private final String userAgent;
 
     /**
      * Access token cache
      */
-    @Getter(value = AccessLevel.PROTECTED)
-    private final Cache<String, OAuth2Credential> accessTokenCache = Caffeine.newBuilder()
-        .expireAfterAccess(15, TimeUnit.MINUTES)
-        .maximumSize(10_000)
-        .build();
-
-    /**
-     * The default app access token that is used if no oauth was passed by the user
-     */
-    private volatile OAuth2Credential defaultAuthToken;
-
-    /**
-     * The default client id, typically associated with {@link TwitchHelixClientIdInterceptor#defaultAuthToken}
-     */
-    private volatile String defaultClientId;
+    private final TwitchHelixTokenManager tokenManager;
 
     /**
      * Constructor
-     *
-     * @param twitchHelixBuilder Twitch Client Builder
      */
-    public TwitchHelixClientIdInterceptor(TwitchHelixBuilder twitchHelixBuilder) {
-        this.twitchAPIBuilder = twitchHelixBuilder;
-        twitchIdentityProvider = new TwitchIdentityProvider(twitchHelixBuilder.getClientId(), twitchHelixBuilder.getClientSecret(), null);
-        this.defaultClientId = twitchAPIBuilder.getClientId();
-        this.apiRateLimit = twitchAPIBuilder.getApiRateLimit();
-        this.defaultAuthToken = twitchHelixBuilder.getDefaultAuthToken();
-        this.rateLimitTracker = new TwitchHelixRateLimitTracker(this);
-        if (defaultAuthToken != null)
-            twitchIdentityProvider.getAdditionalCredentialInformation(defaultAuthToken).ifPresent(oauth -> {
-                this.defaultClientId = (String) oauth.getContext().get("client_id");
-                accessTokenCache.put(oauth.getAccessToken(), oauth);
-            });
+    public TwitchHelixClientIdInterceptor(String userAgent, TwitchHelixTokenManager tokenManager) {
+        this.userAgent = userAgent;
+        this.tokenManager = tokenManager;
     }
 
     /**
@@ -94,19 +40,16 @@ public class TwitchHelixClientIdInterceptor implements RequestInterceptor {
      */
     @Override
     public void apply(RequestTemplate template) {
-        String clientId = this.defaultClientId;
+        String clientId = tokenManager.getDefaultClientId();
 
         // if a oauth token is passed is has to match that client id, default to global client id otherwise (for ie. token verification)
         if (template.headers().containsKey(AUTH_HEADER)) {
             String oauthToken = template.headers().get(AUTH_HEADER).iterator().next().substring(BEARER_PREFIX.length());
 
             if (oauthToken.isEmpty()) {
-                String clientSecret = twitchAPIBuilder.getClientSecret();
-                if (defaultAuthToken == null && (StringUtils.isEmpty(clientId) || StringUtils.isEmpty(clientSecret) || clientSecret.charAt(0) == '*'))
-                    throw new RuntimeException("Necessary OAuth token was missing from Helix call, without the means to generate one!");
-
                 try {
-                    oauthToken = getOrCreateAuthToken().getAccessToken();
+                    oauthToken = tokenManager.getDefaultAuthToken().getAccessToken();
+                    clientId = tokenManager.getDefaultClientId();
                 } catch (Exception e) {
                     throw new RuntimeException("Failed to generate an app access token as no oauth token was passed to this Helix call", e);
                 }
@@ -114,20 +57,8 @@ public class TwitchHelixClientIdInterceptor implements RequestInterceptor {
                 template.removeHeader(AUTH_HEADER);
                 template.header(AUTH_HEADER, BEARER_PREFIX + oauthToken);
             } else if (!StringUtils.contains(oauthToken, '.')) {
-                OAuth2Credential verifiedCredential = accessTokenCache.getIfPresent(oauthToken);
-                if (verifiedCredential == null) {
-                    log.debug("Getting matching client-id for authorization token {}", oauthToken.substring(0, 5));
-
-                    Optional<OAuth2Credential> requestedCredential = twitchIdentityProvider.getAdditionalCredentialInformation(new OAuth2Credential("twitch", oauthToken));
-                    if (!requestedCredential.isPresent()) {
-                        throw new RuntimeException("Failed to get the client_id for the provided authentication token, the authentication token may be invalid!");
-                    }
-
-                    verifiedCredential = requestedCredential.get();
-                    accessTokenCache.put(oauthToken, verifiedCredential);
-                }
-
-                clientId = (String) verifiedCredential.getContext().get("client_id");
+                OAuth2Credential verifiedCredential = tokenManager.getOrPopulateCache(oauthToken);
+                clientId = TwitchHelixTokenManager.extractClientId(verifiedCredential);
             }
 
             log.debug("Setting new client-id {} for token {}", clientId, oauthToken.substring(0, 5));
@@ -136,28 +67,7 @@ public class TwitchHelixClientIdInterceptor implements RequestInterceptor {
         // set headers
         if (!template.headers().containsKey("Client-Id"))
             template.header("Client-Id", clientId);
-        template.header("User-Agent", twitchAPIBuilder.getUserAgent());
-    }
-
-    public void clearDefaultToken() {
-        this.defaultAuthToken = null;
-    }
-
-    private OAuth2Credential getOrCreateAuthToken() {
-        if (defaultAuthToken == null)
-            synchronized (this) {
-                if (defaultAuthToken == null) {
-                    String clientId = twitchAPIBuilder.getClientId();
-                    OAuth2Credential token = twitchIdentityProvider.getAppAccessToken();
-                    token.getContext().put("client_id", clientId);
-                    rateLimitTracker.getOrInitializeBucket(clientId);
-                    accessTokenCache.put(token.getAccessToken(), token);
-                    this.defaultClientId = clientId;
-                    return this.defaultAuthToken = token;
-                }
-            }
-
-        return this.defaultAuthToken;
+        template.header("User-Agent", userAgent);
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixClientIdInterceptor.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixClientIdInterceptor.java
@@ -5,6 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
 import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.common.util.BucketUtils;
 import com.github.twitch4j.helix.TwitchHelixBuilder;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
@@ -199,19 +200,19 @@ public class TwitchHelixClientIdInterceptor implements RequestInterceptor {
     }
 
     protected Bucket getOrInitializeBucket(String key) {
-        return buckets.get(key, k -> Bucket.builder().addLimit(this.apiRateLimit).build());
+        return buckets.get(key, k -> BucketUtils.createBucket(this.apiRateLimit));
     }
 
     public Bucket getModerationBucket(String channelId) {
-        return bansByChannelId.get(channelId, k -> Bucket.builder().addLimit(BANS_BANDWIDTH).build());
+        return bansByChannelId.get(channelId, k -> BucketUtils.createBucket(BANS_BANDWIDTH));
     }
 
     protected Bucket getClipBucket(String userId) {
-        return clipsByUserId.get(userId, k -> Bucket.builder().addLimit(CLIPS_BANDWIDTH).build());
+        return clipsByUserId.get(userId, k -> BucketUtils.createBucket(CLIPS_BANDWIDTH));
     }
 
     protected Bucket getTermsBucket(String channelId) {
-        return termsByChannelId.get(channelId, k -> Bucket.builder().addLimit(TERMS_BANDWIDTH).build());
+        return termsByChannelId.get(channelId, k -> BucketUtils.createBucket(TERMS_BANDWIDTH));
     }
 
     private OAuth2Credential getOrCreateAuthToken() {

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixDecoder.java
@@ -42,10 +42,10 @@ public class TwitchHelixDecoder extends JacksonDecoder {
                 String bearer = token.substring(BEARER_PREFIX.length());
                 if (response.request().httpMethod() == Request.HttpMethod.POST && response.request().requestTemplate().path().endsWith("/clips")) {
                     // Create Clip has a separate rate limit to synchronize
-                    interceptor.updateRemainingCreateClip(bearer, remaining);
+                    interceptor.getRateLimitTracker().updateRemainingCreateClip(bearer, remaining);
                 } else {
                     // Normal/global helix rate limit synchronization
-                    interceptor.updateRemaining(bearer, remaining);
+                    interceptor.getRateLimitTracker().updateRemaining(bearer, remaining);
                 }
             }
         }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixDecoder.java
@@ -16,11 +16,11 @@ public class TwitchHelixDecoder extends JacksonDecoder {
 
     public static final String REMAINING_HEADER = "Ratelimit-Remaining";
 
-    private final TwitchHelixClientIdInterceptor interceptor;
+    private final TwitchHelixRateLimitTracker rateLimitTracker;
 
-    public TwitchHelixDecoder(ObjectMapper mapper, TwitchHelixClientIdInterceptor interceptor) {
+    public TwitchHelixDecoder(ObjectMapper mapper, TwitchHelixRateLimitTracker rateLimitTracker) {
         super(mapper);
-        this.interceptor = interceptor;
+        this.rateLimitTracker = rateLimitTracker;
     }
 
     @Override
@@ -42,10 +42,10 @@ public class TwitchHelixDecoder extends JacksonDecoder {
                 String bearer = token.substring(BEARER_PREFIX.length());
                 if (response.request().httpMethod() == Request.HttpMethod.POST && response.request().requestTemplate().path().endsWith("/clips")) {
                     // Create Clip has a separate rate limit to synchronize
-                    interceptor.getRateLimitTracker().updateRemainingCreateClip(bearer, remaining);
+                    rateLimitTracker.updateRemainingCreateClip(bearer, remaining);
                 } else {
                     // Normal/global helix rate limit synchronization
-                    interceptor.getRateLimitTracker().updateRemaining(bearer, remaining);
+                    rateLimitTracker.updateRemaining(bearer, remaining);
                 }
             }
         }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
@@ -45,7 +45,7 @@ public class TwitchHelixHttpClient implements Client {
             OAuth2Credential credential = interceptor.getAccessTokenCache().getIfPresent(token.substring(BEARER_PREFIX.length()));
             if (credential != null) {
                 // First consume from helix global rate limit (800/min by default)
-                Bucket bucket = interceptor.getOrInitializeBucket(interceptor.getKey(credential));
+                Bucket bucket = interceptor.getRateLimitTracker().getOrInitializeBucket(interceptor.getRateLimitTracker().getKey(credential));
                 return executeAgainstBucket(bucket, () -> delegatedExecute(request, options));
             }
         }
@@ -71,7 +71,7 @@ public class TwitchHelixHttpClient implements Client {
             String channelId = request.requestTemplate().queries().getOrDefault("broadcaster_id", Collections.emptyList()).iterator().next();
 
             // Conform to endpoint-specific bucket
-            Bucket modBucket = interceptor.getModerationBucket(channelId);
+            Bucket modBucket = interceptor.getRateLimitTracker().getModerationBucket(channelId);
             return executeAgainstBucket(modBucket, () -> client.execute(request, options));
         }
 
@@ -81,7 +81,7 @@ public class TwitchHelixHttpClient implements Client {
             String channelId = request.requestTemplate().queries().getOrDefault("broadcaster_id", Collections.emptyList()).iterator().next();
 
             // Conform to endpoint-specific bucket
-            Bucket termsBucket = interceptor.getTermsBucket(channelId);
+            Bucket termsBucket = interceptor.getRateLimitTracker().getTermsBucket(channelId);
             return executeAgainstBucket(termsBucket, () -> client.execute(request, options));
         }
 
@@ -93,7 +93,7 @@ public class TwitchHelixHttpClient implements Client {
             String userId = cred != null ? cred.getUserId() : "";
 
             // Conform to endpoint-specific bucket
-            Bucket clipBucket = interceptor.getClipBucket(userId != null ? userId : "");
+            Bucket clipBucket = interceptor.getRateLimitTracker().getClipBucket(userId != null ? userId : "");
             return executeAgainstBucket(clipBucket, () -> client.execute(request, options));
         }
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
@@ -6,14 +6,19 @@ import feign.Request;
 import feign.Response;
 import feign.okhttp.OkHttpClient;
 import io.github.bucket4j.Bucket;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import static com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor.AUTH_HEADER;
 import static com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor.BEARER_PREFIX;
@@ -42,32 +47,80 @@ public class TwitchHelixHttpClient implements Client {
             OAuth2Credential credential = interceptor.getAccessTokenCache().getIfPresent(token.substring(BEARER_PREFIX.length()));
             if (credential != null) {
                 Bucket bucket = interceptor.getOrInitializeBucket(interceptor.getKey(credential));
-                if (bucket.tryConsume(1)) {
-                    // no delay needed
-                    return client.execute(request, options);
-                } else {
-                    try {
-                        // effectively blocking, unfortunately
-                        return bucket.asScheduler().consume(1, executor)
-                            .thenApplyAsync(v -> {
-                                try {
-                                    return client.execute(request, options);
-                                } catch (IOException e) {
-                                    log.error("Helix API call execution failed", e);
-                                    return null;
-                                }
-                            })
-                            .get(timeout, TimeUnit.MILLISECONDS);
-                    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                        log.error("Throttled Helix API call timed-out before completion", e);
-                        return null;
-                    }
+                try {
+                    return executeAgainstBucket(
+                        bucket,
+                        () -> delegatedExecute(request, options),
+                        executor
+                    ).get(timeout, TimeUnit.MILLISECONDS);
+                } catch (ExecutionException | InterruptedException | TimeoutException e) {
+                    if (e.getCause() instanceof IOException) throw (IOException) e.getCause();
+                    log.error("Throttled Helix API call timed-out before completion", e);
+                    return null;
                 }
             }
         }
 
         // Fallback: just run the http request
+        return delegatedExecute(request, options);
+    }
+
+    /**
+     * After the helix rate limit has been evaluated, check for any other endpoint-specific limits before actually executing the request.
+     *
+     * @param request feign request
+     * @param options feign request options
+     * @return feign response
+     * @throws IOException on network errors
+     */
+    private Response delegatedExecute(Request request, Request.Options options) throws IOException {
+        // Moderation API: banUser and unbanUser share a bucket per channel id
+        if (request.requestTemplate().path().endsWith("/moderation/bans")) {
+            // Obtain the channel id
+            String query = request.requestTemplate().queryLine();
+            int start = query.indexOf("broadcaster_id=") + "broadcaster_id=".length();
+            int end = query.indexOf('&', start);
+            String channelId = query.substring(start, end > start ? end : query.length());
+
+            // Conform to endpoint-specific bucket
+            Bucket modBucket = interceptor.getModerationBucket(channelId);
+            try {
+                return executeAgainstBucket(modBucket, () -> client.execute(request, options), executor).get(timeout, TimeUnit.MILLISECONDS);
+            } catch (ExecutionException | InterruptedException | TimeoutException e) {
+                if (e.getCause() instanceof IOException) throw (IOException) e.getCause();
+                log.error("Throttled Helix API call timed-out before completion", e);
+                return null;
+            }
+        }
+
+        // no endpoint-specific rate limiting was needed; perform network request now
         return client.execute(request, options);
+    }
+
+    /**
+     * Performs the callable after a token has been consumed from the bucket using the executor.
+     *
+     * @param bucket   rate limit bucket
+     * @param call     task that requires a bucket point
+     * @param executor scheduled executor service for async calls
+     * @return the future result of the call
+     */
+    private static <T> CompletableFuture<T> executeAgainstBucket(Bucket bucket, Callable<T> call, ScheduledExecutorService executor) {
+        if (bucket.tryConsume(1L))
+            return CompletableFuture.supplyAsync(new SneakySupplier<>(call));
+
+        return bucket.asScheduler().consume(1L, executor).thenApplyAsync(v -> new SneakySupplier<>(call).get());
+    }
+
+    @RequiredArgsConstructor
+    private static class SneakySupplier<T> implements Supplier<T> {
+        private final Callable<T> callable;
+
+        @Override
+        @SneakyThrows
+        public T get() {
+            return callable.call();
+        }
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
@@ -11,6 +11,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -77,10 +78,7 @@ public class TwitchHelixHttpClient implements Client {
         // Moderation API: banUser and unbanUser share a bucket per channel id
         if (request.requestTemplate().path().endsWith("/moderation/bans")) {
             // Obtain the channel id
-            String query = request.requestTemplate().queryLine();
-            int start = query.indexOf("broadcaster_id=") + "broadcaster_id=".length();
-            int end = query.indexOf('&', start);
-            String channelId = query.substring(start, end > start ? end : query.length());
+            String channelId = request.requestTemplate().queries().getOrDefault("broadcaster_id", Collections.emptyList()).iterator().next();
 
             // Conform to endpoint-specific bucket
             Bucket modBucket = interceptor.getModerationBucket(channelId);

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixRateLimitTracker.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixRateLimitTracker.java
@@ -1,0 +1,136 @@
+package com.github.twitch4j.helix.interceptor;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.common.util.BucketUtils;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+public class TwitchHelixRateLimitTracker {
+
+    /**
+     * Empirically determined rate limit on helix bans and unbans, per channel
+     */
+    @Unofficial
+    private static final Bandwidth BANS_BANDWIDTH = Bandwidth.simple(100, Duration.ofSeconds(30));
+
+    /**
+     * Empirically determined rate limit on the helix create clip endpoint, per user
+     */
+    @Unofficial
+    private static final Bandwidth CLIPS_BANDWIDTH = Bandwidth.simple(600, Duration.ofSeconds(60));
+
+    /**
+     * Empirically determined rate limit on helix add and remove block term, per channel
+     */
+    @Unofficial
+    private static final Bandwidth TERMS_BANDWIDTH = Bandwidth.simple(60, Duration.ofSeconds(60));
+
+    /**
+     * Rate limit buckets by user/app
+     */
+    private final Cache<String, Bucket> primaryBuckets = Caffeine.newBuilder()
+        .expireAfterAccess(1, TimeUnit.MINUTES)
+        .build();
+
+    /**
+     * Moderation API: ban and unban rate limit buckets per channel
+     */
+    private final Cache<String, Bucket> bansByChannelId = Caffeine.newBuilder()
+        .expireAfterAccess(1, TimeUnit.MINUTES)
+        .build();
+
+    /**
+     * Create Clip API rate limit buckets per user
+     */
+    private final Cache<String, Bucket> clipsByUserId = Caffeine.newBuilder()
+        .expireAfterAccess(1, TimeUnit.MINUTES)
+        .build();
+
+    /**
+     * Moderation API: add and remove blocked term rate limit buckets per channel
+     */
+    private final Cache<String, Bucket> termsByChannelId = Caffeine.newBuilder()
+        .expireAfterAccess(1, TimeUnit.MINUTES)
+        .build();
+
+    /**
+     * Twitch Helix Interceptor
+     */
+    private final TwitchHelixClientIdInterceptor interceptor; // provided by RequiredArgsConstructor
+
+    /*
+     * Primary (global helix) rate limit bucket finder
+     */
+
+    protected Bucket getOrInitializeBucket(String key) {
+        return primaryBuckets.get(key, k -> BucketUtils.createBucket(interceptor.getApiRateLimit()));
+    }
+
+    protected String getKey(OAuth2Credential credential) {
+        // App access tokens share the same bucket for a given client id
+        // User access tokens share the same bucket for a given client id & user id pair
+        // For this method to work, credential must have been augmented with information from getAdditionalCredentialInformation (which is done by the interceptor)
+        // Thus, this logic yields the key that is associated with each primary helix bucket
+        String clientId = (String) credential.getContext().get("client_id");
+        return clientId == null ? null : credential.getUserId() == null ? clientId : clientId + "-" + credential.getUserId();
+    }
+
+    /*
+     * Secondary (endpoint-specific) rate limit buckets
+     */
+
+    @Unofficial
+    protected Bucket getModerationBucket(String channelId) {
+        return bansByChannelId.get(channelId, k -> BucketUtils.createBucket(BANS_BANDWIDTH));
+    }
+
+    @Unofficial
+    protected Bucket getClipBucket(String userId) {
+        return clipsByUserId.get(userId, k -> BucketUtils.createBucket(CLIPS_BANDWIDTH));
+    }
+
+    @Unofficial
+    protected Bucket getTermsBucket(String channelId) {
+        return termsByChannelId.get(channelId, k -> BucketUtils.createBucket(TERMS_BANDWIDTH));
+    }
+
+    /*
+     * Methods to conservatively update remaining points in rate limit buckets, based on incoming twitch statistics
+     */
+
+    public void updateRemaining(String token, int remaining) {
+        this.updateRemainingGeneric(token, remaining, this::getKey, this::getOrInitializeBucket);
+    }
+
+    public void updateRemainingCreateClip(String token, int remaining) {
+        this.updateRemainingGeneric(token, remaining, OAuth2Credential::getUserId, this::getClipBucket);
+    }
+
+    public void markDepletedBanBucket(String channelId) {
+        // Called upon a 429 for banUser or unbanUser
+        Bucket modBucket = this.getModerationBucket(channelId);
+        modBucket.consumeIgnoringRateLimits(Math.max(modBucket.tryConsumeAsMuchAsPossible(), 1)); // intentionally go negative to induce a pause
+    }
+
+    private void updateRemainingGeneric(String token, int remaining, Function<OAuth2Credential, String> credToKey, Function<String, Bucket> keyToBucket) {
+        OAuth2Credential credential = interceptor.getAccessTokenCache().getIfPresent(token);
+        if (credential == null) return;
+
+        String key = credToKey.apply(credential);
+        if (key == null) return;
+
+        Bucket bucket = keyToBucket.apply(key);
+        long diff = bucket.getAvailableTokens() - remaining;
+        if (diff > 0) bucket.tryConsumeAsMuchAsPossible(diff);
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
@@ -1,0 +1,120 @@
+package com.github.twitch4j.helix.interceptor;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public final class TwitchHelixTokenManager {
+
+    private static final String CLIENT_ID_CONTEXT = "client_id";
+
+    /**
+     * Access token cache
+     */
+    private final Cache<String, OAuth2Credential> accessTokenCache = Caffeine.newBuilder()
+        .expireAfterAccess(15, TimeUnit.MINUTES)
+        .maximumSize(10_000)
+        .build();
+
+    /**
+     * Reference to the twitch identity provider
+     */
+    private final TwitchIdentityProvider twitchIdentityProvider;
+
+    /**
+     * The client id provided in the helix builder
+     */
+    private final String clientId;
+
+    /**
+     * The client secret provided in the helix builder
+     */
+    private final String clientSecret;
+
+    /**
+     * The client id associated with defaultAuthToken
+     */
+    @Getter(AccessLevel.PACKAGE)
+    private volatile String defaultClientId;
+
+    /**
+     * The default token that is used if no access token was directly provided to a helix call
+     */
+    private volatile OAuth2Credential defaultAuthToken;
+
+    public TwitchHelixTokenManager(String clientId, String clientSecret, OAuth2Credential defaultAuthToken) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.twitchIdentityProvider = new TwitchIdentityProvider(clientId, clientSecret, null);
+        this.defaultClientId = clientId;
+        this.defaultAuthToken = defaultAuthToken;
+
+        if (defaultAuthToken != null) {
+            twitchIdentityProvider.getAdditionalCredentialInformation(defaultAuthToken).ifPresent(oauth -> {
+                populateCache(oauth);
+                this.defaultClientId = extractClientId(oauth);
+                this.defaultAuthToken = oauth;
+            });
+        }
+    }
+
+    OAuth2Credential getDefaultAuthToken() {
+        if (defaultAuthToken == null) {
+            synchronized (this) {
+                if (defaultAuthToken == null) {
+                    checkClientCredentialsParameters();
+                    OAuth2Credential token = twitchIdentityProvider.getAppAccessToken();
+                    populateCache(token);
+                    this.defaultClientId = (String) token.getContext().computeIfAbsent(CLIENT_ID_CONTEXT, s -> clientId);
+                    return this.defaultAuthToken = token;
+                }
+            }
+        }
+
+        return defaultAuthToken;
+    }
+
+    @Nullable
+    OAuth2Credential getIfPresent(@NotNull String accessToken) {
+        return accessTokenCache.getIfPresent(accessToken);
+    }
+
+    @NotNull
+    OAuth2Credential getOrPopulateCache(@NotNull String accessToken) {
+        OAuth2Credential verifiedCredential = getIfPresent(accessToken);
+
+        if (verifiedCredential == null) {
+            log.debug("Getting matching client-id for authorization token {}", accessToken.substring(0, 5));
+            verifiedCredential = twitchIdentityProvider
+                .getAdditionalCredentialInformation(new OAuth2Credential(twitchIdentityProvider.getProviderName(), accessToken))
+                .orElseThrow(() -> new RuntimeException("Failed to get the client_id for the provided authentication token, the authentication token may be invalid!"));
+            populateCache(verifiedCredential);
+        }
+
+        return verifiedCredential;
+    }
+
+    private void populateCache(@NotNull OAuth2Credential enrichedCredential) {
+        accessTokenCache.put(enrichedCredential.getAccessToken(), enrichedCredential);
+    }
+
+    private void checkClientCredentialsParameters() {
+        if (StringUtils.isEmpty(defaultClientId) || StringUtils.isEmpty(clientSecret) || clientSecret.charAt(0) == '*')
+            throw new RuntimeException("Necessary OAuth token was missing from Helix call, without the means to generate one!");
+    }
+
+    static String extractClientId(@NotNull OAuth2Credential credential) {
+        return (String) credential.getContext().get(CLIENT_ID_CONTEXT);
+    }
+
+}

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenErrorDecoder.java
@@ -15,6 +15,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 @Slf4j
@@ -42,15 +43,15 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
      * Overwrite the Decode Method to handle custom error cases
      *
      * @param methodKey Method Key
-     * @param response Response
+     * @param response  Response
      * @return Exception
      */
     @Override
     public Exception decode(String methodKey, Response response) {
-        Exception ex = null;
+        Exception ex;
 
-        try {
-            String responseBody = response.body() == null ? "" : IOUtils.toString(response.body().asInputStream(), StandardCharsets.UTF_8.name());
+        try (InputStream is = response.body() == null ? null : response.body().asInputStream()) {
+            String responseBody = is == null ? "" : IOUtils.toString(is, StandardCharsets.UTF_8);
 
             if (response.status() == 401) {
                 ex = new UnauthorizedException()
@@ -63,10 +64,10 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
                     .addContextValue("requestMethod", response.request().httpMethod())
                     .addContextValue("responseBody", responseBody);
             } else if (response.status() == 429) {
-                ex = new ContextedRuntimeException("To many requests!")
+                ex = new ContextedRuntimeException("Too many requests!")
                     .addContextValue("requestUrl", response.request().url())
                     .addContextValue("requestMethod", response.request().httpMethod())
-                    .addContextValue("responseBody", responseBody);;
+                    .addContextValue("responseBody", responseBody);
             } else if (response.status() == 503) {
                 // If you get an HTTP 503 (Service Unavailable) error, retry once.
                 // If that retry also results in an HTTP 503, there probably is something wrong with the downstream service.
@@ -80,7 +81,8 @@ public class TwitchKrakenErrorDecoder implements ErrorDecoder {
                     .addContextValue("responseBody", responseBody)
                     .addContextValue("errorType", error.getError())
                     .addContextValue("errorStatus", error.getStatus())
-                    .addContextValue("errorType", error.getMessage());
+                    .addContextValue("errorType", error.getMessage())
+                    .addContextValue("errorMessage", error.getMessage());
             }
         } catch (IOException fallbackToDefault) {
             ex = defaultDecoder.decode(methodKey, response);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Prevents 429's from some helix endpoints with special undocumented rate limits
* Prevents 429's from consistently hammering (general) helix endpoints (due to refill rate asymmetry)

### Changes Proposed
* Restrict `banUser`/`unbanUser` calls to 100/30 bucket per channel
* Restrict `addBlockedTerm`/`removeBlockedTerm` calls to 60/60 bucket per channel
* Restrict `createClip` calls to 600/60 bucket per user
* Reduce helix bucket *refill* rate to 600/60
* Allow users to override the global helix ratelimit (to be less than 800/60, for example)
* Fix resource leak in error decoders
