### PR TITLE
Improve build cacheability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,10 @@ subprojects {
 	apply(plugin = "com.coditory.manifest")
 	apply(plugin = "com.github.johnrengelman.shadow")
 
+	manifest {
+		buildAttributes = false
+	}
+
 	lombok {
 		version.set("1.18.24")
 		disableConfig.set(true)


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature


### Changes Proposed

- Explicitly declare places where manifest is a dependency
- normalize runtime classpath analysis of manifest

### Additional Information

These changes resolved most parts of the build that Gradle refused to build incrementally, or cache. On my local machine, the time for repeated `check` executions went from 13 seconds to 0.7 seconds.

If you have any questions/concerns, let me know!

Note: I did not check the contributing guidelines because the link in the readme goes to a dead link, so if there are any issues with style or formatting, I'm happy to fix them.

Here's a build scan of the current master (second build): https://scans.gradle.com/s/esrc625h6w7gw
Here's a build scan of this fork (also second build): https://scans.gradle.com/s/dxxpiwazvenyi

