### PR TITLE
fix: cleanup poolBySub on eventsocket pool unregister

### DIFF
--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
@@ -14,7 +14,7 @@ class SubscriptionWrapper extends EventSubSubscription {
     String rawVersion;
     EventSubCondition condition;
 
-    SubscriptionWrapper(EventSubSubscription sub) {
+    private SubscriptionWrapper(EventSubSubscription sub) {
         super(sub.getId(), sub.getStatus(), sub.getType(), sub.getCondition(),
             sub.getCreatedAt(), sub.getTransport(), sub.getCost(), sub.isBatchingEnabled(),
             sub.getRawType(), sub.getRawVersion());

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
@@ -261,6 +261,7 @@ public final class TwitchEventSocket implements IEventSubSocket {
     }
 
     @Override
+    @Synchronized
     public void close() throws Exception {
         this.websocketId = null;
 

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
@@ -333,6 +333,7 @@ public final class TwitchEventSocket implements IEventSubSocket {
     }
 
     @Override
+    @Synchronized
     public boolean unregister(EventSubSubscription subscription) {
         EventSubSubscription sub = unsubscribeNoHelix(subscription);
         if (sub != null) {

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocketPool.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocketPool.java
@@ -146,10 +146,11 @@ public final class TwitchEventSocketPool implements IEventSubSocket {
     @Override
     @Synchronized
     public boolean unregister(EventSubSubscription sub) {
-        TwitchSingleUserEventSocketPool pool = poolBySub.get(SubscriptionWrapper.wrap(sub));
+        SubscriptionWrapper wrapped = SubscriptionWrapper.wrap(sub);
+        TwitchSingleUserEventSocketPool pool = poolBySub.get(wrapped);
         if (pool == null) return false;
 
-        Boolean unsubscribe = pool.unsubscribe(sub);
+        Boolean unsubscribe = pool.unsubscribe(wrapped);
 
         // cleanup if we removed the last subscription
         if (pool.numSubscriptions() <= 0) {
@@ -174,7 +175,8 @@ public final class TwitchEventSocketPool implements IEventSubSocket {
                 });
         }
 
-        return unsubscribe != null && unsubscribe;
+        // noinspection resource
+        return unsubscribe != null && unsubscribe && poolBySub.remove(wrapped) != null;
     }
 
     @Override

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchSingleUserEventSocketPool.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchSingleUserEventSocketPool.java
@@ -140,13 +140,13 @@ public final class TwitchSingleUserEventSocketPool extends TwitchModuleConnectio
 
     @Override
     public boolean register(OAuth2Credential token, EventSubSubscription sub) {
-        SubscriptionWrapper wrapped = new SubscriptionWrapper(sub);
+        SubscriptionWrapper wrapped = SubscriptionWrapper.wrap(sub);
         credentials.put(wrapped, token != null ? token : Objects.requireNonNull(defaultToken));
         return subscribe(wrapped) != null;
     }
 
     @Override
     public boolean unregister(EventSubSubscription sub) {
-        return this.unsubscribe(new SubscriptionWrapper(sub));
+        return this.unsubscribe(SubscriptionWrapper.wrap(sub));
     }
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* After `TwitchEventSocketPool#unregister`, `poolBySub` was not cleaned up so memory would not be freed and `TwitchEventSocketPool#register` could not be called again for the same subscription

### Changes Proposed
* Remove subscription => pool mapping on successful `TwitchEventSocketPool#unregister` calls

### Additional Information
Thanks to @Awakened-Redstone for debugging
