### PR TITLE
feat: allow custom websocket close delay

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
@@ -22,9 +22,9 @@ public class TwitchAuth {
      * Twitch Identity Provider
      *
      * @param credentialManager Credential Manager
-     * @param clientId OAuth2 Client Id
-     * @param clientSecret OAuth2 Client Secret
-     * @param redirectUrl OAuth2 Redirect Url
+     * @param clientId          OAuth2 Client Id
+     * @param clientSecret      OAuth2 Client Secret
+     * @param redirectUrl       OAuth2 Redirect Url
      */
     public TwitchAuth(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl) {
         this.credentialManager = credentialManager;
@@ -37,9 +37,13 @@ public class TwitchAuth {
         if (!ip.isPresent()) {
             // register
             IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl);
-            credentialManager.registerIdentityProvider(identityProvider);
+            try {
+                credentialManager.registerIdentityProvider(identityProvider);
+            } catch (Exception e) {
+                log.error("TwitchAuth: Encountered conflicting identity provider!", e);
+            }
         } else {
-            log.warn("TwitchIdentityProvider was already registered, ignoring call to TwitchAuth.registerIdentityProvider!");
+            log.debug("TwitchIdentityProvider was already registered, ignoring call to TwitchAuth.registerIdentityProvider!");
         }
     }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -270,8 +270,9 @@ public class TwitchChat implements ITwitchChat {
      * @param connectionBackoffStrategy      WebSocket Connection Backoff Strategy
      * @param perChannelRateLimit            Per channel message limit
      * @param validateOnConnect              Whether token should be validated on connect
+     * @param wsCloseDelay                   Websocket Close Delay
      */
-    public TwitchChat(WebsocketConnection websocketConnection, EventManager eventManager, CredentialManager credentialManager, OAuth2Credential chatCredential, String baseUrl, boolean sendCredentialToThirdPartyHost, Collection<String> commandPrefixes, Integer chatQueueSize, Bucket ircMessageBucket, Bucket ircWhisperBucket, Bucket ircJoinBucket, Bucket ircAuthBucket, ScheduledThreadPoolExecutor taskExecutor, long chatQueueTimeout, ProxyConfig proxyConfig, boolean autoJoinOwnChannel, boolean enableMembershipEvents, Collection<String> botOwnerIds, boolean removeChannelOnJoinFailure, int maxJoinRetries, long chatJoinTimeout, int wsPingPeriod, IBackoffStrategy connectionBackoffStrategy, Bandwidth perChannelRateLimit, boolean validateOnConnect) {
+    public TwitchChat(WebsocketConnection websocketConnection, EventManager eventManager, CredentialManager credentialManager, OAuth2Credential chatCredential, String baseUrl, boolean sendCredentialToThirdPartyHost, Collection<String> commandPrefixes, Integer chatQueueSize, Bucket ircMessageBucket, Bucket ircWhisperBucket, Bucket ircJoinBucket, Bucket ircAuthBucket, ScheduledThreadPoolExecutor taskExecutor, long chatQueueTimeout, ProxyConfig proxyConfig, boolean autoJoinOwnChannel, boolean enableMembershipEvents, Collection<String> botOwnerIds, boolean removeChannelOnJoinFailure, int maxJoinRetries, long chatJoinTimeout, int wsPingPeriod, IBackoffStrategy connectionBackoffStrategy, Bandwidth perChannelRateLimit, boolean validateOnConnect, int wsCloseDelay) {
         this.eventManager = eventManager;
         this.credentialManager = credentialManager;
         this.chatCredential = chatCredential;
@@ -304,6 +305,7 @@ public class TwitchChat implements ITwitchChat {
         if (websocketConnection == null) {
             this.connection = new WebsocketConnection(spec -> {
                 spec.baseUrl(baseUrl);
+                spec.closeDelay(wsCloseDelay);
                 spec.wsPingPeriod(wsPingPeriod);
                 spec.onStateChanged((oldState, newState) -> eventManager.publish(new ChatConnectionStateEvent(oldState, newState, this)));
                 spec.onConnected(this::onConnected);

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -31,6 +31,7 @@ import io.github.xanthic.cache.api.Cache;
 import io.github.xanthic.cache.api.domain.ExpiryType;
 import io.github.xanthic.cache.core.CacheApi;
 import lombok.Getter;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -817,11 +818,12 @@ public class TwitchChat implements ITwitchChat {
     /**
      * Close
      */
+    @SneakyThrows
     @Override
     public void close() {
         this.stopQueueThread = true;
         queueThread.cancel(false);
-        this.disconnect();
+        connection.close();
     }
 
     @Override

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -11,6 +11,7 @@ import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
 import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
 import com.github.twitch4j.client.websocket.WebsocketConnection;
+import com.github.twitch4j.client.websocket.WebsocketConnectionConfig;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
 import com.github.twitch4j.common.enums.TwitchLimitType;
@@ -253,6 +254,14 @@ public class TwitchChatBuilder {
     private int wsPingPeriod = 15_000;
 
     /**
+     * Websocket Close Delay in ms (0 = minimum)
+
+     * @see WebsocketConnectionConfig#closeDelay()
+     */
+    @With
+    private int wsCloseDelay = 1_000;
+
+    /**
      * WebSocket Connection Backoff Strategy
      */
     @With
@@ -327,7 +336,7 @@ public class TwitchChatBuilder {
             perChannelRateLimit = chatRateLimit;
 
         log.debug("TwitchChat: Initializing Module ...");
-        return new TwitchChat(this.websocketConnection, this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod, this.connectionBackoffStrategy, this.perChannelRateLimit, this.verifyChatAccountOnReconnect);
+        return new TwitchChat(this.websocketConnection, this.eventManager, this.credentialManager, this.chatAccount, this.baseUrl, this.sendCredentialToThirdPartyHost, this.commandPrefixes, this.chatQueueSize, this.ircMessageBucket, this.ircWhisperBucket, this.ircJoinBucket, this.ircAuthBucket, this.scheduledThreadPoolExecutor, this.chatQueueTimeout, this.proxyConfig, this.autoJoinOwnChannel, this.enableMembershipEvents, this.botOwnerIds, this.removeChannelOnJoinFailure, this.maxJoinRetries, this.chatJoinTimeout, this.wsPingPeriod, this.connectionBackoffStrategy, this.perChannelRateLimit, this.verifyChatAccountOnReconnect, this.wsCloseDelay);
     }
 
     /**

--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
@@ -308,7 +308,7 @@ public class WebsocketConnection implements AutoCloseable {
         } finally {
             // await the close of the underlying socket
             try {
-                boolean completed = closeLatch.await(Math.max(1000, config.closeDelay()) * 2L, TimeUnit.MILLISECONDS);
+                boolean completed = closeLatch.await(config.closeDelay() + 1000L, TimeUnit.MILLISECONDS);
                 if (completed) {
                     log.trace("Underlying websocket complete close was successful");
                 } else {

--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
@@ -352,7 +352,7 @@ public class WebsocketConnection implements AutoCloseable {
         // Clean up the socket
         final WebSocket socket = this.webSocket;
         if (socket != null) {
-            // The disconnecting socket no needs to invoke this.webSocketAdapter
+            // The disconnecting socket no longer needs to invoke this.webSocketAdapter
             socket.clearListeners();
 
             // However, if a full close is requested, we should track when the underlying socket closes to release the latch.

--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
@@ -297,6 +297,9 @@ public class WebsocketConnection implements AutoCloseable {
         if (closed.getAndSet(true))
             return; // resource close was already requested
 
+        if (backoffClearer != null)
+            backoffClearer.cancel(false);
+
         try {
             disconnect();
         } catch (Exception e) {

--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnection.java
@@ -4,6 +4,7 @@ import com.github.twitch4j.client.websocket.domain.WebsocketConnectionState;
 import com.github.twitch4j.common.util.ExponentialBackoffStrategy;
 import com.neovisionaries.ws.client.WebSocket;
 import com.neovisionaries.ws.client.WebSocketAdapter;
+import com.neovisionaries.ws.client.WebSocketCloseCode;
 import com.neovisionaries.ws.client.WebSocketFactory;
 import com.neovisionaries.ws.client.WebSocketFrame;
 import lombok.Getter;
@@ -149,6 +150,7 @@ public class WebsocketConnection implements AutoCloseable {
 
     protected WebSocket createWebsocket() throws IOException {
         WebSocket ws = webSocketFactory.createSocket(config.baseUrl());
+        ws.setMissingCloseFrameAllowed(true);
         ws.setPingInterval(config.wsPingPeriod());
         if (config.headers() != null)
             config.headers().forEach(ws::addHeader);
@@ -288,7 +290,7 @@ public class WebsocketConnection implements AutoCloseable {
     private void closeSocket() {
         // Clean up the socket
         if (webSocket != null) {
-            this.webSocket.disconnect();
+            this.webSocket.disconnect(WebSocketCloseCode.NORMAL, null, config.closeDelay());
             this.webSocket.clearListeners();
             this.webSocket = null;
         }

--- a/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnectionConfig.java
+++ b/client-websocket/src/main/java/com/github/twitch4j/client/websocket/WebsocketConnectionConfig.java
@@ -42,6 +42,9 @@ public class WebsocketConnectionConfig {
         if (socketTimeout < 0) {
             throw new RuntimeException("socketTimeout must be 0 or greater, set to 0 to disable!");
         }
+        if (closeDelay < 0) {
+            throw new RuntimeException("closeDelay must be 0 or greater!");
+        }
         Objects.requireNonNull(taskExecutor, "taskExecutor may not be null!");
         Objects.requireNonNull(backoffStrategy, "backoffStrategy may not be null!");
         Objects.requireNonNull(onStateChanged, "onStateChanged may not be null!");
@@ -74,6 +77,14 @@ public class WebsocketConnectionConfig {
      * Websocket timeout milliseconds for read and write operations (0 = disabled).
      */
     private int socketTimeout = 30_000;
+
+    /**
+     * The maximum number of milliseconds to wait after sending a close frame
+     * to receive confirmation from the server, before fully closing the socket.
+     * <p>
+     * This can be set as low as 0 for applications that require prompt socket closes upon disconnect calls.
+     */
+    private int closeDelay = 1_000;
 
     /**
      * WebSocket Headers

--- a/kotlin/src/test/kotlin/com/github/twitch4j/kotlin/mock/MockChat.kt
+++ b/kotlin/src/test/kotlin/com/github/twitch4j/kotlin/mock/MockChat.kt
@@ -34,7 +34,8 @@ class MockChat : TwitchChat(
     0,
     null,
     TwitchChatLimitHelper.MOD_MESSAGE_LIMIT,
-    false
+    false,
+    0
 ) {
     @Volatile
     var isConnected = false

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -127,6 +127,7 @@ import com.github.twitch4j.pubsub.events.UserUnbanRequestUpdateEvent;
 import com.github.twitch4j.pubsub.events.VideoPlaybackEvent;
 import com.github.twitch4j.util.IBackoffStrategy;
 import lombok.Getter;
+import lombok.SneakyThrows;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -857,13 +858,14 @@ public class TwitchPubSub implements ITwitchPubSub {
     /**
      * Close
      */
+    @SneakyThrows
     @Override
     public void close() {
         if (!isClosed) {
             isClosed = true;
             heartbeatTask.cancel(false);
             queueTask.cancel(false);
-            disconnect();
+            connection.close();
         }
     }
 

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -245,8 +245,9 @@ public class TwitchPubSub implements ITwitchPubSub {
      * @param botOwnerIds               Bot Owner IDs
      * @param wsPingPeriod              WebSocket Ping Period
      * @param connectionBackoffStrategy WebSocket Connection Backoff Strategy
+     * @param wsCloseDelay              Websocket Close Delay
      */
-    public TwitchPubSub(WebsocketConnection websocketConnection, EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds, int wsPingPeriod, IBackoffStrategy connectionBackoffStrategy) {
+    public TwitchPubSub(WebsocketConnection websocketConnection, EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds, int wsPingPeriod, IBackoffStrategy connectionBackoffStrategy, int wsCloseDelay) {
         this.eventManager = eventManager;
         this.taskExecutor = taskExecutor;
         this.botOwnerIds = botOwnerIds;
@@ -255,6 +256,7 @@ public class TwitchPubSub implements ITwitchPubSub {
         if (websocketConnection == null) {
             this.connection = new WebsocketConnection(spec -> {
                 spec.baseUrl(WEB_SOCKET_SERVER);
+                spec.closeDelay(wsCloseDelay);
                 spec.wsPingPeriod(wsPingPeriod);
                 spec.onStateChanged((oldState, newState) -> eventManager.publish(new PubSubConnectionStateEvent(oldState, newState, this)));
                 spec.onPreConnect(this::onPreConnect);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.api.service.IEventHandler;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.client.websocket.WebsocketConnection;
+import com.github.twitch4j.client.websocket.WebsocketConnectionConfig;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.EventManagerUtils;
 import com.github.twitch4j.common.util.ThreadUtils;
@@ -72,6 +73,14 @@ public class TwitchPubSubBuilder {
     private int wsPingPeriod = 15_000;
 
     /**
+     * Websocket Close Delay in ms (0 = minimum)
+
+     * @see WebsocketConnectionConfig#closeDelay()
+     */
+    @With
+    private int wsCloseDelay = 1_000;
+
+    /**
      * WebSocket Connection Backoff Strategy
      */
     @With
@@ -99,7 +108,7 @@ public class TwitchPubSubBuilder {
         // Initialize/Check EventManager
         eventManager = EventManagerUtils.validateOrInitializeEventManager(eventManager, defaultEventHandler);
 
-        return new TwitchPubSub(this.websocketConnection, this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds, this.wsPingPeriod, this.connectionBackoffStrategy);
+        return new TwitchPubSub(this.websocketConnection, this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds, this.wsPingPeriod, this.connectionBackoffStrategy, this.wsCloseDelay);
     }
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -10,6 +10,7 @@ import com.github.twitch4j.auth.TwitchAuth;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.TwitchChatBuilder;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
+import com.github.twitch4j.client.websocket.WebsocketConnectionConfig;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
@@ -286,6 +287,15 @@ public class TwitchClientBuilder {
     private int wsPingPeriod = 15_000;
 
     /**
+     * Websocket Close Delay in ms (0 = minimum)
+
+     * @see WebsocketConnectionConfig#closeDelay()
+     */
+    @With
+    private int wsCloseDelay = 1_000;
+
+
+    /**
      * With a Bot Owner's User ID
      *
      * @param userId the user id
@@ -440,6 +450,7 @@ public class TwitchClientBuilder {
                 .setBotOwnerIds(botOwnerIds)
                 .setCommandPrefixes(commandPrefixes)
                 .withWsPingPeriod(wsPingPeriod)
+                .withWsCloseDelay(wsCloseDelay)
                 .build();
         }
 
@@ -452,6 +463,7 @@ public class TwitchClientBuilder {
                 .withProxyConfig(proxyConfig)
                 .setBotOwnerIds(botOwnerIds)
                 .withWsPingPeriod(wsPingPeriod)
+                .withWsCloseDelay(wsCloseDelay)
                 .build();
         }
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -12,6 +12,7 @@ import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.TwitchChatBuilder;
 import com.github.twitch4j.chat.TwitchChatConnectionPool;
 import com.github.twitch4j.chat.util.TwitchChatLimitHelper;
+import com.github.twitch4j.client.websocket.WebsocketConnectionConfig;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.config.Twitch4JGlobal;
@@ -303,6 +304,14 @@ public class TwitchClientPoolBuilder {
     private int wsPingPeriod = 15_000;
 
     /**
+     * Websocket Close Delay in ms (0 = minimum)
+
+     * @see WebsocketConnectionConfig#closeDelay()
+     */
+    @With
+    private int wsCloseDelay = 1_000;
+
+    /**
      * With a Bot Owner's User ID
      *
      * @param userId the user id
@@ -458,6 +467,7 @@ public class TwitchClientPoolBuilder {
                         .withChatQueueTimeout(chatQueueTimeout)
                         .withMaxJoinRetries(chatMaxJoinRetries)
                         .withWsPingPeriod(wsPingPeriod)
+                        .withWsCloseDelay(wsCloseDelay)
                         .setCommandPrefixes(commandPrefixes)
                         .setBotOwnerIds(botOwnerIds)
                 )
@@ -481,6 +491,7 @@ public class TwitchClientPoolBuilder {
                 .setBotOwnerIds(botOwnerIds)
                 .setCommandPrefixes(commandPrefixes)
                 .withWsPingPeriod(wsPingPeriod)
+                .withWsCloseDelay(wsCloseDelay)
                 .build();
         }
 
@@ -491,7 +502,11 @@ public class TwitchClientPoolBuilder {
                 .eventManager(eventManager)
                 .executor(() -> scheduledThreadPoolExecutor)
                 .proxyConfig(() -> proxyConfig)
-                .advancedConfiguration(builder -> builder.withWsPingPeriod(wsPingPeriod).setBotOwnerIds(botOwnerIds))
+                .advancedConfiguration(builder ->
+                    builder.withWsPingPeriod(wsPingPeriod)
+                        .withWsCloseDelay(wsCloseDelay)
+                        .setBotOwnerIds(botOwnerIds)
+                )
                 .build();
         } else if (this.enablePubSub) {
             pubSub = TwitchPubSubBuilder.builder()
@@ -499,6 +514,7 @@ public class TwitchClientPoolBuilder {
                 .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
                 .withProxyConfig(proxyConfig)
                 .withWsPingPeriod(wsPingPeriod)
+                .withWsCloseDelay(wsCloseDelay)
                 .setBotOwnerIds(botOwnerIds)
                 .build();
         }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Allows for faster underlying socket close for applications where this is required (e.g., minecraft plugins on disable, which triggers class unloading)

### Changes Proposed
* Add `closeDelay` to `WebsocketConnectionConfig`
* Don't return from `WebsocketConnection#close` until the underlying `Socket` has fully closed

### Additional Information
`nv-websocket-client` defaults `closeDelay` to `10_000` - this seems high to just wait for a single frame, so we default to `1000` instead (this part of the websocket protocol is just good manners anyway, so it's not the end of the world if formal close isn't received)
