### PR TITLE
feat: add user_id and type args to getEventSubSubscriptions

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -6,7 +6,9 @@ import com.github.twitch4j.common.feign.ObjectToJsonExpander;
 import com.github.twitch4j.eventsub.EventSubSubscription;
 import com.github.twitch4j.eventsub.EventSubSubscriptionStatus;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
+import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
 import com.github.twitch4j.helix.domain.*;
+import com.github.twitch4j.helix.interceptor.EventSubSubscriptionNameExpander;
 import com.github.twitch4j.helix.webhooks.domain.WebhookRequest;
 import com.netflix.hystrix.HystrixCommand;
 import feign.*;
@@ -562,21 +564,50 @@ public interface TwitchHelix {
 
     /**
      * Get a list of your EventSub subscriptions.
+     * <p>
+     * The list is paginated and ordered by the oldest subscription first.
+     * <p>
+     * Use the status, type, and user_id query parameters to filter the list of subscriptions that are returned.
+     * The filters are mutually exclusive; the request fails if you specify more than one filter.
+     *
+     * @param authToken Required: App Access Token.
+     * @param status    Optional: Include this parameter to filter subscriptions by their status.
+     * @param type      Optional: Include this parameter to filter subscriptions by subscription type.
+     * @param userId    Optional: Include this parameter to filter subscriptions by user ID in the condition object.
+     * @param after     Optional: Cursor for forward pagination.
+     * @param limit     Optional: Maximum number of objects to return. Maximum: 100. Minimum: 10.
+     * @return EventSubSubscriptionList
+     */
+    @RequestLine("GET /eventsub/subscriptions?status={status}&type={type}&user_id={user_id}&after={after}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<EventSubSubscriptionList> getEventSubSubscriptions(
+        @Param("token") String authToken,
+        @Param("status") EventSubSubscriptionStatus status,
+        @Param(value = "type", expander = EventSubSubscriptionNameExpander.class) SubscriptionType<?, ?, ?> type,
+        @Param("user_id") String userId,
+        @Param("after") String after,
+        @Param("first") Integer limit
+    );
+
+    /**
+     * Get a list of your EventSub subscriptions.
      *
      * @param authToken Required: App Access Token.
      * @param status    Optional: Include this parameter to filter subscriptions by their status.
      * @param after     Optional: Cursor for forward pagination.
      * @param limit     Optional: Maximum number of objects to return. Maximum: 100. Minimum: 10.
      * @return EventSubSubscriptionList
+     * @deprecated in favor of {@link #getEventSubSubscriptions(String, EventSubSubscriptionStatus, SubscriptionType, String, String, Integer)}
      */
-    @RequestLine("GET /eventsub/subscriptions?status={status}&after={after}&first={first}")
-    @Headers("Authorization: Bearer {token}")
-    HystrixCommand<EventSubSubscriptionList> getEventSubSubscriptions(
+    @Deprecated
+    default HystrixCommand<EventSubSubscriptionList> getEventSubSubscriptions(
         @Param("token") String authToken,
         @Param("status") EventSubSubscriptionStatus status,
         @Param("after") String after,
         @Param("first") Integer limit
-    );
+    ) {
+        return getEventSubSubscriptions(authToken, status, null, null, after, limit);
+    }
 
     /**
      * Gets information about your Extensions; either the current version or a specified version.
@@ -1637,7 +1668,6 @@ public interface TwitchHelix {
      * @return RaidRequestList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_RAIDS_MANAGE
      */
-    @Unofficial // currently in open beta
     @RequestLine("POST /raids?from_broadcaster_id={from_broadcaster_id}&to_broadcaster_id={to_broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<RaidRequestList> startRaid(
@@ -1655,7 +1685,6 @@ public interface TwitchHelix {
      * @param broadcasterId The ID of the broadcaster that sent the raiding party.
      * @return 204 No Content upon a successful raid cancel call
      */
-    @Unofficial // currently in open beta
     @RequestLine("DELETE /raids?broadcaster_id={broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> cancelRaid(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/EventSubSubscriptionNameExpander.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/EventSubSubscriptionNameExpander.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.helix.interceptor;
+
+import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
+import feign.Param;
+
+public class EventSubSubscriptionNameExpander implements Param.Expander {
+    @Override
+    public String expand(Object value) {
+        if (value instanceof SubscriptionType<?, ?, ?>)
+            return ((SubscriptionType<?, ?, ?>) value).getName();
+        return null;
+    }
+}

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/WebhooksServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/WebhooksServiceTest.java
@@ -42,6 +42,8 @@ public class WebhooksServiceTest extends AbstractEndpointTest {
             System.getenv("APP_ACCESS_TOKEN"),
             null,
             null,
+            null,
+            null,
             null
         ).execute();
         assertTrue(subList.getTotal() > 0, "Sub list size was " + subList.getTotal());


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `userId` & `type` query params to `getEventSubSubscriptions`
* Remove `@Unofficial` annotation from `startRaid`/`cancelRaid`

### Additional Information
[2022-06-07 changelog](https://dev.twitch.tv/docs/change-log)
