### PR TITLE
chore: ignore logback 1.4.x for renovate bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "github>twitch4j/renovate-config:twitch4j"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["ch.qos.logback:logback-classic"],
+      "allowedVersions": "!/1\\.4\\./"
+    }
   ]
 }


### PR DESCRIPTION
### Changes Proposed
* Avoid logback 1.4.x (as it uses Java 11+ / Jakarta EE) by renovate

### Additional Information
https://docs.renovatebot.com/configuration-options/#allowedversions
