### PR TITLE
feat: add micrometer support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,12 +98,6 @@ subprojects {
 			// Credential Manager
 			api(group = "com.github.philippheuer.credentialmanager", name = "credentialmanager", version = "0.1.2")
 
-			// HTTP Client
-			api(group = "io.github.openfeign", name = "feign-slf4j", version = "11.8")
-			api(group = "io.github.openfeign", name = "feign-okhttp", version = "11.8")
-			api(group = "io.github.openfeign", name = "feign-jackson", version = "11.8")
-			api(group = "io.github.openfeign", name = "feign-hystrix", version = "11.8")
-
 			// WebSocket
 			api(group = "com.neovisionaries", name = "nv-websocket-client", version = "2.14")
 
@@ -130,6 +124,12 @@ subprojects {
 
 		// Jackson BOM
 		api(platform("com.fasterxml.jackson:jackson-bom:2.13.3"))
+
+		// Feign BOM
+		api(platform("io.github.openfeign:feign-bom:11.8"))
+
+		// Micrometer BOM
+		api(platform("io.micrometer:micrometer-bom:1.9.1"))
 
 		// Test
 		testImplementation(platform("org.junit:junit-bom:5.8.2"))

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
 	// Cache
 	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
 
+	// Metrics
+	api("io.micrometer:micrometer-core")
+
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))
 	api(project(":twitch4j-auth"))

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -14,6 +14,7 @@ import com.github.twitch4j.chat.enums.TMIConnectionState;
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.chat.events.CommandEvent;
 import com.github.twitch4j.chat.events.IRCEventHandler;
+import com.github.twitch4j.chat.events.TwitchEvent;
 import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.ChannelMessageEvent;
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
@@ -30,8 +31,10 @@ import com.github.twitch4j.util.IBackoffStrategy;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -402,6 +405,18 @@ public class TwitchChat implements ITwitchChat {
             }
         });
 
+        // channel event metrics
+        eventManager.onEvent(TwitchEvent.class, metricEvent -> {
+            if (metricEvent instanceof AbstractChannelEvent) {
+                String channelId = ((AbstractChannelEvent) metricEvent).getChannel().getId();
+                if (StringUtils.isNotEmpty(channelId)) {
+                    meterRegistry.counter("twitch4j_chat_event", Arrays.asList(Tag.of("connection", instanceId), Tag.of("type", metricEvent.getClass().getSimpleName()), Tag.of("channel_id", channelId))).increment();
+                }
+            } else {
+                meterRegistry.counter("twitch4j_chat_event", Arrays.asList(Tag.of("connection", instanceId), Tag.of("type", metricEvent.getClass().getSimpleName()))).increment();
+            }
+        });
+
         // Initialize joinAttemptsByChannelName (on an attempt expiring without explicit removal, we retry with exponential backoff)
         if (maxJoinRetries > 0) {
             final long initialWait = Math.max(chatJoinTimeout, 0);
@@ -512,8 +527,10 @@ public class TwitchChat implements ITwitchChat {
                             IRCMessageEvent event = new IRCMessageEvent(message, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
 
                             if (event.isValid()) {
+                                meterRegistry.counter("twitch4j_chat_raw_received", Arrays.asList(Tag.of("connection", instanceId), Tag.of("status", "ok"))).increment();
                                 eventManager.publish(event);
                             } else {
+                                meterRegistry.counter("twitch4j_chat_raw_received", Arrays.asList(Tag.of("connection", instanceId), Tag.of("status", "parse_error"))).increment();
                                 log.trace("Can't parse {}", event.getRawMessage());
                             }
                         } catch (Exception ex) {

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -20,6 +20,8 @@ import com.github.twitch4j.common.util.TwitchLimitRegistry;
 import com.github.twitch4j.util.IBackoffStrategy;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -48,6 +50,12 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TwitchChatBuilder {
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
+
+    @With
+    private String instanceId = "twitch-chat-standalone";
 
     /**
      * WebsocketConnection
@@ -314,7 +322,7 @@ public class TwitchChatBuilder {
             perChannelRateLimit = chatRateLimit;
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.websocketConnection, this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod, this.connectionBackoffStrategy, this.perChannelRateLimit);
+        return new TwitchChat(instanceId, this.meterRegistry, this.websocketConnection, this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod, this.connectionBackoffStrategy, this.perChannelRateLimit);
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -53,6 +53,8 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
 
     private final String threadPrefix = "twitch4j-pool-" + RandomStringUtils.random(4, true, true) + "-chat-";
 
+    private int connectionIndex = 0;
+
     /**
      * Provides a chat account to be used when constructing a new {@link TwitchChat} instance.
      * By default, this yields null, which corresponds to an anonymous connection.
@@ -263,6 +265,7 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
         // Instantiate with configuration
         TwitchChat chat = advancedConfiguration.apply(
             TwitchChatBuilder.builder()
+                .withInstanceId("twitch-chat-"+connectionIndex++)
                 .withChatAccount(chatAccount.get())
                 .withEventManager(getConnectionEventManager())
                 .withScheduledThreadPoolExecutor(getExecutor(threadPrefix + RandomStringUtils.random(4, true, true), TwitchChat.REQUIRED_THREAD_COUNT))

--- a/client-websocket/build.gradle.kts
+++ b/client-websocket/build.gradle.kts
@@ -5,6 +5,9 @@ dependencies {
 
 	// WebSocket
 	implementation(group = "com.neovisionaries", name = "nv-websocket-client")
+
+	// Metrics
+	api("io.micrometer:micrometer-core")
 }
 
 tasks.javadoc {

--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnectionConfig.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnectionConfig.java
@@ -3,6 +3,9 @@ package com.github.twitch4j.client.websocket;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.ExponentialBackoffStrategy;
 import com.github.twitch4j.util.IBackoffStrategy;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -30,6 +33,7 @@ public class WebsocketConnectionConfig {
      * validate the config
      */
     public void validate() {
+        Objects.requireNonNull(meterRegistry, "meterRegistry may not be null!");
         Objects.requireNonNull(baseUrl, "baseUrl may not be null!");
         if (wsPingPeriod < 0) {
             throw new RuntimeException("wsPingPeriod must be 0 or greater, set to 0 to disable!");
@@ -45,6 +49,16 @@ public class WebsocketConnectionConfig {
         Objects.requireNonNull(onPreDisconnect, "onPreDisconnect may not be null!");
         Objects.requireNonNull(onPostDisconnect, "onPostDisconnect may not be null!");
     }
+
+    /**
+     * current instance (module + connection index)
+     */
+    private String instanceId;
+
+    /**
+     * micrometer registry
+     */
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry(Clock.SYSTEM);
 
     /**
      * The websocket url for the chat client to connect to.

--- a/pubsub/build.gradle.kts
+++ b/pubsub/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
 	// Annotations
 	api(group = "org.jetbrains", name = "annotations")
 
+	// Metrics
+	api("io.micrometer:micrometer-core")
+
 	// Twitch4J Modules
 	api(project(":twitch4j-eventsub-common"))
 	api(project(":twitch4j-common"))

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -8,6 +8,8 @@ import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.EventManagerUtils;
 import com.github.twitch4j.common.util.ThreadUtils;
 import com.github.twitch4j.util.IBackoffStrategy;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.*;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,9 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TwitchPubSubBuilder {
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
 
     /**
      * WebsocketConnection

--- a/rest-extensions/build.gradle.kts
+++ b/rest-extensions/build.gradle.kts
@@ -5,11 +5,15 @@ dependencies {
 	api(group = "io.github.openfeign", name = "feign-jackson")
 	api(group = "io.github.openfeign", name = "feign-slf4j")
 	api(group = "io.github.openfeign", name = "feign-hystrix")
+	api(group = "io.github.openfeign", name = "feign-micrometer")
 	api(group = "commons-configuration", name = "commons-configuration")
 
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
+
+	// Metrics
+	api("io.micrometer:micrometer-core")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))

--- a/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
+++ b/rest-extensions/src/main/java/com/github/twitch4j/extensions/TwitchExtensionsBuilder.java
@@ -14,8 +14,11 @@ import feign.Retryer;
 import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import feign.micrometer.MicrometerCapability;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,6 +36,9 @@ import java.util.concurrent.TimeUnit;
 @Getter
 @Deprecated
 public class TwitchExtensionsBuilder {
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
 
     /**
      * Base Url
@@ -138,6 +144,7 @@ public class TwitchExtensionsBuilder {
             .decoder(new JacksonDecoder(mapper))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)
+            .addCapability(new MicrometerCapability(meterRegistry))
             .errorDecoder(new TwitchExtensionsErrorDecoder(mapper, new JacksonDecoder()))
             .requestInterceptor(new TwitchExtensionsClientIdInterceptor(this))
             .options(new Request.Options(timeout / 3, TimeUnit.MILLISECONDS, timeout, TimeUnit.MILLISECONDS, true))

--- a/rest-helix/build.gradle.kts
+++ b/rest-helix/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
 	api(group = "io.github.openfeign", name = "feign-jackson")
 	api(group = "io.github.openfeign", name = "feign-slf4j")
 	api(group = "io.github.openfeign", name = "feign-hystrix")
+	api(group = "io.github.openfeign", name = "feign-micrometer")
 	api(group = "commons-configuration", name = "commons-configuration")
 
 	// Rate Limiting
@@ -15,6 +16,9 @@ dependencies {
 
 	// Cache
 	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+
+	// Metrics
+	api("io.micrometer:micrometer-core")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-eventsub-common"))

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -8,11 +8,11 @@ import com.github.twitch4j.common.util.ThreadUtils;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.helix.domain.CustomReward;
 import com.github.twitch4j.helix.interceptor.CustomRewardEncodeMixIn;
-import com.github.twitch4j.helix.interceptor.TwitchHelixTokenManager;
 import com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor;
 import com.github.twitch4j.helix.interceptor.TwitchHelixDecoder;
 import com.github.twitch4j.helix.interceptor.TwitchHelixHttpClient;
 import com.github.twitch4j.helix.interceptor.TwitchHelixRateLimitTracker;
+import com.github.twitch4j.helix.interceptor.TwitchHelixTokenManager;
 import com.netflix.config.ConfigurationManager;
 import feign.Logger;
 import feign.Request;
@@ -20,11 +20,18 @@ import feign.Retryer;
 import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import feign.micrometer.MicrometerCapability;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Refill;
-import lombok.*;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -57,6 +64,9 @@ public class TwitchHelixBuilder {
      * @see <a href="https://dev.twitch.tv/docs/api/guide#rate-limits">Helix Rate Limit Reference</a>
      */
     public static final Bandwidth DEFAULT_BANDWIDTH = Bandwidth.classic(800, Refill.greedy(600, Duration.ofMinutes(1)));
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
 
     /**
      * Client Id
@@ -182,6 +192,7 @@ public class TwitchHelixBuilder {
             .decoder(new TwitchHelixDecoder(mapper, rateLimitTracker))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)
+            .addCapability(new MicrometerCapability(meterRegistry))
             .errorDecoder(new TwitchHelixErrorDecoder(new JacksonDecoder(), rateLimitTracker))
             .requestInterceptor(new TwitchHelixClientIdInterceptor(userAgent, tokenManager))
             .options(new Request.Options(timeout / 3, TimeUnit.MILLISECONDS, timeout, TimeUnit.MILLISECONDS, true))

--- a/rest-kraken/build.gradle.kts
+++ b/rest-kraken/build.gradle.kts
@@ -5,11 +5,15 @@ dependencies {
 	api(group = "io.github.openfeign", name = "feign-jackson")
 	api(group = "io.github.openfeign", name = "feign-slf4j")
 	api(group = "io.github.openfeign", name = "feign-hystrix")
+	api(group = "io.github.openfeign", name = "feign-micrometer")
 	api(group = "commons-configuration", name = "commons-configuration")
 
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
+
+	// Metrics
+	api("io.micrometer:micrometer-core")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))

--- a/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
+++ b/rest-kraken/src/main/java/com/github/twitch4j/kraken/TwitchKrakenBuilder.java
@@ -13,8 +13,11 @@ import feign.Retryer;
 import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import feign.micrometer.MicrometerCapability;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,6 +37,9 @@ import java.util.concurrent.TimeUnit;
 @Getter
 @Deprecated
 public class TwitchKrakenBuilder {
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
 
     /**
      * Client Id
@@ -140,6 +146,7 @@ public class TwitchKrakenBuilder {
             .decoder(new JacksonDecoder(mapper))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)
+            .addCapability(new MicrometerCapability(meterRegistry))
             .errorDecoder(new TwitchKrakenErrorDecoder(new JacksonDecoder()))
             .requestInterceptor(new TwitchClientIdInterceptor(this.clientId, this.userAgent))
             .requestInterceptor(t -> t.header("Accept", "application/vnd.twitchtv.v5+json"))

--- a/rest-tmi/build.gradle.kts
+++ b/rest-tmi/build.gradle.kts
@@ -5,10 +5,14 @@ dependencies {
 	api(group = "io.github.openfeign", name = "feign-jackson")
 	api(group = "io.github.openfeign", name = "feign-slf4j")
 	api(group = "io.github.openfeign", name = "feign-hystrix")
+	api(group = "io.github.openfeign", name = "feign-micrometer")
 	api(group = "commons-configuration", name = "commons-configuration")
 
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
+
+	// Metrics
+	api("io.micrometer:micrometer-core")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -12,9 +12,16 @@ import feign.Retryer;
 import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import feign.micrometer.MicrometerCapability;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
-import lombok.*;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.TimeUnit;
@@ -27,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class TwitchMessagingInterfaceBuilder {
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
 
     /**
      * Client Id
@@ -117,6 +127,7 @@ public class TwitchMessagingInterfaceBuilder {
             .decoder(new JacksonDecoder(mapper))
             .logger(new Slf4jLogger())
             .logLevel(logLevel)
+            .addCapability(new MicrometerCapability(meterRegistry))
             .errorDecoder(new TwitchMessagingInterfaceErrorDecoder(new JacksonDecoder()))
             .requestInterceptor(new TwitchClientIdInterceptor(this.clientId, this.userAgent))
             .retryer(new Retryer.Default(1, 10000, 3))

--- a/twitch4j/build.gradle.kts
+++ b/twitch4j/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
 
 	// Jackson
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
+
+	// Metrics
+	api("io.micrometer:micrometer-core")
 }
 
 base {

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -29,7 +29,14 @@ import com.github.twitch4j.tmi.TwitchMessagingInterface;
 import com.github.twitch4j.tmi.TwitchMessagingInterfaceBuilder;
 import feign.Logger;
 import io.github.bucket4j.Bandwidth;
-import lombok.*;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -243,6 +250,9 @@ public class TwitchClientBuilder {
     @With
     private CredentialManager credentialManager = CredentialManagerBuilder.builder().build();
 
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
+
     /**
      * Scheduler Thread Pool Executor
      */
@@ -364,6 +374,7 @@ public class TwitchClientBuilder {
         TwitchExtensions extensions = null;
         if (this.enableExtensions) {
             extensions = TwitchExtensionsBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
                 .withUserAgent(userAgent)
@@ -378,6 +389,7 @@ public class TwitchClientBuilder {
         TwitchHelix helix = null;
         if (this.enableHelix) {
             helix = TwitchHelixBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withBaseUrl(helixBaseUrl)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
@@ -395,6 +407,7 @@ public class TwitchClientBuilder {
         TwitchKraken kraken = null;
         if (this.enableKraken) {
             kraken = TwitchKrakenBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
                 .withUserAgent(userAgent)
@@ -409,6 +422,7 @@ public class TwitchClientBuilder {
         TwitchMessagingInterface tmi = null;
         if (this.enableTMI) {
             tmi = TwitchMessagingInterfaceBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
                 .withUserAgent(userAgent)
@@ -423,6 +437,7 @@ public class TwitchClientBuilder {
         TwitchChat chat = null;
         if (this.enableChat) {
             chat = TwitchChatBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withEventManager(eventManager)
                 .withCredentialManager(credentialManager)
                 .withChatAccount(chatAccount)
@@ -447,6 +462,7 @@ public class TwitchClientBuilder {
         TwitchPubSub pubSub = null;
         if (this.enablePubSub) {
             pubSub = TwitchPubSubBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withEventManager(eventManager)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withProxyConfig(proxyConfig)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -33,6 +33,8 @@ import com.github.twitch4j.tmi.TwitchMessagingInterface;
 import com.github.twitch4j.tmi.TwitchMessagingInterfaceBuilder;
 import feign.Logger;
 import io.github.bucket4j.Bandwidth;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -171,6 +173,9 @@ public class TwitchClientPoolBuilder {
      */
     @With
     private OAuth2Credential chatAccount;
+
+    @With
+    private MeterRegistry meterRegistry = new CompositeMeterRegistry();
 
     /**
      * EventManager
@@ -383,6 +388,7 @@ public class TwitchClientPoolBuilder {
         TwitchExtensions extensions = null;
         if (this.enableExtensions) {
             extensions = TwitchExtensionsBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
                 .withUserAgent(userAgent)
@@ -397,6 +403,7 @@ public class TwitchClientPoolBuilder {
         TwitchHelix helix = null;
         if (this.enableHelix) {
             helix = TwitchHelixBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withBaseUrl(helixBaseUrl)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
@@ -413,6 +420,7 @@ public class TwitchClientPoolBuilder {
         TwitchKraken kraken = null;
         if (this.enableKraken) {
             kraken = TwitchKrakenBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
                 .withUserAgent(userAgent)
@@ -427,6 +435,7 @@ public class TwitchClientPoolBuilder {
         TwitchMessagingInterface tmi = null;
         if (this.enableTMI) {
             tmi = TwitchMessagingInterfaceBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
                 .withUserAgent(userAgent)
@@ -452,7 +461,9 @@ public class TwitchClientPoolBuilder {
                 .proxyConfig(() -> proxyConfig)
                 .maxSubscriptionsPerConnection(maxChannelsPerChatInstance)
                 .advancedConfiguration(builder ->
-                    builder.withCredentialManager(credentialManager)
+                    builder
+                        .withMeterRegistry(meterRegistry)
+                        .withCredentialManager(credentialManager)
                         .withChatQueueSize(chatQueueSize)
                         .withBaseUrl(chatServer)
                         .withChatQueueTimeout(chatQueueTimeout)
@@ -464,6 +475,7 @@ public class TwitchClientPoolBuilder {
                 .build();
         } else if (this.enableChat) {
             chat = TwitchChatBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withEventManager(eventManager)
                 .withCredentialManager(credentialManager)
                 .withChatAccount(chatAccount)
@@ -491,10 +503,16 @@ public class TwitchClientPoolBuilder {
                 .eventManager(eventManager)
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
-                .advancedConfiguration(builder -> builder.withWsPingPeriod(wsPingPeriod).setBotOwnerIds(botOwnerIds))
+                .advancedConfiguration(builder ->
+                    builder
+                        .withMeterRegistry(meterRegistry)
+                        .withWsPingPeriod(wsPingPeriod)
+                        .setBotOwnerIds(botOwnerIds)
+                )
                 .build();
         } else if (this.enablePubSub) {
             pubSub = TwitchPubSubBuilder.builder()
+                .withMeterRegistry(meterRegistry)
                 .withEventManager(eventManager)
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withProxyConfig(proxyConfig)

--- a/twitch4j/src/test/java/com/github/twitch4j/metrics/LogMetricsRegistry.java
+++ b/twitch4j/src/test/java/com/github/twitch4j/metrics/LogMetricsRegistry.java
@@ -1,0 +1,29 @@
+package com.github.twitch4j.metrics;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * a metrics registry that logs the current metrics every 10s for testing purposes
+ */
+public class LogMetricsRegistry extends LoggingMeterRegistry {
+
+    public LogMetricsRegistry() {
+        super(new LoggingRegistryConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public @NotNull Duration step() {
+                return Duration.ofSeconds(10);
+            }
+        }, Clock.SYSTEM);
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed

micrometer is a facade for metric collection, the goal is to provide metrics from all t4j components in a agnostic / easy way to improve observability.

* metrics for all http clients (feign-micrometer for http request / response metrics)
* metrics for client-websocket
* metrics for chat

TODO
* pubsub
* apollo (graphql)
* pool metrics (connection count, ...)
* add more useful metrics to chat / client-websocket

### Additional Information

