### PR TITLE
chore: disable circuit breaker on helix bans api

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -147,6 +147,10 @@ public class TwitchHelixBuilder {
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", getRequestQueueSize());
         ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", getRequestQueueSize());
 
+        // Hystrix: Ban/Unban API already has special 429 logic such that circuit breaking is not needed (and just trips on trivial errors like 'user is already banned')
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.TwitchHelix#banUser(String,String,String,BanUserInput).circuitBreaker.enabled", false);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.TwitchHelix#unbanUser(String,String,String,String).circuitBreaker.enabled", false);
+
         // Warning
         if (logLevel == Logger.Level.HEADERS || logLevel == Logger.Level.FULL) {
             log.warn("Helix: The current feign loglevel will print sensitive information including your access token, please don't share this log!");


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Disable Hystrix Circuit Breaker for TwitchHelix `banUser`/`unbanUser`

### Additional Information
In #561, we already implemented [special](https://github.com/twitch4j/twitch4j/blob/develop/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java#L79-L84) [logic](https://github.com/twitch4j/twitch4j/blob/develop/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixRateLimitTracker.java#L131-L136) to handle 429's from these endpoints that induces a pause in further requests.
However, twitch also throws errors from this endpoint in more states that can cause needless circuit break tripping (e.g., trying to (un)ban a bunch of users that are already (un)banned), so this PR disables this hystrix behavior for these specific commands
