### PR TITLE
docs: add suspicious users pubsub javadocs

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodCaughtMessage.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.twitch4j.common.annotation.Unofficial;
@@ -58,10 +59,19 @@ public class AutomodCaughtMessage {
     @Setter(AccessLevel.PRIVATE)
     public static class Fragment {
 
+        /**
+         * Plain text fragment of the message sent.
+         */
         private String text;
 
         @Nullable
         private FragmentFlags automod;
+
+        /**
+         * Information about an emote if present in the message.
+         */
+        @Nullable
+        private FragmentEmote emoticon;
 
         @Nullable
         @Unofficial
@@ -94,6 +104,22 @@ public class AutomodCaughtMessage {
             return getUserMention() != null && getUserMention().getUserId() != null;
         }
 
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class FragmentEmote {
+        /**
+         * An ID that identifies this emote.
+         */
+        @JsonAlias("emoticonID")
+        private String emoticonId;
+
+        /**
+         * An ID that identifies the emote set that the emote belongs to.
+         */
+        @JsonAlias("emoticonSetID")
+        private String emoticonSetId;
     }
 
     @Data
@@ -144,6 +170,7 @@ public class AutomodCaughtMessage {
         /**
          * Chat color of the sender.
          */
+        @Unofficial
         private String chatColor;
 
         @Unofficial

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUser.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUser.java
@@ -3,29 +3,69 @@ package com.github.twitch4j.pubsub.domain;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
+import java.util.List;
 
 @Data
 @Setter(AccessLevel.NONE)
 public class LowTrustUser {
 
+    /**
+     * The user ID of the suspicious user.
+     */
     private String id;
 
+    /**
+     * Unique ID for this low trust chat message.
+     */
     private String lowTrustId;
 
+    /**
+     * ID of the channel where the suspicious user was present.
+     */
     private String channelId;
 
+    /**
+     * Information about the suspicious user.
+     */
     private AutomodCaughtMessage.Sender sender;
 
+    /**
+     * If applicable, the timestamp for the first time the suspicious user was automatically evaluated by Twitch.
+     */
     private Instant evaluatedAt;
 
+    /**
+     * The timestamp of when the treatment was updated for the suspicious user.
+     */
     private Instant updatedAt;
 
+    /**
+     * A ban evasion likelihood value (if any) that has been applied to the user automatically by Twitch.
+     */
     private BanEvasionEvaluation banEvasionEvaluation;
 
+    /**
+     * The treatment set for the suspicious user.
+     */
     private LowTrustUserTreatment treatment;
 
+    /**
+     * Information about the moderator who made any update for the suspicious user.
+     */
     private SimpleUser updatedBy;
+
+    /**
+     * A list of channel IDs where the suspicious user is also banned.
+     */
+    @Nullable
+    private List<String> sharedBanChannelIds;
+
+    /**
+     * User types (if any) that apply to the suspicious user.
+     */
+    private List<LowTrustUserTypes> types;
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUserNewMessage.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUserNewMessage.java
@@ -11,13 +11,25 @@ import java.time.Instant;
 @Setter(AccessLevel.NONE)
 public class LowTrustUserNewMessage {
 
+    /**
+     * Information about the low trust message and suspicious user.
+     */
     @JsonProperty("low_trust_user")
     private LowTrustUser user;
 
+    /**
+     * The chat message text and fragments sent by the suspicious user.
+     */
     private AutomodCaughtMessage.Content messageContent;
 
+    /**
+     * ID of the chat message.
+     */
     private String messageId;
 
+    /**
+     * Timestamp of when the chat message was sent.
+     */
     private Instant sentAt;
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUserTreatmentUpdate.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUserTreatmentUpdate.java
@@ -6,28 +6,62 @@ import lombok.Data;
 import lombok.Setter;
 
 import java.time.Instant;
+import java.util.List;
 
 @Data
 @Setter(AccessLevel.NONE)
 public class LowTrustUserTreatmentUpdate {
 
+    /**
+     * An ID for the suspicious user entry, which is a combination of
+     * the channel ID where the treatment was updated and the user ID of the suspicious user.
+     */
     private String lowTrustId;
 
+    /**
+     * ID of the channel where the suspicious user was present.
+     */
     private String channelId;
 
+    /**
+     * Information about the moderator who made any update for the suspicious user.
+     */
     private SimpleUser updatedBy;
 
+    /**
+     * Timestamp of when the treatment was updated for the suspicious user.
+     */
     private Instant updatedAt;
 
+    /**
+     * User ID of the suspicious user.
+     */
     private String targetUserId;
 
+    /**
+     * Login of the suspicious user.
+     */
     @JsonProperty("target_user")
     private String targetUserLogin;
 
+    /**
+     * The treatment set for the suspicious user.
+     */
     private LowTrustUserTreatment treatment;
 
+    /**
+     * User types (if any) that apply to the suspicious user.
+     */
+    private List<LowTrustUserTypes> types;
+
+    /**
+     * A ban evasion likelihood value (if any) that has been applied to the user automatically by Twitch.
+     */
     private BanEvasionEvaluation banEvasionEvaluation;
 
+    /**
+     * If applicable, the timestamp for the first time the suspicious user was automatically evaluated by Twitch.
+     */
     private Instant evaluatedAt;
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUserTypes.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/LowTrustUserTypes.java
@@ -1,0 +1,11 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum LowTrustUserTypes {
+    @JsonEnumDefaultValue
+    UNKNOWN_TYPE,
+    MANUALLY_ADDED,
+    DETECTED_BAN_EVADER,
+    BANNED_IN_SHARED_CHANNEL
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add javadocs for POJOs of pubsub low-trust-users
* Add `AutomodCaughtMessage.Fragment.emoticon` (freshly documented)
* Add `LowTrustUser.sharedBanChannelIds` (freshly documented)
* Add `LowTrustUserTypes` (freshly documented)

### Additional Information
2023-02-03 Changelog Entry: https://dev.twitch.tv/docs/change-log/
