### PR TITLE
refactor: use xanthic cache facade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,10 @@ allprojects {
 	// Repositories
 	repositories {
 		mavenCentral()
+		maven {
+			name = "sonatype-snapshots"
+			url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+		}
 	}
 
 	tasks {
@@ -80,6 +84,7 @@ subprojects {
 			api(group = "org.jetbrains", name = "annotations", version = "23.0.0")
 
 			// Caching
+			api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine", version = "1.0.0-SNAPSHOT")
 			api(group = "com.github.ben-manes.caffeine", name = "caffeine", version = "2.9.3")
 
 			// Apache Commons

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ allprojects {
 				this as StandardJavadocDocletOptions
 				links(
 					"https://javadoc.io/doc/org.jetbrains/annotations/23.0.0",
-					"https://javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.9.3",
 					"https://javadoc.io/doc/commons-configuration/commons-configuration/1.10",
 					"https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.5.0",
 					// "https://javadoc.io/doc/com.squareup.okhttp3/okhttp/4.9.3", // blocked by https://github.com/square/okhttp/issues/6450
@@ -84,8 +83,7 @@ subprojects {
 			api(group = "org.jetbrains", name = "annotations", version = "23.0.0")
 
 			// Caching
-			api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine", version = "1.0.0-SNAPSHOT")
-			api(group = "com.github.ben-manes.caffeine", name = "caffeine", version = "2.9.3")
+			api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine", version = "1.0.0-SNAPSHOT") // switch to just cache-core in t4j 2.0
 
 			// Apache Commons
 			api(group = "commons-configuration", name = "commons-configuration", version = "1.10")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,9 +82,6 @@ subprojects {
 			// Annotations
 			api(group = "org.jetbrains", name = "annotations", version = "23.0.0")
 
-			// Caching
-			api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine", version = "1.0.0-SNAPSHOT") // switch to just cache-core in t4j 2.0
-
 			// Apache Commons
 			api(group = "commons-configuration", name = "commons-configuration", version = "1.10")
 
@@ -127,6 +124,9 @@ subprojects {
 		// Apache Commons
 		api(group = "commons-io", name = "commons-io", version = "2.11.0")
 		api(group = "org.apache.commons", name = "commons-lang3", version = "3.12.0")
+
+		// Cache BOM
+		api(platform("io.github.xanthic.cache:cache-bom:1.0.0-SNAPSHOT"))
 
 		// Logging
 		api(group = "org.slf4j", name = "slf4j-api", version = "1.7.36")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,6 @@ allprojects {
 	// Repositories
 	repositories {
 		mavenCentral()
-		maven {
-			name = "sonatype-snapshots"
-			url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-		}
 	}
 
 	tasks {
@@ -126,7 +122,7 @@ subprojects {
 		api(group = "org.apache.commons", name = "commons-lang3", version = "3.12.0")
 
 		// Cache BOM
-		api(platform("io.github.xanthic.cache:cache-bom:1.0.0-SNAPSHOT"))
+		api(platform("io.github.xanthic.cache:cache-bom:0.1.0"))
 
 		// Logging
 		api(group = "org.slf4j", name = "slf4j-api", version = "1.7.36")

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
 	api(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core")
 
 	// Cache
-	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -1,9 +1,5 @@
 package com.github.twitch4j.chat;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.Scheduler;
 import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.core.EventManager;
@@ -30,6 +26,9 @@ import com.github.twitch4j.common.util.EscapeUtils;
 import com.github.twitch4j.util.IBackoffStrategy;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import io.github.xanthic.cache.api.Cache;
+import io.github.xanthic.cache.api.domain.ExpiryType;
+import io.github.xanthic.cache.core.CacheApi;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -280,9 +279,11 @@ public class TwitchChat implements ITwitchChat {
         this.perChannelRateLimit = perChannelRateLimit;
 
         // init per channel message buckets by channel name
-        this.bucketByChannelName = Caffeine.newBuilder()
-            .expireAfterAccess(Math.max(perChannelRateLimit.getRefillPeriodNanos(), Duration.ofSeconds(30L).toNanos()), TimeUnit.NANOSECONDS)
-            .build();
+        this.bucketByChannelName = CacheApi.create(spec -> {
+            spec.maxSize(2048L);
+            spec.expiryType(ExpiryType.POST_ACCESS);
+            spec.expiryTime(Duration.ofNanos(Math.max(perChannelRateLimit.getRefillPeriodNanos(), Duration.ofSeconds(30L).toNanos())));
+        });
 
         // init connection
         if (websocketConnection == null) {
@@ -396,11 +397,13 @@ public class TwitchChat implements ITwitchChat {
         // Initialize joinAttemptsByChannelName (on an attempt expiring without explicit removal, we retry with exponential backoff)
         if (maxJoinRetries > 0) {
             final long initialWait = Math.max(chatJoinTimeout, 0);
-            this.joinAttemptsByChannelName = Caffeine.newBuilder()
-                .expireAfterWrite(initialWait, TimeUnit.MILLISECONDS)
-                .scheduler(Scheduler.forScheduledExecutorService(taskExecutor)) // required for prompt removals on java 8
-                .<String, Integer>evictionListener((name, attempts, cause) -> {
-                    if (cause == RemovalCause.EXPIRED && name != null && attempts != null) {
+            this.joinAttemptsByChannelName = CacheApi.create(spec -> {
+                spec.maxSize(2048L);
+                spec.expiryType(ExpiryType.POST_WRITE);
+                spec.expiryTime(Duration.ofMillis(initialWait));
+                spec.executor(taskExecutor);
+                spec.removalListener((name, attempts, cause) -> {
+                    if (cause.isEviction()) {
                         if (attempts < maxJoinRetries) {
                             taskExecutor.schedule(() -> {
                                 if (currentChannels.contains(name)) {
@@ -413,14 +416,14 @@ public class TwitchChat implements ITwitchChat {
                             log.warn("Chat connection exhausted retries when attempting to join channel: {}", name);
                         }
                     }
-                })
-                .build();
+                });
+            });
         } else {
-            this.joinAttemptsByChannelName = Caffeine.newBuilder().maximumSize(0).build(); // optimization
+            this.joinAttemptsByChannelName = CacheApi.create(spec -> spec.maxSize(0L)); // optimization
         }
 
         // Remove successfully joined channels from joinAttemptsByChannelName (as further retries are not needed)
-        Consumer<AbstractChannelEvent> joinListener = e -> joinAttemptsByChannelName.invalidate(e.getChannel().getName().toLowerCase());
+        Consumer<AbstractChannelEvent> joinListener = e -> joinAttemptsByChannelName.remove(e.getChannel().getName().toLowerCase());
         eventManager.onEvent(ChannelStateEvent.class, joinListener::accept);
         eventManager.onEvent(ChannelNoticeEvent.class, joinListener::accept);
         eventManager.onEvent(UserStateEvent.class, joinListener::accept);
@@ -645,7 +648,7 @@ public class TwitchChat implements ITwitchChat {
         BucketUtils.scheduleAgainstBucket(ircJoinBucket, taskExecutor, () -> {
             String name = channelName.toLowerCase();
             queueCommand("JOIN #" + name);
-            joinAttemptsByChannelName.asMap().merge(name, attempts, Math::max); // mark that a join has been initiated to track later success or failure state
+            joinAttemptsByChannelName.merge(name, attempts, Math::max); // mark that a join has been initiated to track later success or failure state
         });
     }
 
@@ -837,7 +840,7 @@ public class TwitchChat implements ITwitchChat {
     }
 
     private Bucket getChannelMessageBucket(@NotNull String channelName) {
-        return bucketByChannelName.get(channelName.toLowerCase(), k -> BucketUtils.createBucket(perChannelRateLimit));
+        return bucketByChannelName.computeIfAbsent(channelName.toLowerCase(), k -> BucketUtils.createBucket(perChannelRateLimit));
     }
 
 }

--- a/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
@@ -57,13 +57,13 @@ public class ChatJoinRetryTest {
         TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
-        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
+        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // fake a successful join
         twitchChat.getEventManager().publish(testIRCMessageEvent("@emote-only=0;followers-only=-1;r9k=0;rituals=0;room-id=149223493;slow=0;subs-only=0 :tmi.twitch.tv ROOMSTATE #"+FAKE_CHANNEL_NAME));
 
         // should be gone from joinAttemptsByChannelName after successful join
-        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after successful join");
+        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after successful join");
         Assertions.assertTrue(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should remain in currentChannels after successful join");
 
         // cleanup
@@ -82,11 +82,11 @@ public class ChatJoinRetryTest {
         TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
-        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
+        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // should see a ChannelRemovedPostJoinFailureEvent and entry should have expired
         verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.RETRIES_EXHAUSTED));
-        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after it expired");
+        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after it expired");
         Assertions.assertFalse(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should be gone from currentChannels after retries have been exhausted");
 
         // cleanup
@@ -105,16 +105,16 @@ public class ChatJoinRetryTest {
         TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
-        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
+        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // wait for 2 failed join attempts
-        await().until(() -> Integer.valueOf(2).equals(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME)));
+        await().until(() -> Integer.valueOf(2).equals(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME)));
 
         // fake a successful join
         twitchChat.getEventManager().publish(testIRCMessageEvent("@emote-only=0;followers-only=-1;r9k=0;rituals=0;room-id=149223493;slow=0;subs-only=0 :tmi.twitch.tv ROOMSTATE #"+FAKE_CHANNEL_NAME));
 
         // should be gone from joinAttemptsByChannelName after successful join
-        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after successful join");
+        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after successful join");
         Assertions.assertTrue(twitchChat.currentChannels.contains(FAKE_CHANNEL_NAME), "channel should remain in currentChannels after successful join");
 
         // cleanup
@@ -133,13 +133,13 @@ public class ChatJoinRetryTest {
         TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
-        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
+        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // fake a banned notice
         twitchChat.getEventManager().publish(testIRCMessageEvent("@msg-id=msg_banned :tmi.twitch.tv NOTICE #"+FAKE_CHANNEL_NAME+" :You are permanently banned from talking in "+FAKE_CHANNEL_NAME+"."));
 
         // should be gone from joinAttemptsByChannelName because of the ban notice
-        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the ban notice");
+        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the ban notice");
 
         // should have received an event about the removal of the channel
         verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.USER_BANNED));
@@ -161,13 +161,13 @@ public class ChatJoinRetryTest {
         TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
-        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
+        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // fake a banned notice
         twitchChat.getEventManager().publish(testIRCMessageEvent("@msg-id=msg_channel_suspended :tmi.twitch.tv NOTICE #"+FAKE_CHANNEL_NAME+" :This channel has been suspended."));
 
         // should be gone from joinAttemptsByChannelName because of the ban notice
-        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the channel suspension notice");
+        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the channel suspension notice");
 
         // should have received an event about the removal of the channel
         verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.CHANNEL_SUSPENDED));
@@ -189,13 +189,13 @@ public class ChatJoinRetryTest {
         TestUtils.sleepFor(50);
 
         // check that we kept track of the join attempt in joinAttemptsByChannelName
-        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
+        Assertions.assertNotNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be in joinAttemptsByChannelName while the join attempt is in an unknown state");
 
         // fake a banned notice
         twitchChat.getEventManager().publish(testIRCMessageEvent("@msg-id=tos_ban :tmi.twitch.tv NOTICE #"+FAKE_CHANNEL_NAME+" :The community has closed channel "+FAKE_CHANNEL_NAME+" due to Terms of Service violations."));
 
         // should be gone from joinAttemptsByChannelName because of the ban notice
-        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.getIfPresent(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the channel suspension notice");
+        Assertions.assertNull(twitchChat.joinAttemptsByChannelName.get(FAKE_CHANNEL_NAME), "channel should be gone from joinAttemptsByChannelName after the channel suspension notice");
 
         // should have received an event about the removal of the channel
         verify(twitchChat.getEventManager(), timeout(30_000)).publish(new ChannelJoinFailureEvent(FAKE_CHANNEL_NAME, ChannelJoinFailureEvent.Reason.CHANNEL_SUSPENDED));

--- a/eventsub-common/build.gradle.kts
+++ b/eventsub-common/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
 
 	// Cache
-	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))

--- a/graphql/build.gradle.kts
+++ b/graphql/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 	api(group = "com.netflix.hystrix", name = "hystrix-core")
 
 	// Caching
-	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))

--- a/rest-helix/build.gradle.kts
+++ b/rest-helix/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
 
 	// Cache
-	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-eventsub-common"))

--- a/twitch4j/build.gradle.kts
+++ b/twitch4j/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 		}
 
 	// Cache
-	api(group = "com.github.ben-manes.caffeine", name = "caffeine")
+	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")
 
 	// Jackson
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Forced Caffeine use was incompatible with Android

### Changes Proposed
* Switch all direct Caffeine use to the Xanthic facade

### Additional Information
For now, we still depend on `cache-provider-caffeine` to avoid any breaking changes... users can exclude this dependency & specify a different provider
