### PR TITLE
fix(helix): avoid copying default token

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
@@ -62,10 +62,11 @@ public final class TwitchHelixTokenManager {
         this.defaultAuthToken = defaultAuthToken;
 
         if (defaultAuthToken != null) {
+            this.defaultClientId = defaultAuthToken.getContext().getOrDefault(CLIENT_ID_CONTEXT, clientId).toString();
             twitchIdentityProvider.getAdditionalCredentialInformation(defaultAuthToken).ifPresent(oauth -> {
                 populateCache(oauth);
                 this.defaultClientId = extractClientId(oauth);
-                this.defaultAuthToken = oauth;
+                this.defaultAuthToken.updateCredential(oauth);
             });
         }
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Allow updates to `defaultAuthToken` be propagated to `TwitchHelixTokenManager`

### Changes Proposed
* Use `updateCredential` rather than creating an independent copy of `defaultAuthToken`
