### PR TITLE
feat: add unofficial shoutout pubsub topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -515,6 +515,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForShoutoutEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "shoutout." + channelId);
+    }
+
+    @Unofficial
     default PubSubSubscription listenForVideoPlaybackEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "video-playback-by-id." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -84,7 +84,6 @@ import com.github.twitch4j.pubsub.events.ClaimAvailableEvent;
 import com.github.twitch4j.pubsub.events.ClaimClaimedEvent;
 import com.github.twitch4j.pubsub.events.CommunityBoostProgressionEvent;
 import com.github.twitch4j.pubsub.events.CommunityGoalContributionEvent;
-import com.github.twitch4j.pubsub.events.CreateShoutoutEvent;
 import com.github.twitch4j.pubsub.events.CreatorGoalEvent;
 import com.github.twitch4j.pubsub.events.CrowdChantCreatedEvent;
 import com.github.twitch4j.pubsub.events.CustomRewardCreatedEvent;
@@ -118,6 +117,7 @@ import com.github.twitch4j.pubsub.events.RaidGoEvent;
 import com.github.twitch4j.pubsub.events.RaidUpdateEvent;
 import com.github.twitch4j.pubsub.events.RedemptionStatusUpdateEvent;
 import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
+import com.github.twitch4j.pubsub.events.ShoutoutCreatedEvent;
 import com.github.twitch4j.pubsub.events.SubLeaderboardEvent;
 import com.github.twitch4j.pubsub.events.SupportActivityFeedEvent;
 import com.github.twitch4j.pubsub.events.UpdateOnsiteNotificationSummaryEvent;
@@ -723,7 +723,7 @@ public class TwitchPubSub implements ITwitchPubSub {
                 } else if ("shoutout".equals(topicName)) {
                     if ("create".equalsIgnoreCase(type)) {
                         CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(msgData, CreateShoutoutData.class);
-                        eventManager.publish(new CreateShoutoutEvent(lastTopicIdentifier, shoutoutInfo));
+                        eventManager.publish(new ShoutoutCreatedEvent(lastTopicIdentifier, shoutoutInfo));
                     } else {
                         log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
                     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -31,6 +31,7 @@ import com.github.twitch4j.pubsub.domain.CommerceData;
 import com.github.twitch4j.pubsub.domain.CommunityBoostProgression;
 import com.github.twitch4j.pubsub.domain.CommunityGoalContribution;
 import com.github.twitch4j.pubsub.domain.CreateNotificationData;
+import com.github.twitch4j.pubsub.domain.CreateShoutoutData;
 import com.github.twitch4j.pubsub.domain.CreatedUnbanRequest;
 import com.github.twitch4j.pubsub.domain.CreatorGoal;
 import com.github.twitch4j.pubsub.domain.FollowingData;
@@ -83,6 +84,7 @@ import com.github.twitch4j.pubsub.events.ClaimAvailableEvent;
 import com.github.twitch4j.pubsub.events.ClaimClaimedEvent;
 import com.github.twitch4j.pubsub.events.CommunityBoostProgressionEvent;
 import com.github.twitch4j.pubsub.events.CommunityGoalContributionEvent;
+import com.github.twitch4j.pubsub.events.CreateShoutoutEvent;
 import com.github.twitch4j.pubsub.events.CreatorGoalEvent;
 import com.github.twitch4j.pubsub.events.CrowdChantCreatedEvent;
 import com.github.twitch4j.pubsub.events.CustomRewardCreatedEvent;
@@ -718,6 +720,13 @@ public class TwitchPubSub implements ITwitchPubSub {
                     }
                 } else if ("radio-events-v1".equals(topicName)) {
                     eventManager.publish(new RadioEvent(TypeConvert.jsonToObject(rawMessage, RadioData.class)));
+                } else if ("shoutout".equals(topicName)) {
+                    if ("create".equalsIgnoreCase(type)) {
+                        CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(msgData, CreateShoutoutData.class);
+                        eventManager.publish(new CreateShoutoutEvent(lastTopicIdentifier, shoutoutInfo));
+                    } else {
+                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                    }
                 } else if ("channel-sub-gifts-v1".equals(topicName)) {
                     eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(rawMessage, SubGiftData.class)));
                 } else if ("channel-cheer-events-public-v1".equals(topicName) && topicParts.length > 1) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreateShoutoutData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreateShoutoutData.java
@@ -1,0 +1,49 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.common.util.TypeConvert;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class CreateShoutoutData {
+
+    @JsonProperty("broadcasterUserID")
+    private String broadcasterId;
+
+    @JsonProperty("targetUserID")
+    private String targetId;
+
+    @JsonProperty("targetLogin")
+    private String targetLogin;
+
+    @JsonProperty("targetUserDisplayName")
+    private String targetDisplayName;
+
+    @JsonProperty("targetUserProfileImageURL")
+    private String targetProfileUrlTemplate; // contains %s for the image dimensions
+
+    @JsonProperty("targetUserPrimaryColorHex")
+    private String targetUserColorHex; // can be empty string if not set
+
+    @JsonProperty("sourceUserID")
+    private String moderatorId;
+
+    @JsonProperty("sourceLogin")
+    private String moderatorLogin;
+
+    @JsonProperty("shoutoutID")
+    private String shoutoutId;
+
+    @JsonIgnore
+    private ShoutoutTargetCallToAction targetStreamsInfo;
+
+    @JsonProperty("targetUserCTAInfo")
+    private void unpackCallToAction(String ctaInfo) {
+        this.targetStreamsInfo = TypeConvert.jsonToObject(ctaInfo, ShoutoutTargetCallToAction.class);
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ShoutoutTargetCallToAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ShoutoutTargetCallToAction.java
@@ -1,0 +1,68 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.twitch4j.common.util.AlternativeInstantDeserializer;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ShoutoutTargetCallToAction {
+
+    @Nullable
+    @JsonProperty("NextSegment")
+    private Segment nextSegment;
+
+    @Nullable
+    @JsonProperty("RecentlyStreamedCategories")
+    private List<Category> recentCategories;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Category {
+        @JsonProperty("Id")
+        private String id;
+
+        @JsonProperty("Name")
+        private String name;
+
+        @JsonProperty("DisplayName")
+        private String displayName;
+
+        @JsonProperty("BoxArtURL")
+        private String boxArtUrlTemplate; // contains {width} and {height} for template replacement
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Segment {
+        @JsonProperty("Id")
+        private String id;
+
+        @JsonProperty("StartAt")
+        @JsonDeserialize(using = AlternativeInstantDeserializer.class)
+        private Instant startsAt;
+
+        @JsonProperty("EndAt")
+        @JsonDeserialize(using = AlternativeInstantDeserializer.class)
+        private Instant endsAt;
+
+        @JsonProperty("Title")
+        private String title;
+
+        @Accessors(fluent = true)
+        @JsonProperty("IsCancelled")
+        private Boolean isCancelled;
+
+        @JsonProperty("Categories")
+        private List<Category> categories;
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CreateShoutoutEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/CreateShoutoutEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.CreateShoutoutData;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class CreateShoutoutEvent extends TwitchEvent {
+    String channelId;
+    CreateShoutoutData data;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ShoutoutCreatedEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ShoutoutCreatedEvent.java
@@ -7,7 +7,7 @@ import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class CreateShoutoutEvent extends TwitchEvent {
+public class ShoutoutCreatedEvent extends TwitchEvent {
     String channelId;
     CreateShoutoutData data;
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Implement unofficial `shoutout.<channel-id>` pubsub topic

### Additional Information
https://twitter.com/TwitchSupport/status/1574867514080763927

Not yet implemented (delegated to another PR): activity feed event for an incoming shoutout
