### PR TITLE
fix: clear pubsub command queue on reconnect

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -255,6 +255,7 @@ public class TwitchPubSub implements ITwitchPubSub {
             this.connection = new WebsocketConnection(spec -> {
                 spec.baseUrl(WEB_SOCKET_SERVER);
                 spec.wsPingPeriod(wsPingPeriod);
+                spec.onPreConnect(this::onPreConnect);
                 spec.onConnected(this::onConnected);
                 spec.onTextMessage(this::onTextMessage);
                 spec.onPostDisconnect(commandQueue::clear);
@@ -340,10 +341,6 @@ public class TwitchPubSub implements ITwitchPubSub {
      * Connecting to IRC-WS
      */
     public void connect() {
-        // Reset last ping to avoid edge case loop where reconnect occurred after sending PING but before receiving PONG
-        lastPong = TimeUtils.getCurrentTimeInMillis();
-        lastPing = lastPong - 4 * 60 * 1000;
-
         connection.connect();
     }
 
@@ -360,6 +357,12 @@ public class TwitchPubSub implements ITwitchPubSub {
     @Synchronized
     public void reconnect() {
         connection.reconnect();
+    }
+
+    protected void onPreConnect() {
+        // Reset last ping to avoid edge case loop where reconnect occurred after sending PING but before receiving PONG
+        lastPong = TimeUtils.getCurrentTimeInMillis();
+        lastPing = lastPong - 4 * 60 * 1000;
     }
 
     protected void onConnected() {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -257,6 +257,7 @@ public class TwitchPubSub implements ITwitchPubSub {
                 spec.wsPingPeriod(wsPingPeriod);
                 spec.onConnected(this::onConnected);
                 spec.onTextMessage(this::onTextMessage);
+                spec.onPostDisconnect(commandQueue::clear);
                 spec.taskExecutor(taskExecutor);
                 spec.proxyConfig(proxyConfig);
                 if (connectionBackoffStrategy != null)


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Avoid ping timer related reconnect spam & resulting queue saturation

### Changes Proposed
* Ensure ping timer is reset on each connect, instead of only manual `TwitchPubSub#connect` calls
* Ensure command queue is cleared on disconnect (to avoid cases where there were remaining queued commands on a disconnect being compounded with new commands on reconnect from resending subscribed topics)

### Additional Information
Thanks to `Pocketpac` & `Doc94` for reporting logs to diagnose the issue
