### PR TITLE
fix(charity): resolve twitch doc issues

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCharityDonateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCharityDonateEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.common.util.DonationAmount;
 import lombok.AccessLevel;
@@ -25,6 +26,7 @@ public class ChannelCharityDonateEvent extends EventSubUserChannelEvent {
     /**
      * An object that contains the amount of the user’s donation.
      */
+    @JsonAlias("target_amount") // https://github.com/twitchdev/issues/issues/642
     private DonationAmount amount;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelCharityDonateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelCharityDonateType.java
@@ -14,7 +14,7 @@ import com.github.twitch4j.eventsub.events.ChannelCharityDonateEvent;
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_CHARITY_READ
  */
 @Unofficial
-public class ChannelCharityDonateType implements SubscriptionType<ChannelCharityCampaignCondition, ChannelCharityCampaignCondition.ChannelCharityCampaignConditionBuilder<?, ?>, ChannelCharityDonateEvent> {
+public class BetaChannelCharityDonateType implements SubscriptionType<ChannelCharityCampaignCondition, ChannelCharityCampaignCondition.ChannelCharityCampaignConditionBuilder<?, ?>, ChannelCharityDonateEvent> {
 
     @Override
     public String getName() {
@@ -23,7 +23,7 @@ public class ChannelCharityDonateType implements SubscriptionType<ChannelCharity
 
     @Override
     public String getVersion() {
-        return "1";
+        return "beta";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -14,7 +14,7 @@ public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
     public final ChannelBanType CHANNEL_BAN;
-    @Unofficial public final ChannelCharityDonateType CHANNEL_CHARITY_DONATE;
+    @Unofficial public final BetaChannelCharityDonateType BETA_CHANNEL_CHARITY_DONATE;
     public final ChannelCheerType CHANNEL_CHEER;
     public final ChannelFollowType CHANNEL_FOLLOW;
     public final ChannelGoalBeginType CHANNEL_GOAL_BEGIN;
@@ -60,7 +60,7 @@ public class SubscriptionTypes {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
                 CHANNEL_BAN = new ChannelBanType(),
-                CHANNEL_CHARITY_DONATE = new ChannelCharityDonateType(),
+                BETA_CHANNEL_CHARITY_DONATE = new BetaChannelCharityDonateType(),
                 CHANNEL_CHEER = new ChannelCheerType(),
                 CHANNEL_FOLLOW = new ChannelFollowType(),
                 CHANNEL_GOAL_BEGIN = new ChannelGoalBeginType(),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -330,7 +330,7 @@ public interface TwitchHelix {
      * <p>
      * The ID in the broadcaster_id query parameter must match the user ID in the access token.
      * <p>
-     * To receive events as donations occur, use {@link com.github.twitch4j.eventsub.subscriptions.SubscriptionTypes#CHANNEL_CHARITY_DONATE}.
+     * To receive events as donations occur, use {@link com.github.twitch4j.eventsub.subscriptions.SubscriptionTypes#BETA_CHANNEL_CHARITY_DONATE}.
      *
      * @param authToken     Broadcaster user access token with the channel:read:charity scope.
      * @param broadcasterId The ID of the broadcaster that’s actively running a charity campaign.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/642

### Changes Proposed
* Version for `channel.charity_campaign.donate` should be `beta` (this was [initially](https://web.archive.org/web/20220829104434/https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types) documented as `1`, but was silently changed)
* For `ChannelCharityDonateEvent`, twitch (mistakenly) sends `target_amount` as the field name for `amount`
