### PR TITLE
fix: support named capture groups on Android

### DIFF
--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
 	// Cache
 	api(group = "io.github.xanthic.cache", name = "cache-provider-caffeine")
 
+	// Named Capture Groups
+	api(group = "com.github.tony19", name = "named-regexp", version = "0.2.7")
+
 	// Twitch4J Modules
 	api(project(":twitch4j-common"))
 	api(project(":twitch4j-auth"))

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -13,8 +13,8 @@ import lombok.*;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
 
 /**
  * This event gets called when we receive a raw irc message.


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Add a library which supports named capture groups.

### Additional Information

Android doesn't support named capture groups [before API 26](https://developer.android.com/reference/java/util/regex/Pattern#group-name).
