### PR TITLE
chore(deps): update dependency com.bucket4j.bucket4j-core to v8.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ allprojects {
 				links(
 					"https://javadoc.io/doc/org.jetbrains/annotations/23.0.0",
 					"https://javadoc.io/doc/commons-configuration/commons-configuration/1.10",
-					"https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.6.0",
+					"https://javadoc.io/doc/com.bucket4j/bucket4j_jdk8-core/8.0.1",
 					// "https://javadoc.io/doc/com.squareup.okhttp3/okhttp/4.9.3", // blocked by https://github.com/square/okhttp/issues/6450
 					"https://javadoc.io/doc/com.github.philippheuer.events4j/events4j-core/0.10.0",
 					"https://javadoc.io/doc/com.github.philippheuer.events4j/events4j-handler-simple/0.10.0",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ subprojects {
 			api(group = "commons-configuration", name = "commons-configuration", version = "1.10")
 
 			// Rate Limiting
-			api(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core", version = "7.6.0")
+			api(group = "com.bucket4j", name = "bucket4j_jdk8-core", version = "8.0.1")
 
 			// HTTP
 			api(group = "com.squareup.okhttp3", name = "okhttp", version = "4.9.3")

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -1,7 +1,7 @@
 // In this section you declare the dependencies for your production and test code
 dependencies {
 	// Rate Limiting
-	api(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core")
+	api(group = "com.bucket4j", name = "bucket4j_jdk8-core")
 
 	// Cache
 	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
 
 	// Rate-limit buckets for registry
-	compileOnly(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core")
+	compileOnly(group = "com.bucket4j", name = "bucket4j_jdk8-core")
 
 	// Twitch4J Modules
 	api(project(":twitch4j-auth"))

--- a/rest-helix/build.gradle.kts
+++ b/rest-helix/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 	api(group = "commons-configuration", name = "commons-configuration")
 
 	// Rate Limiting
-	api(group = "com.github.vladimir-bukhtoyarov", name = "bucket4j-core")
+	api(group = "com.bucket4j", name = "bucket4j_jdk8-core")
 
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* bump com.bucket4j.bucket4j-core to v8.0.1

Changelog: https://github.com/bucket4j/bucket4j/releases/tag/8.0.1

### Additional Information
- bucket4j changed the group id, so no automatic update from renovate: 
- they provide two artifacts now, one for jdk8 compatiblity, the default one requires jdk11+ (`bucket4j_jdk8-core` and `bucket4j-core`)
