### PR TITLE
fix(auth): clean up response body in isCredentialValid

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java
@@ -47,16 +47,14 @@ public class TwitchIdentityProvider extends OAuth2IdentityProvider {
         if (credential == null || credential.getAccessToken() == null || credential.getAccessToken().isEmpty())
             return Optional.of(false);
 
-        try {
-            // build request
-            Request request = new Request.Builder()
-                .url("https://id.twitch.tv/oauth2/validate")
-                .header("Authorization", "OAuth " + credential.getAccessToken())
-                .build();
+        // build request
+        Request request = new Request.Builder()
+            .url("https://id.twitch.tv/oauth2/validate")
+            .header("Authorization", "OAuth " + credential.getAccessToken())
+            .build();
 
-            // perform call
-            Response response = httpClient.newCall(request).execute();
-
+        // perform call
+        try (Response response = httpClient.newCall(request).execute()) {
             // return token status
             if (response.isSuccessful())
                 return Optional.of(true);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* `[OkHttp ConnectionPool/WARN]: A connection to https://id.twitch.tv/ was leaked. Did you forget to close a response body?`

### Changes Proposed
* Apply try-with-resources on `Response` in `TwitchIdentityProvider#isCredentialValid` (which closes the body)

### Additional Information
Since a response body is present but never consumed, it was not being closed
