### PR TITLE
chore: treat id as alias in charity eventsub

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCharityDonateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCharityDonateEvent.java
@@ -20,7 +20,7 @@ public class ChannelCharityDonateEvent extends EventSubUserChannelEvent {
     /**
      * An ID that uniquely identifies the charity campaign.
      */
-    @JsonProperty("id")
+    @JsonAlias("id")
     private String campaignId;
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
https://github.com/twitchdev/issues/issues/646

### Changes Proposed
Treat `id` as an *alias* (instead of property name) for `campaignId` in `ChannelCharityDonateEvent` (to smoothly transition on 2022-09-20)

### Additional Information
2022-09-16 Changelog entry:
```
Breaking change to the Beta [channel.charity_campaign.donate](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelcharity_campaigndonate) EventSub subscription type:

The id field of the [Charity Donation Event](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#charity-donation-event) object will change to campaign_id to better reflect its content on Tuesday, September 20 at 1:00pm PDT.
```