### PR TITLE
feat: add last support event pubsub handling

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -54,6 +54,7 @@ import com.github.twitch4j.pubsub.domain.RadioData;
 import com.github.twitch4j.pubsub.domain.RedemptionProgress;
 import com.github.twitch4j.pubsub.domain.SubGiftData;
 import com.github.twitch4j.pubsub.domain.SubscriptionData;
+import com.github.twitch4j.pubsub.domain.SupportActivityFeedData;
 import com.github.twitch4j.pubsub.domain.UpdateSummaryData;
 import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
 import com.github.twitch4j.pubsub.domain.UserAutomodCaughtMessage;
@@ -111,6 +112,7 @@ import com.github.twitch4j.pubsub.events.RaidUpdateEvent;
 import com.github.twitch4j.pubsub.events.RedemptionStatusUpdateEvent;
 import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
 import com.github.twitch4j.pubsub.events.SubLeaderboardEvent;
+import com.github.twitch4j.pubsub.events.SupportActivityFeedEvent;
 import com.github.twitch4j.pubsub.events.UpdateOnsiteNotificationSummaryEvent;
 import com.github.twitch4j.pubsub.events.UpdateRedemptionFinishedEvent;
 import com.github.twitch4j.pubsub.events.UpdateRedemptionProgressEvent;
@@ -595,7 +597,9 @@ public class TwitchPubSub implements ITwitchPubSub {
                             eventManager.publish(new HypeTrainCooldownExpirationEvent(lastTopicIdentifier));
                             break;
                         case "last-x-experiment-event":
-                            // ignore for now (experiment is not publicly deployed)
+                            // note: this isn't a true hype train event (it can be fired with no train active), but twitch hacked together the feature to use the hype pubsub infrastructure
+                            final SupportActivityFeedData lastData = TypeConvert.convertValue(msgData, SupportActivityFeedData.class);
+                            eventManager.publish(new SupportActivityFeedEvent(lastTopicIdentifier, lastData));
                             break;
                         default:
                             log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SupportActivityFeedData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SupportActivityFeedData.java
@@ -24,8 +24,8 @@ public class SupportActivityFeedData {
     private Integer quantity;
 
     @Unofficial
-    public boolean isCheer() {
-        return "BITS".equals(source) || "CHEER".equals(action);
+    public boolean isBitsCheer() {
+        return "BITS".equals(source) && "CHEER".equals(action);
     }
 
     @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SupportActivityFeedData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/SupportActivityFeedData.java
@@ -1,0 +1,58 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.OptionalInt;
+
+@Unofficial
+@Data
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor
+public class SupportActivityFeedData {
+    private String channelId;
+    private String eventId;
+    private String userId;
+    private String userLogin;
+    private String userDisplayName;
+    private String userProfileImageUrl;
+    private String action;
+    private String source;
+    private Integer quantity;
+
+    @Unofficial
+    public boolean isCheer() {
+        return "BITS".equals(source) || "CHEER".equals(action);
+    }
+
+    @Unofficial
+    public boolean isSub() {
+        return "SUBS".equals(source);
+    }
+
+    @Unofficial
+    public boolean isGiftSub() {
+        return action != null && action.endsWith("GIFTED_SUB");
+    }
+
+    @Unofficial
+    public OptionalInt getSubTier() {
+        if (action != null) {
+            int i = action.indexOf("TIER_");
+            if (i >= 0) {
+                i += "TIER_".length();
+                int j = action.indexOf('_', i);
+                if (j > i) {
+                    try {
+                        return OptionalInt.of(Integer.parseInt(action.substring(i, j)));
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+        }
+        return OptionalInt.empty();
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/SupportActivityFeedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/SupportActivityFeedEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.SupportActivityFeedData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class SupportActivityFeedEvent extends TwitchEvent {
+    String channelId;
+    SupportActivityFeedData data;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement "last x event" experiment handling over unofficial pubsub (i.e., fire `SupportActivityFeedEvent`)

### Additional Information
Experiment announcement https://twitter.com/TwitchSupport/status/1534272693486465027

Thanks to Laura for reporting / providing a sample message
