### PR TITLE
chore: deprecate friends and chant pubsub

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -219,7 +219,14 @@ public interface ITwitchPubSub extends AutoCloseable {
         return listenOnTopic(PubSubType.LISTEN, credential, "creator-goals-events-v1." + channelId);
     }
 
+    /**
+     * @param credential {@link OAuth2Credential}
+     * @param channelId  channel id
+     * @return PubSubSubscription
+     * @deprecated the crowd chant experiment was disabled by <a href="https://twitter.com/twitchsupport/status/1486036628523073539">Twitch</a> on 2022-02-02
+     */
     @Unofficial
+    @Deprecated
     default PubSubSubscription listenForCrowdChantEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "crowd-chant-channel-v1." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -458,7 +458,14 @@ public interface ITwitchPubSub extends AutoCloseable {
         return listenOnTopic(PubSubType.LISTEN, credential, "following." + channelId);
     }
 
+    /**
+     * @param credential user access token
+     * @param userId     user id associated with the token
+     * @return PubSubSubscription
+     * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+     */
     @Unofficial
+    @Deprecated
     default PubSubSubscription listenForFriendshipEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "friendship." + userId);
     }
@@ -478,7 +485,14 @@ public interface ITwitchPubSub extends AutoCloseable {
         return listenOnTopic(PubSubType.LISTEN, credential, "polls." + channelId);
     }
 
+    /**
+     * @param credential user access token
+     * @param userId     user id associated with the token
+     * @return PubSubSubscription
+     * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+     */
     @Unofficial
+    @Deprecated
     default PubSubSubscription listenForPresenceEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "presence." + userId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CrowdChant.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CrowdChant.java
@@ -6,8 +6,12 @@ import lombok.Setter;
 
 import java.time.Instant;
 
+/**
+ * @deprecated the crowd chant experiment was disabled by <a href="https://twitter.com/twitchsupport/status/1486036628523073539">Twitch</a> on 2022-02-02
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class CrowdChant {
     private String id;
     private String channelId;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
@@ -7,12 +7,20 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+ */
 @Data
+@Deprecated
 public class FriendshipData {
     private String userId;
     private String targetUserId;
     private Change change;
 
+    /**
+     * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+     */
+    @Deprecated
     public enum Change {
         ACCEPTED,
         REJECTED,

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceData.java
@@ -6,7 +6,11 @@ import lombok.Data;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+ */
 @Data
+@Deprecated
 public class PresenceData {
     private String userId;
     private String userLogin;
@@ -19,7 +23,11 @@ public class PresenceData {
     private Activity activity;
     private List<Activity> activities;
 
+    /**
+     * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+     */
     @Data
+    @Deprecated
     public static class Activity {
         /**
          * Activity Type. Examples include: "none", "watching", "broadcasting"

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceSettings.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PresenceSettings.java
@@ -2,7 +2,11 @@ package com.github.twitch4j.pubsub.domain;
 
 import lombok.Data;
 
+/**
+ * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+ */
 @Data
+@Deprecated
 public class PresenceSettings {
     private Boolean shareActivity;
     private String availabilityOverride;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CrowdChantCreatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CrowdChantCreatedEvent.java
@@ -9,9 +9,13 @@ import lombok.Setter;
 
 import java.time.Instant;
 
+/**
+ * @deprecated the crowd chant experiment was disabled by <a href="https://twitter.com/twitchsupport/status/1486036628523073539">Twitch</a> on 2022-02-02
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class CrowdChantCreatedEvent extends TwitchEvent {
     private Instant timestamp;
     private CrowdChant crowdChant;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/FriendshipEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/FriendshipEvent.java
@@ -5,8 +5,12 @@ import com.github.twitch4j.pubsub.domain.FriendshipData;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+/**
+ * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+ */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@Deprecated
 public class FriendshipEvent extends TwitchEvent {
     private final FriendshipData data;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PresenceSettingsEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PresenceSettingsEvent.java
@@ -5,8 +5,12 @@ import com.github.twitch4j.pubsub.domain.PresenceSettings;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+/**
+ * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+ */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@Deprecated
 public class PresenceSettingsEvent extends TwitchEvent {
     private final String userId;
     private final PresenceSettings data;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPresenceEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/UserPresenceEvent.java
@@ -5,8 +5,12 @@ import com.github.twitch4j.pubsub.domain.PresenceData;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+/**
+ * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
+ */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@Deprecated
 public class UserPresenceEvent extends TwitchEvent {
     private final PresenceData data;
 }

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensions.java
@@ -22,6 +22,7 @@ import java.util.Map;
  * @see <a href="https://discuss.dev.twitch.tv/t/how-extensions-are-affected-by-the-legacy-twitch-api-v5-shutdown/32708">Twitch Shutdown Announcement</a>
  * @deprecated the Extensions API traditionally uses the decommissioned Kraken API. While the module now forwards calls to Helix, please migrate to using Helix directly as this module will be removed in the future.
  */
+@Deprecated
 public interface TwitchExtensions {
 
     /**

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
@@ -41,7 +41,6 @@ public class UsersServiceTest extends AbstractEndpointTest {
             assertEquals(user.getDisplayName(), "twitch4j", "Twitch4J user display name should be twitch4j!");
             assertEquals(user.getType(), "", "Type should be empty!");
             assertEquals(user.getBroadcasterType(), "", "broadcaster-type should be empty!");
-            assertTrue(user.getViewCount() > 0, "Views should be grater than 0!");
             assertEquals(Instant.parse("2017-03-02T12:09:38.184103Z"), user.getCreatedAt());
         });
     }

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
@@ -124,6 +124,7 @@ public class TwitchClient implements ITwitchClient {
      *
      * @return TwitchExtensions
      */
+    @Deprecated
     public TwitchExtensions getExtensions() {
         if (this.extensions == null) {
             throw new RuntimeException("You have not enabled the Extensions Module! Please check out the documentation on Twitch4J -> Extensions.");

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPool.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPool.java
@@ -117,6 +117,7 @@ public class TwitchClientPool implements ITwitchClient {
      *
      * @return TwitchExtensions
      */
+    @Deprecated
     public TwitchExtensions getExtensions() {
         if (this.extensions == null) {
             throw new RuntimeException("You have not enabled the Extensions Module! Please check out the documentation on Twitch4J -> Extensions.");


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate unofficial friendship pubsub topic
* Deprecate unofficial presence pubsub topic
* Deprecate unofficial crowd chant pubsub topic
* Remove deprecated `User#getViewCount` from helix test
* More deprecated annotations for extensions module

### Additional Information
https://help.twitch.tv/s/article/how-to-use-the-friends-feature
https://twitch.uservoice.com/forums/310201-chat/suggestions/43451310--test-crowd-chant
