### PR TITLE
feat: add helix raids endpoints in open beta

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -24,6 +24,7 @@ public enum TwitchScopes {
     HELIX_CHANNEL_POLLS_READ("channel:read:polls"),
     HELIX_CHANNEL_PREDICTIONS_MANAGE("channel:manage:predictions"),
     HELIX_CHANNEL_PREDICTIONS_READ("channel:read:predictions"),
+    HELIX_CHANNEL_RAIDS_MANAGE("channel:manage:raids"),
     HELIX_CHANNEL_REDEMPTIONS_READ("channel:read:redemptions"),
     HELIX_CHANNEL_STREAM_KEY_READ("channel:read:stream_key"),
     HELIX_CHANNEL_SUBSCRIPTIONS_READ("channel:read:subscriptions"),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1627,6 +1627,43 @@ public interface TwitchHelix {
     );
 
     /**
+     * Raid another channel by sending the broadcaster’s viewers to the targeted channel.
+     * <p>
+     * This endpoint triggers a 90-second cooldown before the raid is executed (or the broadcaster can manually press "Raid now").
+     *
+     * @param authToken         Broadcaster user access token with the channel:manage:raids scope.
+     * @param fromBroadcasterId The ID of the broadcaster that’s sending the raiding party.
+     * @param toBroadcasterId   The ID of the broadcaster to raid.
+     * @return RaidRequestList
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_RAIDS_MANAGE
+     */
+    @Unofficial // currently in open beta
+    @RequestLine("POST /raids?from_broadcaster_id={from_broadcaster_id}&to_broadcaster_id={to_broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<RaidRequestList> startRaid(
+        @Param("token") String authToken,
+        @Param("from_broadcaster_id") String fromBroadcasterId,
+        @Param("to_broadcaster_id") String toBroadcasterId
+    );
+
+    /**
+     * Cancel a pending raid.
+     * <p>
+     * You can cancel a raid at any point up until the broadcaster clicks Raid Now in the Twitch UX or the 90 seconds countdown expires.
+     *
+     * @param authToken     Broadcaster user access token with the channel:manage:raids scope.
+     * @param broadcasterId The ID of the broadcaster that sent the raiding party.
+     * @return 204 No Content upon a successful raid cancel call
+     */
+    @Unofficial // currently in open beta
+    @RequestLine("DELETE /raids?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> cancelRaid(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
      * Gets games sorted by number of current viewers on Twitch, most popular first.
      * Using user-token or app-token to increase rate limits.
      *

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BanUsersResult.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BanUsersResult.java
@@ -29,6 +29,11 @@ public class BanUsersResult {
     private String userId;
 
     /**
+     * The UTC date and time (in RFC3999 format) when the ban was created.
+     */
+    private Instant createdAt;
+
+    /**
      * The UTC date and time (in RFC3339 format) that the timeout will end.
      * Is null if the user was banned instead of put in a timeout.
      */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUser.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/BannedUser.java
@@ -35,6 +35,11 @@ public class BannedUser {
     private Instant expiresAt;
 
     /**
+     * The UTC date and time (in RFC3999 format) when the ban was created.
+     */
+    private Instant createdAt;
+
+    /**
      * The reason for the ban if provided by the moderator.
      */
     @Nullable

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/RaidRequest.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/RaidRequest.java
@@ -1,0 +1,27 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class RaidRequest {
+
+    /**
+     * The UTC date and time, in RFC3339 format, when the raid request was created.
+     */
+    private Instant createdAt;
+
+    /**
+     * Whether the channel being raided contains mature content.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_mature")
+    private Boolean isMature;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/RaidRequestList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/RaidRequestList.java
@@ -1,0 +1,18 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class RaidRequestList {
+
+    /**
+     * A list of raids. The list will contain the single raid that this request created.
+     */
+    private List<RaidRequest> data;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Implement `TwitchHelix#startRaid` and `TwitchHelix#cancelRaid` (while rate limiting to 10 calls per 10 minutes)
* Add `channel:manage:raids` to `TwitchScopes`
* Add `createdAt` to `BanUsersResult` & `BannedUser`

### Additional Information
[Endpoint beta forum post](https://discuss.dev.twitch.tv/t/new-raids-api-endpoints-are-now-in-open-beta/38866/)
[Changelog (2022-06-08)](https://dev.twitch.tv/docs/change-log)
