### PR TITLE
chore: add new pubsub hype fields

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -371,7 +371,7 @@ public class TwitchPubSub implements ITwitchPubSub {
         // 3) allow other threads to update subscribedTopics again
         // 4) send unlisten requests for the old elements of subscribedTopics (optional?)
         // 5) call listenOnTopic for each new PubSubRequest
-        subscribedTopics.forEach(topic -> queueRequest(topic));
+        subscribedTopics.forEach(this::queueRequest);
     }
 
     protected void onTextMessage(String text) {
@@ -593,6 +593,9 @@ public class TwitchPubSub implements ITwitchPubSub {
                             break;
                         case "hype-train-cooldown-expiration":
                             eventManager.publish(new HypeTrainCooldownExpirationEvent(lastTopicIdentifier));
+                            break;
+                        case "last-x-experiment-event":
+                            // ignore for now (experiment is not publicly deployed)
                             break;
                         default:
                             log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeLevelUp.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.twitch4j.common.util.MilliInstantDeserializer;
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 import java.time.Instant;
 
@@ -11,4 +13,7 @@ public class HypeLevelUp {
     @JsonDeserialize(using = MilliInstantDeserializer.class)
     private Instant timeToExpire;
     private HypeTrainProgress progress;
+    @Accessors(fluent = true)
+    @JsonProperty("is_boost_train")
+    private Boolean isBoostTrain;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 @Data
 public class HypeProgression {
@@ -10,4 +12,7 @@ public class HypeProgression {
     private String source;
     private Integer quantity;
     private HypeTrainProgress progress;
+    @Accessors(fluent = true)
+    @JsonProperty("is_boost_train")
+    private Boolean isBoostTrain;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.twitch4j.common.util.MilliInstantDeserializer;
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 import java.time.Instant;
 
@@ -11,4 +13,7 @@ public class HypeTrainEnd {
     @JsonDeserialize(using = MilliInstantDeserializer.class)
     private Instant endedAt;
     private String endingReason;
+    @Accessors(fluent = true)
+    @JsonProperty("is_boost_train")
+    private Boolean isBoostTrain;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
@@ -9,4 +9,5 @@ public class HypeTrainLevel {
     private Integer value;
     private Integer goal;
     private List<HypeTrainReward> rewards;
+    private Integer impressions;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainStart.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.twitch4j.common.util.MilliInstantDeserializer;
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 import java.time.Instant;
 
@@ -19,4 +21,7 @@ public class HypeTrainStart {
     private Instant expiresAt;
     @JsonDeserialize(using = MilliInstantDeserializer.class)
     private Instant updatedAt;
+    @Accessors(fluent = true)
+    @JsonProperty("is_boost_train")
+    private Boolean isBoostTrain;
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Log warning spam on `last-x-experiment-event` (will implement the event at a later date when details are more clear)

### Changes Proposed
* Add new `isBoostTrain`, `impressions` fields to unofficial hype train pubsub
