### PR TITLE
fix: parse latest time format of helix teams

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/AlternativeInstantDeserializer.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/AlternativeInstantDeserializer.java
@@ -17,6 +17,15 @@ public class AlternativeInstantDeserializer extends JsonDeserializer<Instant> {
 
         str = str.trim();
 
+        // Accounts for https://github.com/twitchdev/issues/issues/644
+        if (str.startsWith("seconds:")) {
+            int startIndex = "seconds:".length();
+            int endIndex = str.indexOf(' ', startIndex + 1);
+            String seconds = str.substring(startIndex, endIndex > 0 ? endIndex : str.length());
+            return Instant.ofEpochSecond(Integer.parseInt(seconds));
+        }
+
+        // Accounts for https://github.com/twitchdev/issues/issues/347
         if (str.endsWith(" +0000 UTC"))
             str = str.substring(0, str.length() - " +0000 UTC".length()) + "Z";
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/644
* https://github.com/twitchdev/issues/issues/347

### Changes Proposed
* Adds yet another branch to the unconventional timestamp parser for helix teams endpoints, as a result of a new non-standard timestamp format being sent
