### PR TITLE
chore: improve gradle caching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,10 +158,9 @@ subprojects {
 	// Source encoding
 	tasks {
 
-		withType<ManifestTask> {
+		withType<ManifestTask>().configureEach {
 			outputs.file(File(buildDir, "resources/main/META-INF/MANIFEST.MF"))
 					.withPropertyName("outputFile")
-
 		}
 		// shadowjar & relocation
 		val relocateShadowJar by creating(ConfigureShadowRelocation::class) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,13 @@ allprojects {
 	}
 }
 
-val enableManifest = project.gradle.startParameter.taskNames
-		.any { s -> s.startsWith("publish") }
+/**
+ * Enables com.coditory.manifest plugin for `publish` tasks or if `-PenableManifest` is supplied trough cli
+ */
+val enableManifest = with(project) {
+	gradle.startParameter.taskNames.any { s -> s.startsWith("publish") }
+			|| properties.containsKey("enableManifest")
+}
 
 // Subprojects
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.coditory.gradle.manifest.ManifestPluginExtension
 import com.coditory.gradle.manifest.ManifestTask
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
@@ -33,7 +34,7 @@ subprojects {
 	apply(plugin = "com.coditory.manifest")
 	apply(plugin = "com.github.johnrengelman.shadow")
 
-	manifest {
+	project.extensions.getByType(ManifestPluginExtension::class.java).apply {
 		buildAttributes = false
 	}
 


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `io.freefair.lombok`, `com.coditory.manifest`, `com.github.johnrengelman.shadow` plugins applied to the root project, but never used
*  `javadoc` task configured for root project, but never used
* `jar` and `javadoc` tasks implicitly depend on `manifest` output which breaks the build cache
* `manifest` task from `com.coditory.manifest` plugin implemented incorrectly(does not declare outputs) which caused all dependent tasks to execute
* `manifest` task produces different output every time it's executed
* `javadoc` task configured with the absolute path for `options.overview` arg, which prevents cache from being reused in case of project relocation(moved to different dir, or reuse of build-cache generated by CI)


### Changes Proposed

* Use `apply(false)` in root project plugins block - speeds up project configuration by avoiding tasks creation in root project, please note, this approach can't be used for default Gradle plugins. 
* `javadoc` task configuration moved from `allprojects` to `subprojects` block
* Added explicit dependencies of `jar` and `javadoc` tasks to `manifest` task
* Modified `manifest` task with declared outputs
* `javadoc.options.overview` now uses relative path to allow caching
* manifest plugin only enabled when either condition is met
   * `-PenableManifest` is supplied via cli
   *  `publish` task is executed



### Additional Information

You can find attached reports below.

### Before:
Build scan link: https://scans.gradle.com/s/7w3yauarjdv6o/performance/execution
<img width="707" alt="Screenshot 2023-01-31 at 2 20 00 PM" src="https://user-images.githubusercontent.com/1287797/215896836-b8c70d01-3b33-45b2-8243-34eb91b00b27.png">


### After:
https://scans.gradle.com/s/htzrk3pymj4ka/performance/execution
<img width="703" alt="Screenshot 2023-01-31 at 2 19 52 PM" src="https://user-images.githubusercontent.com/1287797/215896855-e95e0b98-ad3a-4e4c-954c-b11d91495e3a.png">

The results of this experiment could be replicated using https://scans.gradle.com/
