### PR TITLE
feat: add secondary per-channel irc message limit

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -33,6 +33,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -279,7 +280,7 @@ public class TwitchChat implements ITwitchChat {
 
         // init per channel message buckets by channel name
         this.bucketByChannelName = Caffeine.newBuilder()
-            .expireAfterAccess(perChannelRateLimit.getRefillPeriodNanos(), TimeUnit.NANOSECONDS)
+            .expireAfterAccess(Math.max(perChannelRateLimit.getRefillPeriodNanos(), Duration.ofSeconds(30L).toNanos()), TimeUnit.NANOSECONDS)
             .build();
 
         // init connection

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -162,7 +162,7 @@ public class TwitchChatBuilder {
     /**
      * Custom RateLimit for Messages per Channel
      * <p>
-     * For example, this can restrict messages per channel at 100/30 for a verified bot that has a global 7500/30 message limit.
+     * For example, this can restrict messages per channel at 100/30 (for a verified bot that has a global 7500/30 message limit).
      */
     @With
     protected Bandwidth perChannelRateLimit = TwitchChatLimitHelper.MOD_MESSAGE_LIMIT.withId("per-channel-limit");

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -160,6 +160,14 @@ public class TwitchChatBuilder {
     protected Bandwidth authRateLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
     /**
+     * Custom RateLimit for Messages per Channel
+     * <p>
+     * For example, this can restrict messages per channel at 100/30 for a verified bot that has a global 7500/30 message limit.
+     */
+    @With
+    protected Bandwidth perChannelRateLimit = TwitchChatLimitHelper.MOD_MESSAGE_LIMIT.withId("per-channel-limit");
+
+    /**
      * Shared bucket for messages
      */
     @With
@@ -302,8 +310,11 @@ public class TwitchChatBuilder {
         if (ircAuthBucket == null)
             ircAuthBucket = userId == null ? BucketUtils.createBucket(this.authRateLimit) : TwitchLimitRegistry.getInstance().getOrInitializeBucket(userId, TwitchLimitType.CHAT_AUTH_LIMIT, Collections.singletonList(authRateLimit));
 
+        if (perChannelRateLimit == null)
+            perChannelRateLimit = chatRateLimit;
+
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.websocketConnection, this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod, this.connectionBackoffStrategy);
+        return new TwitchChat(this.websocketConnection, this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod, this.connectionBackoffStrategy, this.perChannelRateLimit);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -97,6 +97,14 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
     protected Bandwidth authRateLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
     /**
+     * Custom RateLimit for Messages per Channel
+     * <p>
+     * For example, this can restrict messages per channel at 100/30 (for a verified bot that has a global 7500/30 message limit).
+     */
+    @Builder.Default
+    protected Bandwidth perChannelRateLimit = TwitchChatLimitHelper.MOD_MESSAGE_LIMIT.withId("per-channel-limit");
+
+    /**
      * WebSocket Connection Backoff Strategy
      */
     @Builder.Default
@@ -263,6 +271,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
                 .withWhisperRateLimit(whisperRateLimit)
                 .withJoinRateLimit(joinRateLimit)
                 .withAuthRateLimit(authRateLimit)
+                .withPerChannelRateLimit(perChannelRateLimit)
                 .withAutoJoinOwnChannel(false) // user will have to manually send a subscribe call to enable whispers. this avoids duplicating whisper events
                 .withConnectionBackoffStrategy(connectionBackoffStrategy)
         ).build();

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -198,6 +198,14 @@ public class TwitchClientBuilder {
     protected Bandwidth chatAuthLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
     /**
+     * Custom RateLimit for Messages per Channel
+     * <p>
+     * For example, this can restrict messages per channel at 100/30 (for a verified bot that has a global 7500/30 message limit).
+     */
+    @With
+    protected Bandwidth chatChannelMessageLimit = TwitchChatLimitHelper.MOD_MESSAGE_LIMIT.withId("per-channel-limit");
+
+    /**
      * Wait time for taking items off chat queue in milliseconds. Default recommended
      */
     @With
@@ -423,6 +431,7 @@ public class TwitchClientBuilder {
                 .withWhisperRateLimit(chatWhisperLimit)
                 .withJoinRateLimit(chatJoinLimit)
                 .withAuthRateLimit(chatAuthLimit)
+                .withPerChannelRateLimit(chatChannelMessageLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -215,6 +215,14 @@ public class TwitchClientPoolBuilder {
     protected Bandwidth chatAuthLimit = TwitchChatLimitHelper.USER_AUTH_LIMIT;
 
     /**
+     * Custom RateLimit for Messages per Channel
+     * <p>
+     * For example, this can restrict messages per channel at 100/30 (for a verified bot that has a global 7500/30 message limit).
+     */
+    @With
+    protected Bandwidth chatChannelMessageLimit = TwitchChatLimitHelper.MOD_MESSAGE_LIMIT.withId("per-channel-limit");
+
+    /**
      * Wait time for taking items off chat queue in milliseconds. Default recommended
      */
     @With
@@ -439,6 +447,7 @@ public class TwitchClientPoolBuilder {
                 .whisperRateLimit(chatWhisperLimit)
                 .joinRateLimit(chatJoinLimit)
                 .authRateLimit(chatAuthLimit)
+                .perChannelRateLimit(chatChannelMessageLimit)
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
                 .maxSubscriptionsPerConnection(maxChannelsPerChatInstance)
@@ -463,6 +472,7 @@ public class TwitchClientPoolBuilder {
                 .withWhisperRateLimit(chatWhisperLimit)
                 .withJoinRateLimit(chatJoinLimit)
                 .withAuthRateLimit(chatAuthLimit)
+                .withPerChannelRateLimit(chatChannelMessageLimit)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withBaseUrl(chatServer)
                 .withChatQueueTimeout(chatQueueTimeout)


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add the ability to restrict/customize chat message limit at the channel level (rather than globally/across channels)

### Additional Information
* Does *not* implement channel-specific limits (e.g., I want 100/30 in channelX but 20/30 in channelY) -- this is probably too niche for the library to implement (and may falsely give the impression that 100/30 and 20/30 can simultaneously be used to comply with mod & non-mod limits for unverified bots at a channel level)
* More recently verified bots no longer bypass 100/30, so forcing 100/30 per-channel compliance while allowing 7500/30 global limit is desirable
* Even for unverified bots, can be useful to restrict each channel to something lower (e.g., 10/30) so it is harder for one channel to consume the global message limit
