### PR TITLE
feat: add custom tags to helix responses

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
@@ -72,7 +72,7 @@ public class ChannelInformation {
      * Tags are case-insensitive. For readability, consider using camelCasing or PascalCasing.
      * <p>
      * For {@link com.github.twitch4j.helix.TwitchHelix#updateChannelInformation(String, String, ChannelInformation)},
-     * setting this to an empty list will result in all tags being removed from the channel.
+     * setting this to an empty list <a href="https://github.com/twitchdev/issues/issues/708">should</a> result in all tags being removed from the channel.
      */
     private List<String> tags;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
@@ -8,6 +8,8 @@ import lombok.Setter;
 import lombok.With;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 @Data
 @With
 @Setter(AccessLevel.PRIVATE)
@@ -56,8 +58,22 @@ public class ChannelInformation {
      * Stream delay in seconds.
      * <p>
      * Stream delay is a Twitch Partner feature; trying to set this value for other account types will return a 400 error.
+     * <p>
+     * Note: this can only be returned if using the broadcaster's user access toke
      */
     @Nullable
     private Integer delay;
+
+    /**
+     * A list of channel-defined tags to apply to the channel.
+     * <p>
+     * A channel may specify a maximum of 10 tags.
+     * Each tag is limited to a maximum of 25 characters and may not be an empty string or contain spaces or special characters.
+     * Tags are case-insensitive. For readability, consider using camelCasing or PascalCasing.
+     * <p>
+     * For {@link com.github.twitch4j.helix.TwitchHelix#updateChannelInformation(String, String, ChannelInformation)},
+     * setting this to an empty list will result in all tags being removed from the channel.
+     */
+    private List<String> tags;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchResult.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchResult.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.util.List;
@@ -57,9 +58,19 @@ public class ChannelSearchResult {
      * Note: Category Tags are not returned
      *
      * @see <a href="https://www.twitch.tv/directory/all/tags">Tag types</a>
+     * @deprecated Twitch is deprecating this field and will stop providing IDs in 2023 (Twitch will communicate the specific date in early 2023) in favor of {@link #getTags()}
      */
+    @Nullable
+    @Deprecated
     @JsonProperty("tag_ids")
     private List<String> tagsIds;
+
+    /**
+     * The tags applied to the channel.
+     * <p>
+     * Note: Unlike {@link #getTagsIds()}, these tags <i>are</i> returned for offline channels
+     */
+    private List<String> tags;
 
     /**
      * Thumbnail URL of the stream

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -49,6 +50,7 @@ public class Stream {
     private String gameName;
 
     /** Array of community IDs. */
+    @Nullable
     @Deprecated
     private List<UUID> communityIds;
 
@@ -60,6 +62,9 @@ public class Stream {
     @NonNull
     private String title;
 
+    /** The tags applied to the stream. */
+    private List<String> tags;
+
     /** Number of viewers watching the stream at the time of the query. */
     @NonNull
     private Integer viewerCount;
@@ -69,7 +74,13 @@ public class Stream {
     @JsonProperty("started_at")
     private Instant startedAtInstant;
 
-    /** Ids of active tags on the stream */
+    /**
+     * Ids of active tags on the stream
+     *
+     * @deprecated Twitch is deprecating this field and will stop providing IDs in 2023 (Twitch will communicate the specific date in early 2023) in favor of {@link #getTags()}
+     */
+    @Nullable
+    @Deprecated
     private List<UUID> tagIds = new ArrayList<>();
 
     /** Indicates if the broadcaster has specified their channel contains mature content that may be inappropriate for younger audiences. */


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
https://github.com/twitchdev/issues/issues/708

### Changes Proposed
* Add `tags` to `Stream`/`ChannelSearchResult`/`ChannelInformation`

### Additional Information
[2023‑01‑10 Changelog Entry](https://dev.twitch.tv/docs/change-log/)
