### PR TITLE
chore: promote shield mode from beta to official

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeBeginType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ShieldModeCondition;
 import com.github.twitch4j.eventsub.events.ShieldModeBeginEvent;
 
@@ -11,8 +10,7 @@ import com.github.twitch4j.eventsub.events.ShieldModeBeginEvent;
  * <p>
  * Requires the moderator:read:shield_mode or moderator:manage:shield_mode scope.
  */
-@Unofficial
-public class BetaShieldModeBeginType implements SubscriptionType<ShieldModeCondition, ShieldModeCondition.ShieldModeConditionBuilder<?, ?>, ShieldModeBeginEvent> {
+public class ShieldModeBeginType implements SubscriptionType<ShieldModeCondition, ShieldModeCondition.ShieldModeConditionBuilder<?, ?>, ShieldModeBeginEvent> {
     @Override
     public String getName() {
         return "channel.shield_mode.begin";
@@ -20,7 +18,7 @@ public class BetaShieldModeBeginType implements SubscriptionType<ShieldModeCondi
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeEndType.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ShieldModeCondition;
-import com.github.twitch4j.eventsub.events.ShieldModeBeginEvent;
 import com.github.twitch4j.eventsub.events.ShieldModeEndEvent;
 
 /**
@@ -12,8 +10,7 @@ import com.github.twitch4j.eventsub.events.ShieldModeEndEvent;
  * <p>
  * Requires the moderator:read:shield_mode or moderator:manage:shield_mode scope.
  */
-@Unofficial
-public class BetaShieldModeEndType implements SubscriptionType<ShieldModeCondition, ShieldModeCondition.ShieldModeConditionBuilder<?, ?>, ShieldModeEndEvent> {
+public class ShieldModeEndType implements SubscriptionType<ShieldModeCondition, ShieldModeCondition.ShieldModeConditionBuilder<?, ?>, ShieldModeEndEvent> {
     @Override
     public String getName() {
         return "channel.shield_mode.end";
@@ -21,7 +18,7 @@ public class BetaShieldModeEndType implements SubscriptionType<ShieldModeConditi
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -49,8 +49,8 @@ public class SubscriptionTypes {
     public final PredictionProgressType PREDICTION_PROGRESS;
     public final PredictionLockType PREDICTION_LOCK;
     public final PredictionEndType PREDICTION_END;
-    public final @Unofficial BetaShieldModeBeginType BETA_SHIELD_MODE_BEGIN_TYPE;
-    public final @Unofficial BetaShieldModeEndType BETA_SHIELD_MODE_END_TYPE;
+    public final ShieldModeBeginType BETA_SHIELD_MODE_BEGIN_TYPE;
+    public final ShieldModeEndType BETA_SHIELD_MODE_END_TYPE;
     public final StreamOfflineType STREAM_OFFLINE;
     public final StreamOnlineType STREAM_ONLINE;
     public final UserAuthorizationGrantType USER_AUTHORIZATION_GRANT;
@@ -100,8 +100,8 @@ public class SubscriptionTypes {
                 PREDICTION_PROGRESS = new PredictionProgressType(),
                 PREDICTION_LOCK = new PredictionLockType(),
                 PREDICTION_END = new PredictionEndType(),
-                BETA_SHIELD_MODE_BEGIN_TYPE = new BetaShieldModeBeginType(),
-                BETA_SHIELD_MODE_END_TYPE = new BetaShieldModeEndType(),
+                BETA_SHIELD_MODE_BEGIN_TYPE = new ShieldModeBeginType(),
+                BETA_SHIELD_MODE_END_TYPE = new ShieldModeEndType(),
                 STREAM_OFFLINE = new StreamOfflineType(),
                 STREAM_ONLINE = new StreamOnlineType(),
                 USER_AUTHORIZATION_GRANT = new UserAuthorizationGrantType(),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -49,8 +49,8 @@ public class SubscriptionTypes {
     public final PredictionProgressType PREDICTION_PROGRESS;
     public final PredictionLockType PREDICTION_LOCK;
     public final PredictionEndType PREDICTION_END;
-    public final ShieldModeBeginType BETA_SHIELD_MODE_BEGIN_TYPE;
-    public final ShieldModeEndType BETA_SHIELD_MODE_END_TYPE;
+    public final ShieldModeBeginType SHIELD_MODE_BEGIN_TYPE;
+    public final ShieldModeEndType SHIELD_MODE_END_TYPE;
     public final StreamOfflineType STREAM_OFFLINE;
     public final StreamOnlineType STREAM_ONLINE;
     public final UserAuthorizationGrantType USER_AUTHORIZATION_GRANT;
@@ -100,8 +100,8 @@ public class SubscriptionTypes {
                 PREDICTION_PROGRESS = new PredictionProgressType(),
                 PREDICTION_LOCK = new PredictionLockType(),
                 PREDICTION_END = new PredictionEndType(),
-                BETA_SHIELD_MODE_BEGIN_TYPE = new ShieldModeBeginType(),
-                BETA_SHIELD_MODE_END_TYPE = new ShieldModeEndType(),
+                SHIELD_MODE_BEGIN_TYPE = new ShieldModeBeginType(),
+                SHIELD_MODE_END_TYPE = new ShieldModeEndType(),
                 STREAM_OFFLINE = new StreamOfflineType(),
                 STREAM_ONLINE = new StreamOnlineType(),
                 USER_AUTHORIZATION_GRANT = new UserAuthorizationGrantType(),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1838,7 +1838,6 @@ public interface TwitchHelix {
      * @param moderatorId   The ID of the broadcaster or a user that is one of the broadcaster’s moderators. This ID must match the user ID in the access token.
      * @return ShieldModeStatusWrapper
      */
-    @Unofficial
     @RequestLine("GET /moderation/shield_mode?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<ShieldModeStatusWrapper> getShieldModeStatus(
@@ -1856,7 +1855,6 @@ public interface TwitchHelix {
      * @param active        A Boolean value that determines whether to activate Shield Mode.
      * @return ShieldModeStatusWrapper
      */
-    @Unofficial
     @RequestLine("PUT /moderation/shield_mode?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
     @Headers({
         "Authorization: Bearer {token}",


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove `@Unofficial`/`Beta` from helix/eventsub shield mode endpoints/topics

### Additional Information
[2023‑01‑10 Changelog Entry](https://dev.twitch.tv/docs/change-log/)
