### PR TITLE
fix: prevent maven from using jackson3 snapshot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,8 +110,8 @@ subprojects {
 			listOf("com.fasterxml.jackson.core:jackson-annotations", "com.fasterxml.jackson.core:jackson-core", "com.fasterxml.jackson.core:jackson-databind", "com.fasterxml.jackson.datatype:jackson-datatype-jsr310").forEach { dep ->
 				add("api", dep) {
 					version {
-						strictly("[2.12,3[")
-						prefer("2.13.2")
+						strictly("[2.12,3-alpha[")
+						prefer("2.13.3")
 					}
 				}
 			}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,7 @@ subprojects {
 				add("api", dep) {
 					version {
 						strictly("[2.12,3-alpha[")
+						// renovate: depName=com.fasterxml.jackson:jackson-bom
 						prefer("2.13.3")
 					}
 				}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Maven users that have added a repository to their pom that offers a 3.x snapshot version of jackson have an incompatible version of jackson resolved via the rich version declaration

### Changes Proposed
* Fully exclude jackson 3.x (incl. snapshots) in the rich version declaration
* Bump preferred version of jackson to `2.13.3`

### Additional Information
In the [rich version declaration](https://github.com/twitch4j/twitch4j/blob/6e704eae9f46ac99f94adf757617232bd5c7f2d4/build.gradle.kts#L113), we exclude jackson 3.x

However, maven [resolves](https://maven.apache.org/pom.html#Version_Order_Specification): `3-snapshot < 3`, so it allows `3.0.0-SNAPSHOT` to be selected

Further, maven [ignores](https://docs.gradle.org/current/userguide/rich_versions.html) the `prefer` version in the presence of `strictly`, unlike gradle (explaining why gradle users did not encounter this problem)

&nbsp;

```
$ java -jar maven-artifact.jar 2.12 2.12.0 2.13.3 3-alpha 3.0-SNAPSHOT 3.0.0

Display parameters as parsed by Maven (in canonical form) and comparison result:
1. 2.12 == 2.12
   2.12 == 2.12.0
2. 2.12.0 == 2.12
   2.12.0 < 2.13.3
3. 2.13.3 == 2.13.3
   2.13.3 < 3-alpha
4. 3-alpha == 3-alpha
   3-alpha < 3.0-SNAPSHOT
5. 3.0-SNAPSHOT == 3-snapshot
   3.0-SNAPSHOT < 3.0.0
6. 3.0.0 == 3
```