### PR TITLE
chore: promote shoutout api out of beta

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShoutoutCreateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShoutoutCreateType.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
-import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.eventsub.condition.ChannelShoutoutCondition;
 import com.github.twitch4j.eventsub.events.ShoutoutCreateEvent;
 
@@ -16,8 +15,7 @@ import com.github.twitch4j.eventsub.events.ShoutoutCreateEvent;
  *
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHOUTOUTS_READ
  */
-@Unofficial // in public beta
-public class BetaShoutoutCreateType implements SubscriptionType<ChannelShoutoutCondition, ChannelShoutoutCondition.ChannelShoutoutConditionBuilder<?, ?>, ShoutoutCreateEvent> {
+public class ShoutoutCreateType implements SubscriptionType<ChannelShoutoutCondition, ChannelShoutoutCondition.ChannelShoutoutConditionBuilder<?, ?>, ShoutoutCreateEvent> {
 
     @Override
     public String getName() {
@@ -26,7 +24,7 @@ public class BetaShoutoutCreateType implements SubscriptionType<ChannelShoutoutC
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShoutoutReceiveType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShoutoutReceiveType.java
@@ -7,7 +7,7 @@ import com.github.twitch4j.eventsub.events.ShoutoutReceiveEvent;
 /**
  * Sends a notification when the specified broadcaster receives a Shoutout.
  * <p>
- * NOTE Sent only if Twitch posts the Shoutout to the broadcaster’s activity feed.
+ * Note: Sent only if Twitch posts the Shoutout to the broadcaster’s activity feed.
  * <p>
  * Requires the moderator:read:shoutouts or moderator:manage:shoutouts scope.
  * <p>
@@ -17,8 +17,8 @@ import com.github.twitch4j.eventsub.events.ShoutoutReceiveEvent;
  *
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHOUTOUTS_READ
  */
-@Unofficial // in public beta
-public class BetaShoutoutReceiveType implements SubscriptionType<ChannelShoutoutCondition, ChannelShoutoutCondition.ChannelShoutoutConditionBuilder<?, ?>, ShoutoutReceiveEvent> {
+public class ShoutoutReceiveType implements SubscriptionType<ChannelShoutoutCondition, ChannelShoutoutCondition.ChannelShoutoutConditionBuilder<?, ?>, ShoutoutReceiveEvent> {
+
     @Override
     public String getName() {
         return "channel.shoutout.receive";
@@ -26,7 +26,7 @@ public class BetaShoutoutReceiveType implements SubscriptionType<ChannelShoutout
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override
@@ -38,4 +38,5 @@ public class BetaShoutoutReceiveType implements SubscriptionType<ChannelShoutout
     public Class<ShoutoutReceiveEvent> getEventClass() {
         return ShoutoutReceiveEvent.class;
     }
+
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -54,8 +54,8 @@ public class SubscriptionTypes {
     public final PredictionEndType PREDICTION_END;
     public final ShieldModeBeginType SHIELD_MODE_BEGIN_TYPE;
     public final ShieldModeEndType SHIELD_MODE_END_TYPE;
-    public final @Unofficial BetaShoutoutCreateType BETA_SHOUTOUT_CREATE_TYPE;
-    public final @Unofficial BetaShoutoutReceiveType BETA_SHOUTOUT_RECEIVE_TYPE;
+    public final ShoutoutCreateType SHOUTOUT_CREATE_TYPE;
+    public final ShoutoutReceiveType SHOUTOUT_RECEIVE_TYPE;
     public final StreamOfflineType STREAM_OFFLINE;
     public final StreamOnlineType STREAM_ONLINE;
     public final UserAuthorizationGrantType USER_AUTHORIZATION_GRANT;
@@ -109,8 +109,8 @@ public class SubscriptionTypes {
                 PREDICTION_END = new PredictionEndType(),
                 SHIELD_MODE_BEGIN_TYPE = new ShieldModeBeginType(),
                 SHIELD_MODE_END_TYPE = new ShieldModeEndType(),
-                BETA_SHOUTOUT_CREATE_TYPE = new BetaShoutoutCreateType(),
-                BETA_SHOUTOUT_RECEIVE_TYPE = new BetaShoutoutReceiveType(),
+                SHOUTOUT_CREATE_TYPE = new ShoutoutCreateType(),
+                SHOUTOUT_RECEIVE_TYPE = new ShoutoutReceiveType(),
                 STREAM_OFFLINE = new StreamOfflineType(),
                 STREAM_ONLINE = new StreamOnlineType(),
                 USER_AUTHORIZATION_GRANT = new UserAuthorizationGrantType(),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -536,7 +536,6 @@ public interface TwitchHelix {
      * @return 204 No Content upon a successful request
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHOUTOUTS_MANAGE
      */
-    @Unofficial // in public beta
     @RequestLine("POST /chat/shoutouts?from_broadcaster_id={from_broadcaster_id}&to_broadcaster_id={to_broadcaster_id}&moderator_id={moderator_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> sendShoutout(


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Promote shoutout eventsub from beta to v1
* Remove `@Unofficial` from `TwitchHelix#sendShoutout`

### Additional Information
2023-02-09 changelog entry: https://dev.twitch.tv/docs/change-log/
