### PR TITLE
fix: handle new direct cheer tags for currency

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/DirectCheerEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/DirectCheerEvent.java
@@ -1,18 +1,12 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.common.util.DonationAmount;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.Currency;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * This event gets called when a user does a direct cheer in an eligible channel for this experiment.
@@ -24,8 +18,6 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = true)
 public class DirectCheerEvent extends CheerEvent {
 
-    private static final Map<String, Currency> CURRENCY_MAP;
-
     /**
      * Creator receives 80% of the amount after fees, during the experiment.
      *
@@ -34,41 +26,9 @@ public class DirectCheerEvent extends CheerEvent {
     private static final float CREATOR_REVENUE_SPLIT = 0.8F;
 
     /**
-     * The amount of the direct cheer.
-     * <p>
-     * For example, $1 = 100
-     * <p>
-     * Note: this is before adjustment for twitch's revenue split.
-     * Use {@link #getBits()} for the adjusted value.
+     * The parsed direct cheer payment information.
      */
-    Integer amount;
-
-    /**
-     * The twitch notification text for this event.
-     * <p>
-     * For example: DisplayName Cheered with $50
-     * <p>
-     * Note: this is distinct from the user's message attached to the cheer ({@link #getMessage()})
-     */
-    @NotNull
-    String systemMessage;
-
-    /**
-     * Parses the currency used in this direct cheer, or null if unknown.
-     * Currently, this always resolves to USD due to the experiment restrictions.
-     */
-    @Nullable
-    @Getter(lazy = true)
-    Currency currency = parseCurrency(getSystemMessage());
-
-    /**
-     * Parses the monetary value that was directly cheered.
-     * <p>
-     * For example, $50 is parsed to 50
-     */
-    @Nullable
-    @Getter(lazy = true)
-    BigDecimal monetaryValue = parseValue(getSystemMessage());
+    DonationAmount cheer;
 
     /**
      * Event Constructor
@@ -78,60 +38,51 @@ public class DirectCheerEvent extends CheerEvent {
     public DirectCheerEvent(IRCMessageEvent event) {
         this(
             event,
-            event.getTagValue("msg-param-amount").map(Integer::parseInt).orElse(0),
-            event.getTagValue("system-msg").map(String::trim).orElse("")
+            event.getTagValue("msg-param-amount").map(Long::parseLong).orElse(0L),
+            event.getTagValue("msg-param-exponent").map(Integer::parseInt).orElse(2),
+            event.getTagValue("msg-param-currency").orElse("USD")
         );
     }
 
-    DirectCheerEvent(IRCMessageEvent event, Integer amount, @NotNull String systemMessage) {
-        super(event, event.getChannel(), event.getUser(), event.getMessage().orElse(""), Math.round(amount * CREATOR_REVENUE_SPLIT), event.getSubscriberMonths().orElse(0), event.getSubscriptionTier().orElse(0), event.getFlags());
-        this.amount = amount;
-        this.systemMessage = systemMessage;
+    DirectCheerEvent(IRCMessageEvent event, long amount, int exponent, String currency) {
+        super(event,
+            event.getChannel(),
+            event.getUser(),
+            event.getMessage().orElse(""),
+            "USD".equalsIgnoreCase(currency) ? Math.round(amount * CREATOR_REVENUE_SPLIT) : 0,
+            event.getSubscriberMonths().orElse(0),
+            event.getSubscriptionTier().orElse(0),
+            event.getFlags());
+
+        this.cheer = new DonationAmount(amount, exponent, currency);
     }
 
-    private static Currency parseCurrency(String systemMsg) {
-        int start = systemMsg.lastIndexOf(' ');
-        if (start < 0) return null; // empty message
-        if (Character.isDigit(systemMsg.charAt(start + 1))) {
-            start = systemMsg.substring(0, start).lastIndexOf(' '); // workaround for currencies that have a space between symbol and monetary value
-        }
-        start = start + 1; // skip the space character
-
-        int end = start + 1; // default symbol has length 1
-        for (; end < systemMsg.length(); end++) {
-            if (Character.isDigit(systemMsg.charAt(end)))
-                break; // symbol ends before digits start
-        }
-
-        return CURRENCY_MAP.get(systemMsg.substring(start, end).trim());
+    /**
+     * @return the amount of this direct cheer, before the revenue split, and in arbitrary currency and decimal places.
+     */
+    public Integer getAmount() {
+        return cheer.getValue().intValue();
     }
 
-    private static BigDecimal parseValue(String systemMsg) {
-        int start = systemMsg.lastIndexOf(' ');
-        if (start < 0) return null; // empty message
-
-        for (; start < systemMsg.length(); start++) {
-            if (Character.isDigit(systemMsg.charAt(start)))
-                break; // value starts at first digit
-        }
-
-        int end = systemMsg.indexOf(' ', start); // value ends at next space
-        if (end < 0) {
-            end = systemMsg.length(); // or end of string if no spaces remaining
-        }
-
-        return new BigDecimal(systemMsg.substring(start, end));
+    /**
+     * @return the parsed currency used in this direct cheer, or throws if unknown.
+     */
+    public Currency getCurrency() {
+        return cheer.getParsedCurrency();
     }
 
-    static {
-        Set<Currency> currencies = Currency.getAvailableCurrencies();
+    /**
+     * @return the parsed monetary value that was directly cheered. For example, $50 is parsed to 50
+     */
+    public BigDecimal getMonetaryValue() {
+        return cheer.getParsedValue();
+    }
 
-        final Map<String, Currency> map = new HashMap<>(currencies.size() * 3);
-        currencies.forEach(c -> map.put(c.getSymbol(), c));
-        currencies.forEach(c -> map.putIfAbsent(c.getCurrencyCode(), c)); // future proofing
-        currencies.forEach(c -> map.putIfAbsent(c.getDisplayName(), c)); // future proofing
-
-        CURRENCY_MAP = Collections.unmodifiableMap(map);
+    /**
+     * @return the twitch notification text for this event (which is distinct from the user's message attached to the cheer).
+     */
+    public String getSystemMessage() {
+        return messageEvent.getTagValue("system-msg").map(String::trim).orElse("");
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/DirectCheerEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/DirectCheerEvent.java
@@ -85,4 +85,15 @@ public class DirectCheerEvent extends CheerEvent {
         return messageEvent.getTagValue("system-msg").map(String::trim).orElse("");
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated direct cheer values are not easily translatable into bit amounts, especially for non-USD currencies.
+     */
+    @Deprecated
+    @Override
+    public Integer getBits() {
+        return super.getBits();
+    }
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Handle new `msg-param-exponent` & `msg-param-currency` tags in `DirectCheerEvent`

### Additional Information
* Round 2 of `midnightsquid` allows for non-USD direct cheers
* If the currency is not USD, we don't provide a corresponding bits value (0), as we don't keep track of currency exchange rates
