### PR TITLE
chore: promote helix chat endpoints out of beta

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -326,8 +326,6 @@ public interface TwitchHelix {
 
     /**
      * Sends an announcement to the broadcaster’s chat room.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken     User access token (scope: moderator:manage:announcements) of the broadcaster or a moderator.
      * @param broadcasterId The ID of the broadcaster that owns the chat room to send the announcement to.
@@ -337,7 +335,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_ANNOUNCEMENTS_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("POST /chat/announcements?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
     @Headers({
         "Authorization: Bearer {token}",
@@ -381,15 +378,12 @@ public interface TwitchHelix {
 
     /**
      * Gets the color used for the user’s name in chat.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken App access token or user access token.
      * @param userIds   The ID of the users whose color you want to get. Maximum: 100.
      * @return UserChatColorList
      * @see ChatUserColor#getColor()
      */
-    @Unofficial // beta
     @RequestLine("GET /chat/color?user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<UserChatColorList> getUserChatColor(
@@ -400,8 +394,6 @@ public interface TwitchHelix {
     /**
      * Updates the color used for the user’s name in chat.
      * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
-     * <p>
      * All users may specify one of the following named color values in {@link NamedUserChatColor}.
      * Turbo and Prime users may specify a named color or a Hex color code like #9146FF.
      *
@@ -411,7 +403,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_COLOR_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("PUT /chat/color?user_id={user_id}&color={color}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> updateUserChatColor(
@@ -1119,8 +1110,6 @@ public interface TwitchHelix {
 
     /**
      * Gets a list of the channel’s VIPs.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken     Broadcaster's user access token that includes the channel:read:vips scope.
      * @param broadcasterId The ID of the broadcaster whose list of VIPs you want to get.
@@ -1130,7 +1119,6 @@ public interface TwitchHelix {
      * @return ChannelVipList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_VIPS_READ
      */
-    @Unofficial // beta
     @RequestLine("GET /channels/vips?broadcaster_id={broadcaster_id}&user_id={user_id}&first={first}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<ChannelVipList> getChannelVips(
@@ -1143,8 +1131,6 @@ public interface TwitchHelix {
 
     /**
      * Adds a VIP to the broadcaster’s chat room.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken     Broadcaster's user access token that includes the channel:manage:vips scope.
      * @param broadcasterId The ID of the broadcaster that’s granting VIP status to the user.
@@ -1152,7 +1138,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_VIPS_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("POST /channels/vips?broadcaster_id={broadcaster_id}&user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> addChannelVip(
@@ -1163,8 +1148,6 @@ public interface TwitchHelix {
 
     /**
      * Removes a VIP from the broadcaster’s chat room.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken     Broadcaster's user access token that includes the channel:manage:vips scope.
      * @param broadcasterId The ID of the broadcaster that’s removing VIP status from the user.
@@ -1172,7 +1155,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_VIPS_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("DELETE /channels/vips?broadcaster_id={broadcaster_id}&user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> removeChannelVip(
@@ -1599,8 +1581,6 @@ public interface TwitchHelix {
     /**
      * Removes a single chat message or all chat messages from the broadcaster’s chat room.
      * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
-     * <p>
      * The ID in the moderator_id query parameter must match the user ID in the access token.
      * If the broadcaster wants to remove messages themselves (instead of having the moderator do it), set this parameter to the broadcaster’s ID, too.
      * <p>
@@ -1619,7 +1599,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_MESSAGES_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("DELETE /moderation/chat?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&message_id={message_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> deleteChatMessages(
@@ -1670,8 +1649,6 @@ public interface TwitchHelix {
 
     /**
      * Adds a moderator to the broadcaster’s chat room.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken     Broadcaster's user access token that includes the channel:manage:moderators scope.
      * @param broadcasterId The ID of the broadcaster that owns the chat room.
@@ -1679,7 +1656,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_MODS_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("POST /moderation/moderators?broadcaster_id={broadcaster_id}&user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> addChannelModerator(
@@ -1690,8 +1666,6 @@ public interface TwitchHelix {
 
     /**
      * Removes a moderator from the broadcaster’s chat room.
-     * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
      *
      * @param authToken     Broadcaster's user access token that includes the channel:manage:moderators scope.
      * @param broadcasterId The ID of the broadcaster that owns the chat room.
@@ -1699,7 +1673,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_MODS_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("DELETE /moderation/moderators?broadcaster_id={broadcaster_id}&user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> removeChannelModerator(
@@ -2681,8 +2654,6 @@ public interface TwitchHelix {
     /**
      * Sends a whisper message to the specified user.
      * <p>
-     * This endpoint is in <a href="https://discuss.dev.twitch.tv/t/new-chat-and-role-management-api-endpoints-are-now-in-open-beta/39563">open beta</a>.
-     * <p>
      * Note: The user sending the whisper must have a verified phone number.
      * <p>
      * Note: The API may silently drop whispers that it suspects of violating Twitch policies.
@@ -2709,7 +2680,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful call, even if the message was silently dropped
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_WHISPERS_MANAGE
      */
-    @Unofficial // beta
     @RequestLine("POST /whispers?from_user_id={from_user_id}&to_user_id={to_user_id}")
     @Headers({
         "Authorization: Bearer {token}",


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove `@Unofficial` on new endpoints from #606

### Additional Information
[2022‑07‑29](https://dev.twitch.tv/docs/change-log): All Twitch API endpoints introduced on 2022-07-15 have moved from public beta to general availability.


