### PR TITLE
chore: promote suspicious users pubsub to official

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -127,6 +127,21 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     /**
+     * Event Listener: Suspicious user events.
+     * <p>
+     * This includes when a chatter's treatment status changes (e.g., monitored or restricted),
+     * and when a treated user sends a chat message.
+     *
+     * @param credential Moderator's user access token (scope: channel:moderate) associated with the specified user id.
+     * @param userId     The user id of the moderator.
+     * @param channelId  The channel id to monitor events from.
+     * @return PubSubSubscription
+     */
+    default PubSubSubscription listenForLowTrustUsersEvents(OAuth2Credential credential, String userId, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "low-trust-users." + userId + "." + channelId);
+    }
+
+    /**
      * Event Listener: A moderator performs an action in the channel
      *
      * @param credential Credential (for channelId, scope: channel:moderate)
@@ -480,11 +495,6 @@ public interface ITwitchPubSub extends AutoCloseable {
     @Deprecated
     default PubSubSubscription listenForFriendshipEvents(OAuth2Credential credential, String userId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "friendship." + userId);
-    }
-
-    @Unofficial
-    default PubSubSubscription listenForLowTrustUsersEvents(OAuth2Credential credential, String userId, String channelId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "low-trust-users." + userId + "." + channelId);
     }
 
     @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -136,6 +136,7 @@ public interface ITwitchPubSub extends AutoCloseable {
      * @param userId     The user id of the moderator.
      * @param channelId  The channel id to monitor events from.
      * @return PubSubSubscription
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_CHANNEL_MODERATE
      */
     default PubSubSubscription listenForLowTrustUsersEvents(OAuth2Credential credential, String userId, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "low-trust-users." + userId + "." + channelId);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Promote `low-trust-users` pubsub topic to official status, following twitchdev announcement

### Additional Information
https://cdn.discordapp.com/attachments/143001431388061696/1025110131312177233/unknown.png
