### PR TITLE
chore: add public all args constructor in AutomodEnforceCheckList

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceCheckList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutomodEnforceCheckList.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
@@ -10,6 +11,7 @@ import java.util.List;
 
 @Value
 @Builder
+@AllArgsConstructor
 public class AutomodEnforceCheckList {
 
     @NonNull


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Make all args constructor in `AutomodEnforceCheckList` public (was not due to `@Builder`)
