### PR TITLE
feat: add scoped read follows beta api

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -19,6 +19,7 @@ public enum TwitchScopes {
     HELIX_CHANNEL_COMMERCIALS_EDIT("channel:edit:commercial"),
     HELIX_CHANNEL_EXTENSION_MANAGE("channel:manage:extensions"),
     HELIX_CHANNEL_EDITORS_READ("channel:read:editors"),
+    HELIX_CHANNEL_FOLLOWERS_READ("moderator:read:followers"),
     HELIX_CHANNEL_GOALS_READ("channel:read:goals"),
     HELIX_CHANNEL_HYPE_TRAIN_READ("channel:read:hype_train"),
     HELIX_CHANNEL_MODS_MANAGE("channel:manage:moderators"),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelFollowV2Condition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelFollowV2Condition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Jacksonized
+public class ChannelFollowV2Condition extends ModeratorEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelFollowType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelFollowType.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelFollowV2Condition;
+import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A specified channel receives a follow.
+ * <p>
+ * Must have {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope;
+ * the broadcaster or a moderator must have authenticated with your client_id for this scope.
+ * <p>
+ * Warning: you will not be able to create subscriptions with this type after 2023-02-17 (but existing subscriptions will work for a few weeks afterwards)
+ * in favor of {@link ChannelFollowTypeV2}.
+ *
+ * @see <a href="https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322">Official Announcement</a>
+ */
+@ApiStatus.Experimental
+public class BetaChannelFollowType implements SubscriptionType<ChannelFollowV2Condition, ChannelFollowV2Condition.ChannelFollowV2ConditionBuilder<?, ?>, ChannelFollowEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.follow";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelFollowV2Condition.ChannelFollowV2ConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelFollowV2Condition.builder();
+    }
+
+    @Override
+    public Class<ChannelFollowEvent> getEventClass() {
+        return ChannelFollowEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelFollowType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelFollowType.java
@@ -7,7 +7,12 @@ import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
  * A specified channel receives a follow.
  * <p>
  * No authorization required.
+ *
+ * @see <a href="https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322">Deprecation Announcement</a>
+ * @deprecated Twitch will shutdown this topic on 2023-08-03 in favor of {@link ChannelFollowTypeV2} (which has the same event data but more stringent auth).
  */
+@Deprecated
+@SuppressWarnings("DeprecatedIsStillUsed")
 public class ChannelFollowType implements SubscriptionType<ChannelFollowCondition, ChannelFollowCondition.ChannelFollowConditionBuilder<?, ?>, ChannelFollowEvent> {
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelFollowTypeV2.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelFollowTypeV2.java
@@ -1,0 +1,39 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelFollowV2Condition;
+import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A specified channel receives a follow.
+ * <p>
+ * Must have moderator:read:followers scope; the broadcaster or a moderator must have authenticated with your client_id for this scope.
+ * <p>
+ * Warning: This topic will not be available until 2023-02-17.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ
+ */
+@ApiStatus.Experimental
+public class ChannelFollowTypeV2 implements SubscriptionType<ChannelFollowV2Condition, ChannelFollowV2Condition.ChannelFollowV2ConditionBuilder<?, ?>, ChannelFollowEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.follow";
+    }
+
+    @Override
+    public String getVersion() {
+        return "2";
+    }
+
+    @Override
+    public ChannelFollowV2Condition.ChannelFollowV2ConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelFollowV2Condition.builder();
+    }
+
+    @Override
+    public Class<ChannelFollowEvent> getEventClass() {
+        return ChannelFollowEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @UtilityClass
+@SuppressWarnings({ "deprecation", "DeprecatedIsStillUsed" })
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
@@ -19,7 +20,9 @@ public class SubscriptionTypes {
     public final CharityCampaignProgressType CHANNEL_CHARITY_PROGRESS;
     public final CharityCampaignStopType CHANNEL_CHARITY_STOP;
     public final ChannelCheerType CHANNEL_CHEER;
-    public final ChannelFollowType CHANNEL_FOLLOW;
+    public final @Unofficial BetaChannelFollowType BETA_CHANNEL_FOLLOW;
+    public final @Deprecated ChannelFollowType CHANNEL_FOLLOW;
+    public final ChannelFollowTypeV2 CHANNEL_FOLLOW_V2;
     public final ChannelGoalBeginType CHANNEL_GOAL_BEGIN;
     public final ChannelGoalProgressType CHANNEL_GOAL_PROGRESS;
     public final ChannelGoalEndType CHANNEL_GOAL_END;
@@ -72,7 +75,9 @@ public class SubscriptionTypes {
                 CHANNEL_CHARITY_PROGRESS = new CharityCampaignProgressType(),
                 CHANNEL_CHARITY_STOP = new CharityCampaignStopType(),
                 CHANNEL_CHEER = new ChannelCheerType(),
+                BETA_CHANNEL_FOLLOW = new BetaChannelFollowType(),
                 CHANNEL_FOLLOW = new ChannelFollowType(),
+                CHANNEL_FOLLOW_V2 = new ChannelFollowTypeV2(),
                 CHANNEL_GOAL_BEGIN = new ChannelGoalBeginType(),
                 CHANNEL_GOAL_PROGRESS = new ChannelGoalProgressType(),
                 CHANNEL_GOAL_END = new ChannelGoalEndType(),

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/EventSubNotificationTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/EventSubNotificationTest.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.eventsub;
 
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.eventsub.condition.ChannelFollowCondition;
+import com.github.twitch4j.eventsub.condition.ChannelFollowV2Condition;
 import com.github.twitch4j.eventsub.condition.DropEntitlementGrantCondition;
 import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
 import com.github.twitch4j.eventsub.events.DropEntitlementGrantEvent;
@@ -35,9 +35,10 @@ public class EventSubNotificationTest {
     @DisplayName("Deserialize Follow Notification")
     public void deserializeFollowNotification() {
         EventSubNotification notif = TypeConvert.jsonToObject(
-            "{\"subscription\":{\"id\":\"f1c2a387-161a-49f9-a165-0f21d7a4e1c4\",\"type\":\"channel.follow\",\"version\":\"1\",\"status\":\"enabled\",\"condition\":{\"broadcaster_user_id\":\"1337\"},\"transport\":{\"method\":\"webhook\"," +
-                "\"callback\":\"https://example.com/webhooks/callback\"},\"created_at\":\"2019-11-16T10:11:12.123Z\"},\"event\":{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\"," +
-                "\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\",\"followed_at\":\"2020-07-15T18:16:11.17106713Z\"}}",
+            "{\"subscription\":{\"id\":\"f1c2a387-161a-49f9-a165-0f21d7a4e1c4\",\"type\":\"channel.follow\",\"version\":\"2\",\"status\":\"enabled\",\"condition\":{\"broadcaster_user_id\":\"1337\",\"moderator_user_id\":\"1234\"}," +
+                "\"transport\":{\"method\":\"webhook\",\"callback\":\"https://example.com/webhooks/callback\"},\"created_at\":\"2019-11-16T10:11:12.123Z\"}," +
+                "\"event\":{\"user_id\":\"1234\",\"user_login\":\"cool_user\",\"user_name\":\"Cool_User\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cooler_user\",\"broadcaster_user_name\":\"Cooler_User\"," +
+                "\"followed_at\":\"2020-07-15T18:16:11.17106713Z\"}}",
             EventSubNotification.class
         );
 
@@ -45,8 +46,8 @@ public class EventSubNotificationTest {
         assertNotNull(notif.getSubscription());
         assertEquals("f1c2a387-161a-49f9-a165-0f21d7a4e1c4", notif.getSubscription().getId());
         assertEquals(EventSubSubscriptionStatus.ENABLED, notif.getSubscription().getStatus());
-        assertEquals(SubscriptionTypes.CHANNEL_FOLLOW, notif.getSubscription().getType());
-        assertEquals(ChannelFollowCondition.builder().broadcasterUserId("1337").build(), notif.getSubscription().getCondition());
+        assertEquals(SubscriptionTypes.CHANNEL_FOLLOW_V2, notif.getSubscription().getType());
+        assertEquals(ChannelFollowV2Condition.builder().broadcasterUserId("1337").moderatorUserId("1234").build(), notif.getSubscription().getCondition());
         assertNotNull(notif.getSubscription().getTransport());
         assertEquals(EventSubTransportMethod.WEBHOOK, notif.getSubscription().getTransport().getMethod());
         assertEquals("https://example.com/webhooks/callback", notif.getSubscription().getTransport().getCallback());

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1200,6 +1200,60 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets a list of broadcasters that the specified user follows.
+     * <p>
+     * You can also use this endpoint to see whether a user follows a specific broadcaster.
+     * <p>
+     * Requires a user access token that includes the user:read:follows scope.
+     *
+     * @param authToken     User access token (scope: user:read:follows) that matches the specified userId.
+     * @param userId        Required: A user’s ID. Returns the list of broadcasters that this user follows.
+     * @param broadcasterId Optional: The ID of a channel to see whether this user follows the channel. If not specified, the response contains all broadcasters that the user follows.
+     * @param limit         Optional: The maximum number of items to return per page in the response. Default: 20. Minimum: 1. Maximum: 100.
+     * @param after         Optional: The cursor used to get the next page of results.
+     * @return OutboundFollowing
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_FOLLOWS_READ
+     */
+    @Unofficial // in public beta
+    @RequestLine("GET /channels/followed?user_id={user_id}&broadcaster_id={broadcaster_id}&first={first}&after={after}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<OutboundFollowing> getFollowedChannels(
+        @Param("token") String authToken,
+        @NotNull @Param("user_id") String userId,
+        @Nullable @Param("broadcaster_id") String broadcasterId,
+        @Nullable @Param("first") Integer limit,
+        @Nullable @Param("after") String after
+    );
+
+    /**
+     * Gets a list of users that follow the specified broadcaster.
+     * <p>
+     * You can also use this endpoint to see whether a specific user follows the broadcaster.
+     * <p>
+     * Requires a user access token that includes the moderator:read:followers scope.
+     * The user ID in the access token must match the ID in the broadcaster_id query parameter or the ID of a moderator for the specified broadcaster.
+     * If a scope is not provided, only the total follower account will be included in the response.
+     *
+     * @param authToken     User access token (scope: moderator:read:followers) from the broadcaster or their moderator
+     * @param broadcasterId Required: The broadcaster's ID whose list of followers is being queried.
+     * @param userId        Optional: The ID of a user to see whether the user follows this broadcaster. If not specified, the response contains all users that follow the broadcaster.
+     * @param limit         Optional: The maximum number of items to return per page in the response. Default: 20. Minimum: 1. Maximum: 100.
+     * @param after         Optional: The cursor used to get the next page of results.
+     * @return InboundFollowers
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ
+     */
+    @Unofficial // in public beta
+    @RequestLine("GET /channels/followers?broadcaster_id={broadcaster_id}&user_id={user_id}&first={first}&after={after}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<InboundFollowers> getChannelFollowers(
+        @Param("token") String authToken,
+        @NotNull @Param("broadcaster_id") String broadcasterId,
+        @Nullable @Param("user_id") String userId,
+        @Nullable @Param("first") Integer limit,
+        @Nullable @Param("after") String after
+    );
+
+    /**
      * Gets a list of the channel’s VIPs.
      *
      * @param authToken     Broadcaster's user access token that includes the channel:read:vips scope.
@@ -2578,8 +2632,11 @@ public interface TwitchHelix {
      * @param after     Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
      * @param limit     Maximum number of objects to return. Maximum: 100. Default: 20.
      * @return FollowList
-     * @see <a href="https://www.twitch.tv/videos/1604648673?t=0h36m30s">Early deprecation notice</a>
+     * @see <a href="https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322">Deprecation Announcement</a>
+     * @deprecated Twitch will shutdown this endpoint on 2023-08-03 in favor of {@link #getChannelFollowers(String, String, String, Integer, String)} and {@link #getFollowedChannels(String, String, String, Integer, String)}.
      */
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<FollowList> getFollowers(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/InboundFollow.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/InboundFollow.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class InboundFollow {
+
+    /**
+     * An ID that uniquely identifies the user that’s following the broadcaster.
+     */
+    private String userId;
+
+    /**
+     * The user’s login name.
+     */
+    private String userLogin;
+
+    /**
+     * The user’s display name.
+     */
+    private String userName;
+
+    /**
+     * The UTC timestamp when the user started following the broadcaster.
+     */
+    private Instant followedAt;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/InboundFollowers.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/InboundFollowers.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class InboundFollowers {
+
+    /**
+     * The list of users that follow the specified broadcaster,
+     * in descending order by followed_at (with the most recent follower first).
+     */
+    @Nullable
+    @JsonProperty("data")
+    private List<InboundFollow> follows;
+
+    /**
+     * Contains the information used to page through the list of results.
+     * <p>
+     * The object is empty if there are no more pages left to page through.
+     */
+    private HelixPagination pagination;
+
+    /**
+     * The total number of users that follow this broadcaster.
+     * <p>
+     * As someone pages through the list, the number of users may change as users follow or unfollow the broadcaster.
+     */
+    private Integer total;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OutboundFollow.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OutboundFollow.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class OutboundFollow {
+
+    /**
+     * An ID that uniquely identifies the broadcaster that this user is following.
+     */
+    private String broadcasterId;
+
+    /**
+     * The broadcaster’s login name.
+     */
+    private String broadcasterLogin;
+
+    /**
+     * The broadcaster’s display name.
+     */
+    private String broadcasterName;
+
+    /**
+     * The UTC timestamp when the user started following the broadcaster.
+     */
+    private Instant followedAt;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OutboundFollowing.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/OutboundFollowing.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class OutboundFollowing {
+
+    /**
+     * The list of broadcasters that the user follows,
+     * in descending order by followed_at (with the most recently followed broadcaster first).
+     */
+    @Nullable
+    @JsonProperty("data")
+    private List<OutboundFollow> follows;
+
+    /**
+     * Contains the information used to page through the list of results.
+     * <p>
+     * The object is empty if there are no more pages left to page through.
+     */
+    private HelixPagination pagination;
+
+    /**
+     * The total number of broadcasters that the user follows.
+     * <p>
+     * As someone pages through the list, the number may change as the user follows or unfollows broadcasters.
+     */
+    private Integer total;
+
+}

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
@@ -78,9 +78,11 @@ public interface TwitchMessagingInterface {
      *
      * @param channelName Channel Name
      * @return List of all Viewers/mods/...
-     * @deprecated This method will eventually be decommissioned in favor of TwitchHelix#getChatters
+     * @see <a href="https://discuss.dev.twitch.tv/t/legacy-chatters-endpoint-shutdown-details-and-timeline-april-2023/">Shutdown Announcement</a>
+     * @deprecated This method will be permanently shutdown by Twitch on 2023-04-03 in favor of TwitchHelix#getChatters
      */
     @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @RequestLine("GET /group/user/{channel}/chatters")
     HystrixCommand<Chatters> getChatters(
         @Param("channel") String channelName

--- a/rest-tmi/src/test/java/com/github/twitch4j/tmi/TMIServiceTest.java
+++ b/rest-tmi/src/test/java/com/github/twitch4j/tmi/TMIServiceTest.java
@@ -2,21 +2,23 @@ package com.github.twitch4j.tmi;
 
 import com.github.twitch4j.tmi.domain.Chatters;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
 @Tag("integration")
+@SuppressWarnings("deprecation")
 public class TMIServiceTest {
 
     /**
-     * Gets a instance of the Client
+     * Gets an instance of the Client
      *
      * @return TwitchMessagingInterface
      */
     public static TwitchMessagingInterface getClient() {
-       return TwitchMessagingInterfaceBuilder.builder().build();
+        return TwitchMessagingInterfaceBuilder.builder().build();
     }
 
     /**
@@ -24,6 +26,7 @@ public class TMIServiceTest {
      */
     @Test
     @DisplayName("Get all viewers of channel")
+    @Disabled
     public void getViewers() {
         // TestCase
         Chatters chatters = getClient().getChatters("lirik").execute();


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
#### Helix
* Deprecate `TwitchHelix#getFollowers` (this is being killed in August)
* Add `TwitchHelix#getChannelFollowers`
* Add `TwitchHelix#getFollowedChannels`

#### EventSub
* Deprecate eventsub `ChannelFollowType` (this is being killed in August)
* Add eventsub `BetaChannelFollowType` (this *can* be actively subscribed to until Feb17)
* Add eventsub `ChannelFollowTypeV2` (this *cannot* be subscribed to until Feb17)

#### Other
* Add new required scope to read channel followers: `TwitchScopes.HELIX_CHANNEL_FOLLOWERS_READ`
* Document specific date that `TwitchMessagingInterface#getChatters` will be permanently decommissioned

### Additional Information
https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322/
