### PR TITLE
fix: use new shadowJar relocation syntax

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,8 +157,6 @@ subprojects {
 
 	// Source encoding
 	tasks {
-
-		// shadowjar & relocation
 		// jar artifact id and version
 		withType<Jar> {
 			if (this is ShadowJar) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.coditory.gradle.manifest.ManifestPluginExtension
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.freefair.gradle.plugins.lombok.LombokExtension
 import io.freefair.gradle.plugins.lombok.tasks.Delombok
@@ -160,16 +159,12 @@ subprojects {
 	tasks {
 
 		// shadowjar & relocation
-		val relocateShadowJar by creating(ConfigureShadowRelocation::class) {
-			target = named<ShadowJar>("shadowJar").get()
-			prefix = "com.github.twitch4j.shaded.${"$version".replace(".", "_")}"
-		}
-
 		// jar artifact id and version
 		withType<Jar> {
 			if (this is ShadowJar) {
-				dependsOn(relocateShadowJar)
 				archiveClassifier.set("shaded")
+				isEnableRelocation = true
+				relocationPrefix = "com.github.twitch4j.shaded.${"$version".replace(".", "_")}"
 			}
 			if (enableManifest) {
 				manifest.from(File(buildDir, "resources/main/META-INF/MANIFEST.MF"))


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* use the new syntax for relocation after `ConfigureShadowRelocation` was removed in 8.1.0

### Additional Information
