### PR TITLE
feat: add eventsub fields from may 2022 update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ allprojects {
 				this as StandardJavadocDocletOptions
 				links(
 					"https://javadoc.io/doc/org.jetbrains/annotations/latest",
-					"https://javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.9.2",
+					"https://javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.9.3",
 					"https://commons.apache.org/proper/commons-configuration/javadocs/v1.10/apidocs",
 					"https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.5.0/",
 					"https://square.github.io/okhttp/4.x/okhttp/",

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelBanEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelBanEvent.java
@@ -25,6 +25,11 @@ public class ChannelBanEvent extends EventSubModerationEvent {
     private String reason;
 
     /**
+     * The UTC date and time (in RFC3339 format) of when the user was banned or put in a timeout.
+     */
+    private Instant bannedAt;
+
+    /**
      * Will be null if permanent ban. If it is a timeout, this field shows when the timeout will end.
      */
     @Nullable

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEndEvent.java
@@ -17,11 +17,6 @@ import java.time.Instant;
 public class HypeTrainEndEvent extends HypeTrainEvent {
 
     /**
-     * Current level of hype train event.
-     */
-    private Integer level;
-
-    /**
      * The timestamp at which the hype train ended.
      */
     private Instant endedAt;

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEvent.java
@@ -29,6 +29,11 @@ public abstract class HypeTrainEvent extends EventSubChannelEvent {
     private List<Contribution> topContributions;
 
     /**
+     * Current level of hype train event.
+     */
+    private Integer level;
+
+    /**
      * The timestamp at which the hype train started.
      */
     private Instant startedAt;

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainProgressEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainProgressEvent.java
@@ -18,11 +18,6 @@ import java.time.Instant;
 public class HypeTrainProgressEvent extends HypeTrainEvent {
 
     /**
-     * Current level of hype train event.
-     */
-    private Integer level;
-
-    /**
      * The number of points contributed to the hype train at the current level.
      */
     private Integer progress;

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserUpdateEvent.java
@@ -1,11 +1,13 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -19,6 +21,16 @@ public class UserUpdateEvent extends EventSubUserEvent {
      * Only included if you have the user:read:email scope for the user.
      */
     private String email;
+
+    /**
+     * A Boolean value that determines whether Twitch has verified the user’s email address.
+     * Is true if Twitch has verified the email address; otherwise, false.
+     * <p>
+     * Note from Twitch: Ignore this field if the email field contains an empty string.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("email_verified")
+    private Boolean isEmailVerified;
 
     /**
      * The user’s description.

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -29,7 +29,7 @@ public class EventSubEventTest {
     public void deserializeModerationEvent() {
         ChannelBanEvent event = jsonToObject(
             "{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\",\"moderator_user_id\":\"1339\"," +
-                "\"moderator_user_login\":\"mod_user\",\"moderator_user_name\":\"Mod_User\",\"reason\":\"Offensive language\",\"ends_at\":\"2020-07-15T18:16:11.17106713Z\",\"is_permanent\":false}",
+                "\"moderator_user_login\":\"mod_user\",\"moderator_user_name\":\"Mod_User\",\"reason\":\"Offensive language\",\"banned_at\":\"2020-07-15T18:15:11.17106713Z\",\"ends_at\":\"2020-07-15T18:16:11.17106713Z\",\"is_permanent\":false}",
             ChannelBanEvent.class
         );
 
@@ -46,6 +46,7 @@ public class EventSubEventTest {
         assertEquals("Mod_User", event.getModeratorUserName());
 
         assertEquals("Offensive language", event.getReason());
+        assertEquals(Instant.parse("2020-07-15T18:15:11.17106713Z"), event.getBannedAt());
         assertEquals(Instant.parse("2020-07-15T18:16:11.17106713Z"), event.getEndsAt());
         assertFalse(event.isPermanent());
     }
@@ -377,13 +378,14 @@ public class EventSubEventTest {
     @DisplayName("Deserialize UserUpdateEvent")
     public void deserializeComplexUserEvent() {
         UserUpdateEvent event = jsonToObject(
-            "{\"user_id\":\"1337\",\"user_name\":\"cool_user\",\"email\":\"user@email.com\",\"description\":\"cool description\"}",
+            "{\"user_id\":\"1337\",\"user_name\":\"cool_user\",\"email\":\"user@email.com\",\"email_verified\":true,\"description\":\"cool description\"}",
             UserUpdateEvent.class
         );
 
         assertEquals("1337", event.getUserId());
         assertEquals("cool_user", event.getUserName());
         assertEquals("user@email.com", event.getEmail());
+        assertTrue(event.isEmailVerified());
         assertEquals("cool description", event.getDescription());
     }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `email_verified` to `UserUpdateEvent`
* Add `banned_at` to `ChannelBanEvent`
* Add `level` to `HypeTrainBeginEvent`

### Additional Information
https://dev.twitch.tv/docs/change-log
