### PR TITLE
chore: deprecate irc commands due to twitch announcement

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
@@ -124,7 +124,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel The target channel name.
      * @param seconds The slow mode seconds.
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
+    @Deprecated
     default boolean setSlowMode(String channel, int seconds) {
         if (seconds <= 0)
             return this.sendMessage(channel, "/slowoff");
@@ -142,7 +144,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel The target channel name.
      * @param time    The amount of time users must be followed.
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
+    @Deprecated
     default boolean setFollowersOnly(String channel, Duration time) {
         if (time == null || time.isNegative())
             return this.sendMessage(channel, "/followersoff");
@@ -156,7 +160,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel The target channel name.
      * @param enable  Whether the setting should be enabled or disabled.
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
+    @Deprecated
     default boolean setSubscribersOnly(String channel, boolean enable) {
         return this.sendMessage(channel, enable ? "/subscribers" : "/subscribersoff");
     }
@@ -167,7 +173,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel The target channel name.
      * @param enable  Whether the setting should be enabled or disabled.
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
+    @Deprecated
     default boolean setUniqueChat(String channel, boolean enable) {
         return this.sendMessage(channel, enable ? "/uniquechat" : "/uniquechatoff");
     }
@@ -178,7 +186,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel The target channel name.
      * @param enable  Whether the setting should be enabled or disabled.
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
+    @Deprecated
     default boolean setEmoteOnly(String channel, boolean enable) {
         return this.sendMessage(channel, enable ? "/emoteonly" : "/emoteonlyoff");
     }
@@ -188,7 +198,9 @@ public interface ITwitchChat extends AutoCloseable {
      *
      * @param channel The target channel name.
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#deleteChatMessages
      */
+    @Deprecated
     default boolean clearChat(String channel) {
         return this.sendMessage(channel, "/clear");
     }
@@ -200,7 +212,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param targetMsgId the unique id of the message to be deleted.
      * @return whether the command was added to the queue
      * @see IRCMessageEvent#getMessageId()
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#deleteChatMessages
      */
+    @Deprecated
     default boolean delete(String channel, String targetMsgId) {
         return this.sendMessage(channel, String.format("/delete %s", targetMsgId));
     }
@@ -213,7 +227,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param duration duration
      * @param reason   reason
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
+    @Deprecated
     default boolean timeout(String channel, String user, Duration duration, String reason) {
         StringBuilder sb = new StringBuilder(user).append(' ').append(duration.getSeconds());
         if (reason != null) {
@@ -230,7 +246,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param user    username
      * @param reason  reason
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
+    @Deprecated
     default boolean ban(String channel, String user, String reason) {
         StringBuilder sb = new StringBuilder(user);
         if (reason != null) {
@@ -246,7 +264,9 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel channel
      * @param user    username
      * @return whether the command was added to the queue
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
+    @Deprecated
     default boolean unban(String channel, String user) {
         return this.sendMessage(channel, String.format("/unban %s", user));
     }
@@ -258,8 +278,10 @@ public interface ITwitchChat extends AutoCloseable {
      * @param message the message to be announced.
      * @return whether the command was added to the queue
      * @see <a href="https://twitter.com/TwitchSupport/status/1509634525982302208">Official Announcement</a>
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#sendChatAnnouncement
      */
     @Unofficial
+    @Deprecated
     default boolean sendAnnouncement(String channel, String message) {
         return this.sendMessage(channel, String.format("/announce %s", message));
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -782,7 +782,9 @@ public class TwitchChat implements ITwitchChat {
      *
      * @param targetUser username
      * @param message    message
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#sendWhisper
      */
+    @Deprecated
     public void sendPrivateMessage(String targetUser, String message) {
         log.debug("Adding private message for user [{}] with content [{}] to the queue.", targetUser, message);
         BucketUtils.scheduleAgainstBucket(

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -145,8 +145,12 @@ public class TwitchChatBuilder {
 
     /**
      * Custom RateLimit for Whispers
+     *
+     * @deprecated Twitch will decommission whispers over IRC on February 18, 2023;
+     * please migrate to TwitchHelix#sendWhisper and TwitchLimitRegistry#setLimit
      */
     @With
+    @Deprecated
     protected Bandwidth[] whisperRateLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT.toArray(new Bandwidth[2]);
 
     /**
@@ -177,8 +181,12 @@ public class TwitchChatBuilder {
 
     /**
      * Shared bucket for whispers
+     *
+     * @deprecated Twitch will decommission whispers over IRC on February 18, 2023;
+     * please migrate to TwitchHelix#sendWhisper and TwitchLimitRegistry#setLimit
      */
     @With
+    @Deprecated
     protected Bucket ircWhisperBucket = null;
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatConnectionPool.java
@@ -178,7 +178,9 @@ public class TwitchChatConnectionPool extends TwitchModuleConnectionPool<TwitchC
      * @param message                       the message to send in the whisper.
      * @return whether a {@link TwitchChat} instance was identified to send the message from.
      * @throws NullPointerException if the identified {@link TwitchChat} does not have a valid chatCredential
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
+    @Deprecated
     public boolean sendPrivateMessage(final String channelToIdentifyChatInstance, final String toChannel, final String message) {
         final TwitchChat chat;
         if (channelToIdentifyChatInstance == null || (chat = subscriptions.get(channelToIdentifyChatInstance.toLowerCase())) == null)

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -591,6 +591,7 @@ public class IRCEventHandler {
         }
     }
 
+    @Deprecated
     public void onListModsEvent(IRCMessageEvent event) {
         if ("NOTICE".equals(event.getCommandType()) && event.getTagValue("msg-id").filter(s -> s.equals(NoticeTag.ROOM_MODS.toString()) || s.equals(NoticeTag.NO_MODS.toString())).isPresent()) {
             List<String> names = extractItemsFromDelimitedList(event.getMessage(), "The moderators of this channel are: ", ", ");
@@ -598,6 +599,7 @@ public class IRCEventHandler {
         }
     }
 
+    @Deprecated
     public void onListVipsEvent(IRCMessageEvent event) {
         if ("NOTICE".equals(event.getCommandType()) && event.getTagValue("msg-id").filter(s -> s.equals(NoticeTag.VIPS_SUCCESS.toString()) || s.equals(NoticeTag.NO_VIPS.toString())).isPresent()) {
             List<String> names = extractItemsFromDelimitedList(event.getMessage(), "The VIPs of this channel are: ", ", ");

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ListModsEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ListModsEvent.java
@@ -9,9 +9,15 @@ import lombok.Value;
 
 import java.util.List;
 
+/**
+ * Called following a /mods message.
+ *
+ * @deprecated Twitch will decommission this event on February 18, 2023; migrate to TwitchHelix#getModerators
+ */
 @Value
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
 public class ListModsEvent extends AbstractChannelEvent {
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ListVipsEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ListVipsEvent.java
@@ -9,9 +9,15 @@ import lombok.Value;
 
 import java.util.List;
 
+/**
+ * Called following a /vips message.
+ *
+ * @deprecated Twitch will decommission this event on February 18, 2023; migrate to TwitchHelix#getChannelVips
+ */
 @Value
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@Deprecated
 public class ListVipsEvent extends AbstractChannelEvent {
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -182,8 +182,12 @@ public class TwitchClientBuilder {
 
     /**
      * Custom RateLimit for Whispers
+     *
+     * @deprecated Twitch will decommission whispers over IRC on February 18, 2023;
+     * please migrate to TwitchHelix#sendWhisper and TwitchLimitRegistry#setLimit
      */
     @With
+    @Deprecated
     protected Bandwidth[] chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT.toArray(new Bandwidth[2]);
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -199,8 +199,12 @@ public class TwitchClientPoolBuilder {
 
     /**
      * Custom RateLimit for Whispers
+     *
+     * @deprecated Twitch will decommission whispers over IRC on February 18, 2023;
+     * please migrate to TwitchHelix#sendWhisper and TwitchLimitRegistry#setLimit
      */
     @With
+    @Deprecated
     protected Bandwidth[] chatWhisperLimit = TwitchChatLimitHelper.USER_WHISPER_LIMIT.toArray(new Bandwidth[2]);
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate irc commands that will be removed on 2023-02-18 in favor of helix equivalents

### Additional Information
https://discuss.dev.twitch.tv/t/deprecation-of-chat-commands-through-irc/40486
