### PR TITLE
fix(eventsub): looser equality on optional condition fields

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CampaignEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CampaignEventSubCondition.java
@@ -2,31 +2,48 @@ package com.github.twitch4j.eventsub.condition;
 
 import lombok.AccessLevel;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
+import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
-@EqualsAndHashCode(callSuper = false)
 @Jacksonized
 public class CampaignEventSubCondition extends EventSubCondition {
 
     /**
-     * The organization ID of the organization that owns the game on the developer portal.
+     * Required: The organization ID of the organization that owns the game on the developer portal.
      */
     private String organizationId;
 
     /**
-     * The category (or game) ID of the game for which entitlement notifications will be received.
+     * Optional: The category (or game) ID of the game for which entitlement notifications will be received.
      */
     private String categoryId;
 
     /**
-     * The campaign ID for a specific campaign for which entitlement notifications will be received.
+     * Optional: The campaign ID for a specific campaign for which entitlement notifications will be received.
      */
     private String campaignId;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CampaignEventSubCondition)) return false;
+
+        CampaignEventSubCondition that = (CampaignEventSubCondition) o;
+        return defaultString(organizationId).equals(defaultString(that.organizationId))
+            && defaultString(categoryId).equals(defaultString(that.categoryId))
+            && defaultString(campaignId).equals(defaultString(that.campaignId));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultString(organizationId), defaultString(categoryId), defaultString(campaignId));
+    }
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelFromToEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelFromToEventSubCondition.java
@@ -2,10 +2,13 @@ package com.github.twitch4j.eventsub.condition;
 
 import lombok.AccessLevel;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+
+import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 /**
  * Generic condition when a broadcaster can be either on the receiving or giving end of the event type.
@@ -13,7 +16,6 @@ import lombok.extern.jackson.Jacksonized;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
-@EqualsAndHashCode(callSuper = false)
 @Jacksonized
 public class ChannelFromToEventSubCondition extends EventSubCondition {
 
@@ -27,4 +29,18 @@ public class ChannelFromToEventSubCondition extends EventSubCondition {
      */
     private String toBroadcasterUserId;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ChannelFromToEventSubCondition)) return false;
+
+        ChannelFromToEventSubCondition that = (ChannelFromToEventSubCondition) o;
+        return defaultString(fromBroadcasterUserId).equals(defaultString(that.fromBroadcasterUserId))
+            && defaultString(toBroadcasterUserId).equals(defaultString(that.toBroadcasterUserId));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultString(fromBroadcasterUserId), defaultString(toBroadcasterUserId));
+    }
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CustomRewardEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/CustomRewardEventSubCondition.java
@@ -2,17 +2,17 @@ package com.github.twitch4j.eventsub.condition;
 
 import lombok.AccessLevel;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 @Jacksonized
 public class CustomRewardEventSubCondition extends ChannelEventSubCondition {
 
@@ -21,4 +21,18 @@ public class CustomRewardEventSubCondition extends ChannelEventSubCondition {
      */
     private String rewardId;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CustomRewardEventSubCondition)) return false;
+        if (!super.equals(o)) return false;
+
+        CustomRewardEventSubCondition that = (CustomRewardEventSubCondition) o;
+        return defaultString(rewardId).equals(defaultString(that.rewardId));
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() * 31 + defaultString(rewardId).hashCode();
+    }
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/EventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/EventSubCondition.java
@@ -1,6 +1,8 @@
 package com.github.twitch4j.eventsub.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class EventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ModeratorEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ModeratorEventSubCondition.java
@@ -2,15 +2,15 @@ package com.github.twitch4j.eventsub.condition;
 
 import lombok.AccessLevel;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 @Data
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
-@EqualsAndHashCode(callSuper = false)
 @Jacksonized
 public class ModeratorEventSubCondition extends ChannelEventSubCondition {
 
@@ -22,4 +22,18 @@ public class ModeratorEventSubCondition extends ChannelEventSubCondition {
      */
     private String moderatorUserId;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ModeratorEventSubCondition)) return false;
+        if (!super.equals(o)) return false;
+
+        ModeratorEventSubCondition that = (ModeratorEventSubCondition) o;
+        return defaultString(moderatorUserId).equals(defaultString(that.moderatorUserId));
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() * 31 + defaultString(moderatorUserId).hashCode();
+    }
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/condition/EventSubConditionEqualsTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/condition/EventSubConditionEqualsTest.java
@@ -1,0 +1,99 @@
+package com.github.twitch4j.eventsub.condition;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Tag("unittest")
+public class EventSubConditionEqualsTest {
+
+    @Test
+    public void testFromToConditionEquality() {
+        assertEquals(
+            ChannelRaidCondition.builder().fromBroadcasterUserId("a").toBroadcasterUserId("b").build(),
+            ChannelRaidCondition.builder().fromBroadcasterUserId("a").toBroadcasterUserId("b").build()
+        );
+
+        assertEquals(
+            ChannelRaidCondition.builder().fromBroadcasterUserId("a").toBroadcasterUserId(null).build(),
+            ChannelRaidCondition.builder().fromBroadcasterUserId("a").build()
+        );
+
+        assertEquals(
+            ChannelRaidCondition.builder().fromBroadcasterUserId("a").toBroadcasterUserId("").build(),
+            ChannelRaidCondition.builder().fromBroadcasterUserId("a").build()
+        );
+
+        assertEquals(
+            ChannelRaidCondition.builder().fromBroadcasterUserId(null).toBroadcasterUserId("b").build(),
+            ChannelRaidCondition.builder().fromBroadcasterUserId("").toBroadcasterUserId("b").build()
+        );
+
+        assertEquals(
+            ChannelRaidCondition.builder().toBroadcasterUserId("b").build(),
+            ChannelRaidCondition.builder().fromBroadcasterUserId("").toBroadcasterUserId("b").build()
+        );
+
+        assertNotEquals(
+            ChannelRaidCondition.builder().toBroadcasterUserId("b").build(),
+            ChannelRaidCondition.builder().toBroadcasterUserId("c").build()
+        );
+    }
+
+    @Test
+    public void testCampaignConditionEquality() {
+        assertEquals(
+            DropEntitlementGrantCondition.builder().organizationId("a").campaignId("b").categoryId("").build(),
+            DropEntitlementGrantCondition.builder().organizationId("a").campaignId("b").build()
+        );
+
+        assertEquals(
+            DropEntitlementGrantCondition.builder().organizationId("a").campaignId("").categoryId("").build(),
+            DropEntitlementGrantCondition.builder().organizationId("a").build()
+        );
+
+        assertEquals(
+            DropEntitlementGrantCondition.builder().organizationId("a").campaignId("").categoryId("c").build(),
+            DropEntitlementGrantCondition.builder().organizationId("a").categoryId("c").build()
+        );
+
+        assertNotEquals(
+            DropEntitlementGrantCondition.builder().organizationId("a").campaignId("b").categoryId("c").build(),
+            DropEntitlementGrantCondition.builder().organizationId("a").categoryId("c").build()
+        );
+    }
+
+    @Test
+    public void testRewardConditionEquality() {
+        assertEquals(
+            ChannelPointsCustomRewardRedemptionAddCondition.builder().broadcasterUserId("a").rewardId("").build(),
+            ChannelPointsCustomRewardRedemptionAddCondition.builder().broadcasterUserId("a").build()
+        );
+
+        assertNotEquals(
+            ChannelPointsCustomRewardRedemptionAddCondition.builder().broadcasterUserId("a").rewardId("").build(),
+            ChannelPointsCustomRewardRedemptionAddCondition.builder().broadcasterUserId("b").build()
+        );
+
+        assertNotEquals(
+            ChannelPointsCustomRewardRedemptionAddCondition.builder().broadcasterUserId("a").rewardId("c").build(),
+            ChannelPointsCustomRewardRedemptionAddCondition.builder().broadcasterUserId("a").build()
+        );
+    }
+
+    @Test
+    public void testModerationConditionEquality() {
+        assertEquals(
+            ShieldModeCondition.builder().broadcasterUserId("a").moderatorUserId("").build(),
+            ShieldModeCondition.builder().broadcasterUserId("a").moderatorUserId(null).build()
+        );
+
+        assertNotEquals(
+            ShieldModeCondition.builder().broadcasterUserId("a").moderatorUserId("b").build(),
+            ShieldModeCondition.builder().broadcasterUserId("a").moderatorUserId(null).build()
+        );
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* `TwitchEventSocket#unregister` may not succeed when two subscriptions are the same except their condition object has an optional field & one sub has it set to an empty string while the other sub has it set to null.
* `TwitchEventSocket#register` may attempt a duplicate subscription when the only difference is the value of an optional field in the condition object such that one is empty string while the other is null.

### Changes Proposed
* Define equals/hashCode for eventsub condition objects that include optional fields such that null string and empty string are considered equivalent.
