### PR TITLE
fix: reset ping tracker on websocket close

### DIFF
--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
@@ -283,11 +283,16 @@ public class WebsocketConnection implements AutoCloseable {
 
     @Synchronized
     private void closeSocket() {
+        // Clean up the socket
         if (webSocket != null) {
             this.webSocket.disconnect();
             this.webSocket.clearListeners();
             this.webSocket = null;
         }
+
+        // Reset latency tracker
+        this.latency = -1L;
+        lastPing.lazySet(0L);
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed

* Avoids a very rare edge case where a disconnect could've occurred after a ping was sent but before a pong was received, resulting in a falsely exaggerated latency value on the next pong frame (post-reconnect)
