### PR TITLE
feat: parse new prediction badges over irc

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -313,6 +313,30 @@ public class IRCMessageEvent extends TwitchEvent {
         return OptionalInt.empty();
     }
 
+    /**
+     * @return the index of the choice this user is predicting, in an optional wrapper
+     */
+    public OptionalInt getPredictedChoiceIndex() {
+        String predictions = badges.get("predictions");
+
+        if (predictions != null) {
+            int delim = predictions.indexOf('-');
+            try {
+                return OptionalInt.of(Integer.parseInt(predictions.substring(delim + 1)));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return OptionalInt.empty();
+    }
+
+    /**
+     * @return the title of the choice this user is predicting, in an optional wrapper
+     */
+    public Optional<String> getPredictedChoiceTitle() {
+        return Optional.ofNullable(badgeInfo.get("predictions")).map(EscapeUtils::unescapeTagValue);
+    }
+
 	/**
 	 * Gets a optional tag from the irc message
      *

--- a/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/CommandPermission.java
@@ -47,12 +47,14 @@ public enum CommandPermission {
     CURRENT_HYPE_TRAIN_CONDUCTOR,
 
     /**
-     * Participated in the most recent predictions event for the blue/first option
+     * Participated in the most recent predictions event for a blue option
+     * <p>
+     * Warning: when there are three or more prediction choices, they are all blue
      */
     PREDICTIONS_BLUE,
 
     /**
-     * Participated in the most recent predictions event for the pink/second option
+     * Participated in the most recent predictions event for a pink option
      */
     PREDICTIONS_PINK,
 

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -58,7 +58,7 @@ public class TwitchUtils {
                 permissionSet.add(CommandPermission.MODERATOR);
             }
             // Partner
-            if (badges.containsKey("partner")) {
+            if (badges.containsKey("partner") || badges.containsKey("ambassador")) {
                 permissionSet.add(CommandPermission.PARTNER);
             }
             // VIP
@@ -112,10 +112,9 @@ public class TwitchUtils {
             String predictionBadge = badges.get("predictions");
             if (StringUtils.isNotEmpty(predictionBadge)) {
                 char first = predictionBadge.charAt(0);
-                char last = predictionBadge.charAt(predictionBadge.length() - 1);
-                if (first == 'b' || last == '1') {
+                if (first == 'b') {
                     permissionSet.add(CommandPermission.PREDICTIONS_BLUE);
-                } else if (first == 'p' || last == '2') {
+                } else if (first == 'p') {
                     permissionSet.add(CommandPermission.PREDICTIONS_PINK);
                 }
             }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChannelPointsReward.java
@@ -30,6 +30,7 @@ public class ChannelPointsReward {
 	private GlobalCooldown globalCooldown;
 	private Integer redemptionsRedeemedCurrentStream;
 	private Instant cooldownExpiresAt;
+    private String templateId;
 
 	@Data
 	public static class Image {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `IRCMessageEvent#getPredictedChoiceIndex`
* Add `IRCMessageEvent#getPredictedChoiceTitle`
* Clarify docs for `PREDICTIONS_BLUE`/`PREDICTIONS_PINK`

Unrelated:
* Parse ambassador badge as partner
* Add `templateId` to unofficial pubsub `ChannelPointsReward`

### Additional Information
Predictions now can have 2-10 options https://help.twitch.tv/s/article/channel-points-predictions?language=en_US#creatorfaq
