### PR TITLE
fix: deserialize eventsub follow goal type

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
@@ -17,14 +17,14 @@ public enum GoalType {
      * The goal is to increase subscriptions.
      * This type shows the net increase or decrease in subscriptions.
      */
-    @JsonAlias("subscription")
+    @JsonAlias({ "subscription", "sub" })
     SUBSCRIPTIONS,
 
     /**
      * The goal is to increase subscriptions.
      * This type shows only the net increase in subscriptions (it does not account for users that stopped subscribing since the goal's inception).
      */
-    @JsonAlias("new_subscription")
+    @JsonAlias({ "new_subscription", "new_sub" })
     NEW_SUBSCRIPTIONS,
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/GoalType.java
@@ -10,7 +10,7 @@ public enum GoalType {
     /**
      * The goal is to increase followers.
      */
-    @JsonAlias("follower")
+    @JsonAlias({ "follower", "follow" })
     FOLLOWERS,
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* EventSub docs are wrong; follow count creator goal type is `follow` in practice (instead of the documented `follower`)

### Changes Proposed
* Add more aliases to creator goal type enum

### Additional Information
https://discord.com/channels/504015559252377601/776875921654546463/1006570884510781450
