### PR TITLE
docs: reflect looser auth for getChannelChatBadges

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -374,8 +374,8 @@ public interface TwitchHelix {
      * Gets a list of custom chat badges that can be used in chat for the specified channel.
      * This includes <a href="https://help.twitch.tv/s/article/subscriber-badge-guide">subscriber badges</a> and <a href="https://help.twitch.tv/s/article/custom-bit-badges-guide">Bit badges</a>.
      *
-     * @param authToken     User OAuth Token from the broadcaster.
-     * @param broadcasterId The id of the broadcaster whose chat badges are being requested. Provided broadcaster_id must match the user_id in the user OAuth token.
+     * @param authToken     App or User OAuth Token.
+     * @param broadcasterId The id of the broadcaster whose chat badges are being requested.
      * @return ChatBadgeSetList
      */
     @RequestLine("GET /chat/badges?broadcaster_id={broadcaster_id}")


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* `getChannelChatBadges` was changed to not require a broadcaster token; update the javadoc accordingly

### Additional Information
https://twitch.uservoice.com/forums/310213-developers/suggestions/43614432-allow-access-to-the-get-channel-chat-badges-endp
