### PR TITLE
chore: deprecate poll bits due to twitch change

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/BitsVoting.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/BitsVoting.java
@@ -7,9 +7,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+/**
+ * @deprecated Twitch no longer supports bits on polls.
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class BitsVoting {
 
     /**
@@ -17,11 +21,11 @@ public class BitsVoting {
      */
     @Accessors(fluent = true)
     @JsonProperty("is_enabled")
-    private Boolean isEnabled;
+    private Boolean isEnabled = false;
 
     /**
      * Number of Bits required to vote once with Bits.
      */
-    private Integer amountPerVote;
+    private Integer amountPerVote = 0;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollChoice.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/PollChoice.java
@@ -45,8 +45,11 @@ public class PollChoice {
 
     /**
      * Number of votes received via Bits.
+     *
+     * @deprecated Twitch no longer supports bits on polls.
      */
     @Nullable
+    @Deprecated
     private Integer bitsVotes;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelPollEvent.java
@@ -39,7 +39,10 @@ public abstract class ChannelPollEvent extends EventSubChannelEvent {
 
     /**
      * The Bits voting settings for the poll.
+     *
+     * @deprecated Twitch no longer supports bits on polls.
      */
+    @Deprecated
     private BitsVoting bitsVoting;
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PollData.java
@@ -24,6 +24,7 @@ public class PollData {
     private Integer totalVoters;
     private Long remainingDurationMilliseconds;
     private Contributor topContributor;
+    @Deprecated
     private Contributor topBitsContributor;
     private Contributor topChannelPointsContributor;
 
@@ -32,6 +33,7 @@ public class PollData {
         private Setting multiChoice;
         private Setting subscriberOnly;
         private Setting subscriberMultiplier;
+        @Deprecated
         private Setting bitsVotes;
         private Setting channelPointsVotes;
 
@@ -54,6 +56,7 @@ public class PollData {
     @Data
     public static class Votes {
         private Long total;
+        @Deprecated
         private Long bits;
         private Long channelPoints;
         private Long base;
@@ -61,6 +64,7 @@ public class PollData {
 
     @Data
     public static class Tokens {
+        @Deprecated
         private Long bits;
         private Long channelPoints;
     }
@@ -69,6 +73,7 @@ public class PollData {
     public static class Contributor {
         private String userId;
         private String displayName;
+        @Deprecated
         private Long bitsContributed;
         private Long channelPointsContributed;
     }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
@@ -64,14 +64,20 @@ public class Poll {
 
     /**
      * Indicates whether Bits can be used for voting. Default: false.
+     *
+     * @deprecated Twitch no longer supports bits on polls.
      */
+    @Deprecated
     @Accessors(fluent = true)
     @JsonProperty("bits_voting_enabled")
-    private Boolean isBitsVotingEnabled;
+    private Boolean isBitsVotingEnabled = false;
 
     /**
      * Number of Bits required to vote once with Bits. Minimum: 0. Maximum: 10000.
+     *
+     * @deprecated Twitch no longer supports bits on polls.
      */
+    @Deprecated
     private Integer bitsPerVote;
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Deprecate references to bits on poll objects across helix/eventsub/pubsub

### Additional Information
![image](https://user-images.githubusercontent.com/8106344/188036145-06a25f5a-959d-49af-9720-aa35549be743.png)
