### PR TITLE
feat: add clip creation event fired by client helper

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/PaginationUtil.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/PaginationUtil.java
@@ -1,0 +1,57 @@
+package com.github.twitch4j.common.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@UtilityClass
+public class PaginationUtil {
+
+    public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> extractResult, Function<K, String> extractCursor, int maxPages, int maxElements, Supplier<C> collectionFactory, boolean strict) {
+        final C collection = collectionFactory.get();
+
+        Set<String> cursors = strict ? new HashSet<>(maxPages) : null;
+        String cursor = null;
+        int page = 0;
+        do {
+            final K call = callByCursor.apply(cursor);
+            page++;
+            if (call == null) break;
+
+            final Collection<T> results = extractResult.apply(call);
+            if (results == null || results.isEmpty()) break;
+            collection.addAll(results);
+
+            final String next = extractCursor.apply(call);
+            if (Objects.equals(next, cursor)) break; // we got the same cursor back; avoid infinite loop
+            if (strict && cursor != null && !cursors.add(cursor)) break; // we've already seen this cursor in the past; avoid infinite loop
+            cursor = next;
+        } while (cursor != null && !cursor.isEmpty() && page < maxPages && collection.size() < maxElements);
+
+        return collection;
+    }
+
+    public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall, int maxPages, int maxElements, Supplier<C> createCollection) {
+        return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, maxPages, maxElements, createCollection, false);
+    }
+
+    public static <T, K> List<T> getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall, int maxPages, int maxElements) {
+        return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, maxPages, maxElements, ArrayList::new);
+    }
+
+    public static <T, K> List<T> getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall, int maxPages) {
+        return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, maxPages, Integer.MAX_VALUE);
+    }
+
+    public static <T, K> List<T> getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall) {
+        return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, Integer.MAX_VALUE);
+    }
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/PaginationUtil.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/PaginationUtil.java
@@ -14,8 +14,33 @@ import java.util.function.Supplier;
 @UtilityClass
 public class PaginationUtil {
 
-    public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> extractResult, Function<K, String> extractCursor, int maxPages, int maxElements, Supplier<C> collectionFactory, boolean strict) {
-        final C collection = collectionFactory.get();
+    /**
+     * Obtains a full (user-specified) collection of results from paginated calls, up to a max number of pages and elements, while optionally avoiding duplicate cursors.
+     * <p>
+     * Implementation notes:
+     * <ul>
+     * <li>strict mode involves more memory usage but can avoid unnecessary loops when max pages and elements are high and the call can yield undesirable duplicate cursors</li>
+     * <li>even without strict mode, this checks that the next cursor does not equal the previous cursor to avoid some loops while reducing memory footprint</li>
+     * <li>the max elements constraint can be marginally violated when the final page of results had enough elements to go beyond this threshold</li>
+     * <li>pagination stops if any threshold is met (it does not wait for both the max pages and max elements thresholds to be exceeded)</li>
+     * <li>null or empty cursors yielded from a call end further pagination</li>
+     * <li>the first call executed is done with a null cursor</li>
+     * </ul>
+     *
+     * @param callByCursor     Performs a query based on the string cursor (which is initially null)
+     * @param extractResult    Yields the results contained in the executed call
+     * @param extractCursor    Yields the next cursor to paginate on (or null to cease pagination)
+     * @param maxPages         The maximum number of pages to paginate over
+     * @param maxElements      The (approximate) maximum number of elements that can be queried
+     * @param createCollection The supplier of the collection to store the paginated results
+     * @param strict           Whether pagination should stop upon encountering an already-seen cursor
+     * @param <T>              Result unit class
+     * @param <K>              Container class of results and pagination information
+     * @param <C>              The type of collection that should be used to store the result units
+     * @return the paginated results
+     */
+    public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> extractResult, Function<K, String> extractCursor, int maxPages, int maxElements, Supplier<C> createCollection, boolean strict) {
+        final C collection = createCollection.get();
 
         Set<String> cursors = strict ? new HashSet<>(maxPages) : null;
         String cursor = null;
@@ -38,18 +63,69 @@ public class PaginationUtil {
         return collection;
     }
 
+    /**
+     * Obtains a full (user-specified) collection of results from paginated calls, up to a max number of pages and elements.
+     *
+     * @param callByCursor       Performs a query based on the string cursor (which is initially null)
+     * @param resultsFromCall    Yields the results contained in the executed call
+     * @param nextCursorFromCall Yields the next cursor to paginate on (or null to cease pagination)
+     * @param maxPages           The maximum number of pages to paginate over
+     * @param maxElements        The (approximate) maximum number of elements that can be queried
+     * @param createCollection   The supplier of the collection to store the paginated results
+     * @param <T>                Result unit class
+     * @param <K>                Container class of results and pagination information
+     * @param <C>                The type of collection that should be used to store the result units
+     * @return the paginated results
+     * @see #getPaginated(Function, Function, Function, int, int, Supplier, boolean)
+     */
     public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall, int maxPages, int maxElements, Supplier<C> createCollection) {
         return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, maxPages, maxElements, createCollection, false);
     }
 
+    /**
+     * Obtains a full list of results from paginated calls, up to a max number of pages and elements.
+     *
+     * @param callByCursor       Performs a query based on the string cursor (which is initially null)
+     * @param resultsFromCall    Yields the results contained in the executed call
+     * @param nextCursorFromCall Yields the next cursor to paginate on (or null to cease pagination)
+     * @param maxPages           The maximum number of pages to paginate over
+     * @param maxElements        The (approximate) maximum number of elements that can be queried
+     * @param <T>                Result unit class
+     * @param <K>                Container class of results and pagination information
+     * @return the paginated results
+     * @see #getPaginated(Function, Function, Function, int, int, Supplier, boolean)
+     */
     public static <T, K> List<T> getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall, int maxPages, int maxElements) {
         return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, maxPages, maxElements, ArrayList::new);
     }
 
+    /**
+     * Obtains a full list of results from paginated calls, up to a max number of pages.
+     *
+     * @param callByCursor       Performs a query based on the string cursor (which is initially null)
+     * @param resultsFromCall    Yields the results contained in the executed call
+     * @param nextCursorFromCall Yields the next cursor to paginate on (or null to cease pagination)
+     * @param maxPages           The maximum number of pages to paginate over
+     * @param <T>                Result unit class
+     * @param <K>                Container class of results and pagination information
+     * @return the paginated results
+     * @see #getPaginated(Function, Function, Function, int, int, Supplier, boolean)
+     */
     public static <T, K> List<T> getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall, int maxPages) {
         return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, maxPages, Integer.MAX_VALUE);
     }
 
+    /**
+     * Obtains a full list of results from paginated calls.
+     *
+     * @param callByCursor       Performs a query based on the string cursor (which is initially null)
+     * @param resultsFromCall    Yields the results contained in the executed call
+     * @param nextCursorFromCall Yields the next cursor to paginate on (or null to cease pagination)
+     * @param <T>                Result unit class
+     * @param <K>                Container class of results and pagination information
+     * @return the paginated results
+     * @see #getPaginated(Function, Function, Function, int, int, Supplier, boolean)
+     */
     public static <T, K> List<T> getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> resultsFromCall, Function<K, String> nextCursorFromCall) {
         return getPaginated(callByCursor, resultsFromCall, nextCursorFromCall, Integer.MAX_VALUE);
     }

--- a/common/src/main/java/com/github/twitch4j/common/util/PaginationUtil.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/PaginationUtil.java
@@ -42,7 +42,7 @@ public class PaginationUtil {
     public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> extractResult, Function<K, String> extractCursor, int maxPages, int maxElements, Supplier<C> createCollection, boolean strict) {
         final C collection = createCollection.get();
 
-        Set<String> cursors = strict ? new HashSet<>(maxPages) : null;
+        Set<String> cursors = strict ? new HashSet<>(Math.max(16, Math.min(maxPages, 1024))) : null;
         String cursor = null;
         int page = 0;
         do {
@@ -58,7 +58,7 @@ public class PaginationUtil {
             if (Objects.equals(next, cursor)) break; // we got the same cursor back; avoid infinite loop
             if (strict && cursor != null && !cursors.add(cursor)) break; // we've already seen this cursor in the past; avoid infinite loop
             cursor = next;
-        } while (cursor != null && !cursor.isEmpty() && page < maxPages && collection.size() < maxElements);
+        } while (cursor != null && !cursor.isEmpty() && (maxPages < 0 || page < maxPages) && (maxElements < 0 || collection.size() < maxElements));
 
         return collection;
     }

--- a/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
@@ -8,6 +8,7 @@ import com.github.twitch4j.helix.domain.User;
 import com.github.twitch4j.helix.domain.UserList;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -56,13 +57,14 @@ public interface IClientHelper extends AutoCloseable {
     boolean disableFollowEventListenerForId(String channelId);
 
     /**
-     * Enable Clip Creation Listener, without invoking a Helix API call
+     * Enable Clip Creation Listener, without invoking a Helix API call, starting at a custom timestamp
      *
      * @param channelId   Channel Id
      * @param channelName Channel Name
+     * @param startedAt   The oldest clip creation timestamp to start the queries at
      * @return whether the channel was added
      */
-    boolean enableClipEventListener(String channelId, String channelName);
+    boolean enableClipEventListener(String channelId, String channelName, Instant startedAt);
 
     /**
      * Disable Clip Creation Listener, without invoking a Helix API call
@@ -213,6 +215,17 @@ public interface IClientHelper extends AutoCloseable {
             UserList users = getTwitchHelix().getUsers(null, null, channels).execute();
             users.getUsers().forEach(user -> disableFollowEventListenerForId(user.getId()));
         });
+    }
+
+    /**
+     * Enable Clip Creation Listener, without invoking a Helix API call
+     *
+     * @param channelId   Channel Id
+     * @param channelName Channel Name
+     * @return whether the channel was added
+     */
+    default boolean enableClipEventListener(String channelId, String channelName) {
+        return enableClipEventListener(channelId, channelName, Instant.now());
     }
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
@@ -56,6 +56,23 @@ public interface IClientHelper {
     boolean disableFollowEventListenerForId(String channelId);
 
     /**
+     * Enable Clip Creation Listener, without invoking a Helix API call
+     *
+     * @param channelId   Channel Id
+     * @param channelName Channel Name
+     * @return whether the channel was added
+     */
+    boolean enableClipEventListener(String channelId, String channelName);
+
+    /**
+     * Disable Clip Creation Listener, without invoking a Helix API call
+     *
+     * @param channelId Channel Id
+     * @return whether a previously-tracked channel was removed
+     */
+    boolean disableClipEventListenerForId(String channelId);
+
+    /**
      * Get cached information for a channel's stream status and follower count.
      * <p>
      * For this information to be valid, the respective event listeners need to be enabled for the channel.

--- a/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import static com.github.twitch4j.TwitchClientHelper.MAX_LIMIT;
 import static com.github.twitch4j.TwitchClientHelper.log;
 
-public interface IClientHelper {
+public interface IClientHelper extends AutoCloseable {
 
     TwitchHelix getTwitchHelix();
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -444,14 +444,15 @@ public class TwitchClientHelper implements IClientHelper {
     }
 
     @Override
-    public boolean enableClipEventListener(String channelId, String channelName) {
+    public boolean enableClipEventListener(String channelId, String channelName, Instant startedAt) {
         // add to set
         final boolean add = listenForClips.add(channelId);
         if (!add) {
             log.info("Channel {} already added for Clip Creation Events", channelName);
         } else {
             // initialize cache
-            channelInformation.get(channelId, s -> new ChannelCache(channelName));
+            ChannelCache channelCache = channelInformation.get(channelId, s -> new ChannelCache(channelName));
+            channelCache.getClipWindowStart().compareAndSet(null, startedAt);
         }
         startOrStopEventGenerationThread();
         return add;

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -52,7 +52,7 @@ import java.util.function.UnaryOperator;
 /**
  * A helper class that covers a few basic use cases of most library users
  */
-public class TwitchClientHelper implements IClientHelper, AutoCloseable {
+public class TwitchClientHelper implements IClientHelper {
 
     static final Logger log = LoggerFactory.getLogger(TwitchClientHelper.class);
 
@@ -582,8 +582,13 @@ public class TwitchClientHelper implements IClientHelper, AutoCloseable {
         if (followerFuture != null)
             followerFuture.cancel(false);
 
+        final Future<?> clipFuture = this.clipEventFuture.getAndSet(null);
+        if (clipFuture != null)
+            clipFuture.cancel(false);
+
         listenForGoLive.clear();
         listenForFollow.clear();
+        listenForClips.clear();
         channelInformation.invalidateAll();
     }
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -366,7 +366,8 @@ public class TwitchClientHelper implements IClientHelper {
 
                 // next clip window should start just after the most recent clip we've seen for this channel
                 final Instant nextStartedAt = maxCreatedAt;
-                windowStart.updateAndGet(old -> old == null || old.compareTo(nextStartedAt) < 0 ? nextStartedAt : old);
+                if (nextStartedAt != startedAt)
+                    windowStart.updateAndGet(old -> old == null || old.compareTo(nextStartedAt) < 0 ? nextStartedAt : old);
             }
 
             return nextRequestCanBeImmediate;

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -9,7 +9,7 @@ import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import com.github.twitch4j.common.util.CollectionUtils;
 import com.github.twitch4j.common.util.ExponentialBackoffStrategy;
-import com.github.twitch4j.common.util.PaginationUtil;
+import com.github.twitch4j.util.PaginationUtil;
 import com.github.twitch4j.domain.ChannelCache;
 import com.github.twitch4j.events.ChannelChangeGameEvent;
 import com.github.twitch4j.events.ChannelChangeTitleEvent;

--- a/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/domain/ChannelCache.java
@@ -51,6 +51,11 @@ public class ChannelCache {
     private final AtomicReference<Integer> followers = new AtomicReference<>();
 
     /**
+     * Clip Query Started At
+     */
+    private final AtomicReference<Instant> clipWindowStart = new AtomicReference<>();
+
+    /**
      * Construct Channel Cache
      *
      * @param userName the name of the channel.

--- a/twitch4j/src/main/java/com/github/twitch4j/events/ChannelClipCreatedEvent.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/events/ChannelClipCreatedEvent.java
@@ -1,0 +1,42 @@
+package com.github.twitch4j.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.events.domain.EventUser;
+import com.github.twitch4j.helix.domain.Clip;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import java.util.Optional;
+
+/**
+ * Called when a new clip is created in a channel.
+ * <p>
+ * Fired by {@link com.github.twitch4j.TwitchClientHelper}; so this event must explicitly be enabled for specific channels.
+ * <p>
+ * Due to Twitch heavily caching the get clips endpoint, these creation events can have multi-minute delays.
+ *
+ * @see com.github.twitch4j.IClientHelper#enableClipEventListener(String, String)
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChannelClipCreatedEvent extends TwitchEvent {
+
+    /**
+     * The channel where the clip was created.
+     */
+    EventChannel channel;
+
+    /**
+     * The clip that was created.
+     */
+    Clip clip;
+
+    /**
+     * @return the user that created the clip
+     */
+    public Optional<EventUser> getCreatingUser() {
+        return Optional.ofNullable(clip.getCreatorId()).map(id -> new EventUser(id, clip.getCreatorName()));
+    }
+
+}

--- a/util/src/main/java/com/github/twitch4j/util/PaginationUtil.java
+++ b/util/src/main/java/com/github/twitch4j/util/PaginationUtil.java
@@ -1,4 +1,4 @@
-package com.github.twitch4j.common.util;
+package com.github.twitch4j.util;
 
 import lombok.experimental.UtilityClass;
 
@@ -9,13 +9,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 @UtilityClass
 public class PaginationUtil {
 
     /**
-     * Obtains a full (user-specified) collection of results from paginated calls, up to a max number of pages and elements, while optionally avoiding duplicate cursors.
+     * Obtains a full (user-specified) collection of results from paginated calls with arbitrary cursors, up to a max number of pages and elements, while optionally avoiding duplicate cursors.
      * <p>
      * Implementation notes:
      * <ul>
@@ -23,6 +24,56 @@ public class PaginationUtil {
      * <li>even without strict mode, this checks that the next cursor does not equal the previous cursor to avoid some loops while reducing memory footprint</li>
      * <li>the max elements constraint can be marginally violated when the final page of results had enough elements to go beyond this threshold</li>
      * <li>pagination stops if any threshold is met (it does not wait for both the max pages and max elements thresholds to be exceeded)</li>
+     * <li>null cursors yielded from a call end further pagination</li>
+     * </ul>
+     *
+     * @param callByCursor Performs a query based on the cursor
+     * @param getResult    Yields the results contained in the executed call
+     * @param getNext      Yields the next cursor to paginate on (or null to cease pagination)
+     * @param maxPages     The maximum number of pages to paginate over
+     * @param maxUnits     The (approximate) maximum number of elements that can be queried
+     * @param collector    The supplier of the collection to store the paginated results
+     * @param strict       Whether pagination should stop upon encountering an already-seen cursor
+     * @param first        The initial cursor to use in the first call
+     * @param valid        Whether a cursor is valid to be used in a subsequent call
+     * @param <T>          Result unit class
+     * @param <K>          Container class of results and pagination information
+     * @param <C>          The type of collection that should be used to store the result units
+     * @param <P>          The type of the cursor object; should implement equals and hashcode
+     * @return the paginated results
+     */
+    public static <T, K, C extends Collection<T>, P> C getPaginated(Function<P, K> callByCursor, Function<K, Collection<T>> getResult, Function<K, P> getNext, int maxPages, int maxUnits, Supplier<C> collector, boolean strict, P first, Predicate<P> valid) {
+        final C collection = collector.get();
+
+        Set<P> cursors = strict ? new HashSet<>(Math.max(16, Math.min(maxPages, 1024))) : null;
+        P cursor = first;
+        int page = 0;
+        do {
+            // Perform the call
+            final K call = callByCursor.apply(cursor);
+            page++;
+            if (call == null) break;
+
+            // Save the results
+            final Collection<T> results = getResult.apply(call);
+            if (results == null || results.isEmpty()) break;
+            collection.addAll(results);
+
+            // Obtain the cursor for the next call
+            final P next = getNext.apply(call);
+            if (Objects.equals(next, cursor)) break; // we got the same cursor back; avoid infinite loop
+            if (strict && next != null && !cursors.add(next)) break; // we've already seen this cursor in the past; avoid infinite loop
+            cursor = next;
+        } while (cursor != null && valid.test(cursor) && (maxPages < 0 || page < maxPages) && (maxUnits < 0 || collection.size() < maxUnits));
+
+        return collection;
+    }
+
+    /**
+     * Obtains a full (user-specified) collection of results from paginated calls, up to a max number of pages and elements, while optionally avoiding duplicate cursors.
+     * <p>
+     * Implementation notes:
+     * <ul>
      * <li>null or empty cursors yielded from a call end further pagination</li>
      * <li>the first call executed is done with a null cursor</li>
      * </ul>
@@ -38,29 +89,10 @@ public class PaginationUtil {
      * @param <K>              Container class of results and pagination information
      * @param <C>              The type of collection that should be used to store the result units
      * @return the paginated results
+     * @see #getPaginated(Function, Function, Function, int, int, Supplier, boolean, Object, Predicate)
      */
     public static <T, K, C extends Collection<T>> C getPaginated(Function<String, K> callByCursor, Function<K, Collection<T>> extractResult, Function<K, String> extractCursor, int maxPages, int maxElements, Supplier<C> createCollection, boolean strict) {
-        final C collection = createCollection.get();
-
-        Set<String> cursors = strict ? new HashSet<>(Math.max(16, Math.min(maxPages, 1024))) : null;
-        String cursor = null;
-        int page = 0;
-        do {
-            final K call = callByCursor.apply(cursor);
-            page++;
-            if (call == null) break;
-
-            final Collection<T> results = extractResult.apply(call);
-            if (results == null || results.isEmpty()) break;
-            collection.addAll(results);
-
-            final String next = extractCursor.apply(call);
-            if (Objects.equals(next, cursor)) break; // we got the same cursor back; avoid infinite loop
-            if (strict && cursor != null && !cursors.add(cursor)) break; // we've already seen this cursor in the past; avoid infinite loop
-            cursor = next;
-        } while (cursor != null && !cursor.isEmpty() && (maxPages < 0 || page < maxPages) && (maxElements < 0 || collection.size() < maxElements));
-
-        return collection;
+        return getPaginated(callByCursor, extractResult, extractCursor, maxPages, maxElements, createCollection, strict, null, s -> !s.isEmpty());
     }
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Create `ChannelClipCreatedEvent` and fire it from `TwitchClientHelper` (given the appropriate enable method was called)
* Create `IClientHelper`
* Create `PaginationUtil`

### Additional Information
Requested a few times on the discord; due to twitch caching, no events are fired for the first 5 mins & afterwards events are fired every ~minute (assuming new clips are being created)
