### PR TITLE
chore: restore helix refill rate after twitch fix

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -23,7 +23,6 @@ import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.Refill;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -56,7 +55,7 @@ public class TwitchHelixBuilder {
     /**
      * @see <a href="https://dev.twitch.tv/docs/api/guide#rate-limits">Helix Rate Limit Reference</a>
      */
-    public static final Bandwidth DEFAULT_BANDWIDTH = Bandwidth.classic(800, Refill.greedy(600, Duration.ofMinutes(1)));
+    public static final Bandwidth DEFAULT_BANDWIDTH = Bandwidth.simple(800, Duration.ofMinutes(1));
 
     /**
      * Client Id


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/597

### Changes Proposed
* Restore the intended 800/60 helix bucket refill rate (was throttled in https://github.com/twitch4j/twitch4j/commit/4627bdb61ba35c643feb718a61cc8add660adb4c due to a bug on Twitch's end)

### Additional Information
Updated logs can be found at https://gist.github.com/iProdigy/d5d22f598bf9888e79c30302c19d76a5 - 1659 calls were executed over 124.4 seconds while the remaining header stayed relatively constant, implying the correct rate of 800/60.
