### PR TITLE
feat: fetch mods and vips over gql

### DIFF
--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchModsQuery.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchModsQuery.graphql
@@ -1,0 +1,19 @@
+query fetchMods($channelLogin: String!, $first: Int = 10, $after: Cursor) {
+	user(login: $channelLogin) {
+		id
+		mods(first: $first, after: $after) {
+			edges {
+				cursor
+				grantedAt
+				node {
+					id
+					displayName
+					login
+				}
+			}
+			pageInfo {
+				hasNextPage
+			}
+		}
+	}
+}

--- a/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchVipsQuery.graphql
+++ b/graphql/src/main/graphql/com/github/twitch4j/graphql/internal/fetchVipsQuery.graphql
@@ -1,0 +1,19 @@
+query fetchVips($channelLogin: String!, $first: Int = 10, $after: Cursor) {
+	user(login: $channelLogin) {
+		id
+		vips(first: $first, after: $after) {
+			edges {
+				cursor
+				grantedAt
+				node {
+					id
+					displayName
+					login
+				}
+			}
+			pageInfo {
+				hasNextPage
+			}
+		}
+	}
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/TwitchGraphQL.java
@@ -250,6 +250,10 @@ public class TwitchGraphQL {
         return new CommandFetchModComments(getApolloClient(auth), channelId, targetId, after);
     }
 
+    public CommandFetchMods fetchMods(OAuth2Credential auth, String channelLogin, String after, Integer limit) {
+        return new CommandFetchMods(getApolloClient(auth), channelLogin, after, limit);
+    }
+
     public CommandArchivePoll archivePoll(OAuth2Credential auth, String pollId) {
         return new CommandArchivePoll(getApolloClient(auth), pollId);
     }
@@ -337,6 +341,10 @@ public class TwitchGraphQL {
 
     public CommandFetchVideoComments fetchVideoComments(OAuth2Credential auth, String channelId, String videoId, String id, String after, String before, Integer first, Integer last) {
         return new CommandFetchVideoComments(getApolloClient(auth), channelId, videoId, id, after, before, first, last);
+    }
+
+    public CommandFetchVips fetchVips(OAuth2Credential auth, String channelLogin, String after, Integer limit) {
+        return new CommandFetchVips(getApolloClient(auth), channelLogin, after, limit);
     }
 
     /**

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchMods.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchMods.java
@@ -1,0 +1,49 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchModsQuery;
+
+public class CommandFetchMods extends BaseCommand<FetchModsQuery.Data> {
+
+    /**
+     * The login name of the channel whose mod list is being queried
+     */
+    private final String channelLogin;
+
+    /**
+     * Relay cursor for forward pagination (optional)
+     */
+    private final String cursor;
+
+    /**
+     * The maximum number of nodes to return in a single call
+     */
+    private final int limit;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelLogin The login name of the channel whose mod list is being queried
+     * @param cursor       Relay cursor for forward pagination (optional)
+     * @param limit        The maximum number of nodes to return in a single call
+     */
+    public CommandFetchMods(ApolloClient apolloClient, String channelLogin, String cursor, Integer limit) {
+        super(apolloClient);
+        this.channelLogin = channelLogin;
+        this.cursor = cursor;
+        this.limit = limit != null ? limit : 100;
+    }
+
+    @Override
+    protected ApolloCall<FetchModsQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchModsQuery.builder()
+                .channelLogin(channelLogin)
+                .after(cursor)
+                .first(limit)
+                .build()
+        );
+    }
+}

--- a/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchVips.java
+++ b/graphql/src/main/java/com/github/twitch4j/graphql/command/CommandFetchVips.java
@@ -1,0 +1,49 @@
+package com.github.twitch4j.graphql.command;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.github.twitch4j.graphql.internal.FetchVipsQuery;
+
+public class CommandFetchVips extends BaseCommand<FetchVipsQuery.Data> {
+
+    /**
+     * The login name of the channel whose vip list is being queried
+     */
+    private final String channelLogin;
+
+    /**
+     * Relay cursor for forward pagination (optional)
+     */
+    private final String cursor;
+
+    /**
+     * The maximum number of nodes to return in a single call
+     */
+    private final int limit;
+
+    /**
+     * Constructor
+     *
+     * @param apolloClient Apollo Client
+     * @param channelLogin The login name of the channel whose vip list is being queried
+     * @param cursor       Relay cursor for forward pagination (optional)
+     * @param limit        The maximum number of nodes to return in a single call
+     */
+    public CommandFetchVips(ApolloClient apolloClient, String channelLogin, String cursor, Integer limit) {
+        super(apolloClient);
+        this.channelLogin = channelLogin;
+        this.cursor = cursor;
+        this.limit = limit != null ? limit : 100;
+    }
+
+    @Override
+    protected ApolloCall<FetchVipsQuery.Data> getGraphQLCall() {
+        return apolloClient.query(
+            FetchVipsQuery.builder()
+                .channelLogin(channelLogin)
+                .after(cursor)
+                .first(limit)
+                .build()
+        );
+    }
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `TwitchGraphQL#fetchMods`
* Add `TwitchGraphQL#fetchVips`

### Additional Information
* Twitch intends for non-mods to be able to read mods/vips (in the webchat interface)
* IRC version of these commands is being removed in Feb 2023
