### PR TITLE
feat: add charity name and logo to eventsub

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCharityDonateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelCharityDonateEvent.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.eventsub.events;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.util.DonationAmount;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -22,6 +22,18 @@ public class ChannelCharityDonateEvent extends EventSubUserChannelEvent {
      */
     @JsonAlias("id")
     private String campaignId;
+
+    /**
+     * The charity’s name.
+     */
+    @Unofficial
+    private String charityName;
+
+    /**
+     * A URL to an image of the charity’s logo.
+     */
+    @Unofficial
+    private String charityLogo;
 
     /**
      * An object that contains the amount of the user’s donation.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/642#issuecomment-1295432538

### Changes Proposed
* Add `charity_name` and `charity_logo` to `ChannelCharityDonateEvent`

### Additional Information
Marked as `@Unofficial` as these fields do not appear in the eventsub docs (but are present in helix)
