### PR TITLE
fix(helix): read remaining header from correct object

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixErrorDecoder.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -101,8 +100,10 @@ public class TwitchHelixErrorDecoder implements ErrorDecoder {
                     .addContextValue("errorType", error.getMessage())
                     .addContextValue("errorMessage", error.getMessage());
             }
-        } catch (IOException fallbackToDefault) {
+        } catch (Exception fallbackToDefault) {
             ex = defaultDecoder.decode(methodKey, response);
+        } finally {
+            response.close();
         }
 
         return ex;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixDecoder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixDecoder.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Type;
 import static com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor.AUTH_HEADER;
 import static com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor.BEARER_PREFIX;
 import static com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor.CLIENT_HEADER;
+import static com.github.twitch4j.helix.interceptor.TwitchHelixHttpClient.getFirst;
 import static com.github.twitch4j.helix.interceptor.TwitchHelixHttpClient.getFirstHeader;
 import static com.github.twitch4j.helix.interceptor.TwitchHelixHttpClient.getFirstParam;
 
@@ -32,7 +33,7 @@ public class TwitchHelixDecoder extends JacksonDecoder {
         String token = getFirstHeader(AUTH_HEADER, request);
         if (token != null && token.startsWith(BEARER_PREFIX)) {
             // Parse remaining
-            String remainingStr = getFirstHeader(REMAINING_HEADER, request);
+            String remainingStr = getFirst(REMAINING_HEADER, response.headers());
             Integer remaining;
             try {
                 remaining = Integer.parseInt(remainingStr);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `TwitchHelixRateLimitTracker#updateRemaining` wasn't being called
* Close response body even when `InputStream` fails to be instantiated

### Changes Proposed
* Read `Ratelimit-Remaining` from response headers (instead of request)
