### PR TITLE
chore(helix): deprecate more tag_id references

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2346,14 +2346,17 @@ public interface TwitchHelix {
      * @param limit     Maximum number of objects to return. Maximum: 100. Default: 20.
      * @param tagIds    Returns tags by one or more specified tag IDs. You can specify up to 100 IDs. If you search by tagIds, no pagination is used.
      * @return StreamTagList
+     * @see <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Information</a>
+     * @deprecated Twitch will decommission this endpoint on 2023-07-13 due to the latest custom tags system.
      */
+    @Deprecated
     @RequestLine("GET /tags/streams?after={after}&first={first}&tag_id={tag_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<StreamTagList> getAllStreamTags(
-            @Param("token") String authToken,
-            @Param("after") String after,
-            @Param("first") Integer limit,
-            @Param("tag_id") List<UUID> tagIds
+        @Param("token") String authToken,
+        @Param("after") String after,
+        @Param("first") Integer limit,
+        @Param("tag_id") List<UUID> tagIds
     );
 
     /**
@@ -2362,12 +2365,15 @@ public interface TwitchHelix {
      * @param authToken     User Token or App auth Token, for increased rate-limits
      * @param broadcasterId ID of the stream to fetch current tags from
      * @return StreamTagList
+     * @see <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Information</a>
+     * @deprecated Twitch will decommission this endpoint on 2023-07-13 in favor of {@link #getChannelInformation(String, List)} due to the latest custom tags system.
      */
+    @Deprecated
     @RequestLine("GET /streams/tags?broadcaster_id={broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<StreamTagList> getStreamTags(
-            @Param("token") String authToken,
-            @Param("broadcaster_id") String broadcasterId
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
     );
 
     /**
@@ -2378,7 +2384,10 @@ public interface TwitchHelix {
      * @param broadcasterId ID of the stream to replace tags for
      * @param tagIds        Tag ids to replace the current stream tags with. Maximum: 100. If empty, all tags are cleared from the stream. Tags currently expire 72 hours after they are applied, unless the stream is live within that time period.
      * @return Object       nothing
+     * @see <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Information</a>
+     * @deprecated Twitch has decommissioned this endpoint in favor of {@link #updateChannelInformation(String, String, ChannelInformation)} due to the latest custom tags system.
      */
+    @Deprecated
     @RequestLine("PUT /streams/tags?broadcaster_id={broadcaster_id}")
     @Headers({
         "Authorization: Bearer {token}",
@@ -2386,9 +2395,9 @@ public interface TwitchHelix {
     })
     @Body("%7B\"tag_ids\": [{tag_ids}]%7D")
     HystrixCommand<Void> replaceStreamTags(
-            @Param("token") String authToken,
-            @Param("broadcaster_id") String broadcasterId,
-            @Param(value = "tag_ids", expander = ObjectToJsonExpander.class) List<UUID> tagIds
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param(value = "tag_ids", expander = ObjectToJsonExpander.class) List<UUID> tagIds
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchResult.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelSearchResult.java
@@ -57,8 +57,8 @@ public class ChannelSearchResult {
      * <p>
      * Note: Category Tags are not returned
      *
-     * @see <a href="https://www.twitch.tv/directory/all/tags">Tag types</a>
-     * @deprecated Twitch is deprecating this field and will stop providing IDs in 2023 (Twitch will communicate the specific date in early 2023) in favor of {@link #getTags()}
+     * @see <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Announcement</a>
+     * @deprecated Twitch has deprecated tag ids in favor of {@link #getTags()} due to the latest custom tags system
      */
     @Nullable
     @Deprecated

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -77,11 +77,12 @@ public class Stream {
     /**
      * Ids of active tags on the stream
      *
-     * @deprecated Twitch is deprecating this field and will stop providing IDs in 2023 (Twitch will communicate the specific date in early 2023) in favor of {@link #getTags()}
+     * @see <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Announcement</a>
+     * @deprecated Twitch has deprecated tag ids in favor of {@link #getTags()} due to the latest custom tags system
      */
     @Nullable
     @Deprecated
-    private List<UUID> tagIds = new ArrayList<>();
+    private List<UUID> tagIds;
 
     /** Indicates if the broadcaster has specified their channel contains mature content that may be inappropriate for younger audiences. */
     @Accessors(fluent = true)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTag.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTag.java
@@ -7,13 +7,22 @@ import java.util.UUID;
 
 /**
  * Stream Tags (LiveStream)
+ *
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Information</a>
  */
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class StreamTag {
-    /** Tag ID. */
+    /**
+     * Tag ID.
+     *
+     * @see ChannelInformation#getTags()
+     * @deprecated Twitch has deprecated UUID-based tags with the latest custom tags system.
+     */
     @NonNull
+    @Deprecated
     private UUID tagId;
 
     /** Whether the tag is automatically set by Twitch (meaning that it cannot be set manually) */

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTagList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/StreamTagList.java
@@ -7,12 +7,20 @@ import java.util.List;
 
 /**
  * Stream Tags List
+ *
+ * @see ChannelInformation#getTags()
+ * @deprecated Twitch has deprecated UUID-based tags with the latest custom tags system.
  */
 @Data
+@Deprecated
 public class StreamTagList {
     /**
      * Data
+     *
+     * @see <a href="https://discuss.dev.twitch.tv/t/adding-customizable-tags-to-the-twitch-api/42921">Deprecation Information</a>
+     * @deprecated These tags are no longer populated due to Twitch deprecation.
      */
+    @Deprecated
     @JsonProperty("data")
     private List<StreamTag> streamTags;
 

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/StreamsServiceTest.java
@@ -1,7 +1,10 @@
 package com.github.twitch4j.helix.endpoints;
 
 import com.github.twitch4j.helix.TestUtils;
-import com.github.twitch4j.helix.domain.*;
+import com.github.twitch4j.helix.domain.IngestServerList;
+import com.github.twitch4j.helix.domain.StreamKey;
+import com.github.twitch4j.helix.domain.StreamList;
+import com.github.twitch4j.helix.domain.StreamMarkersList;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -9,9 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,7 +28,7 @@ public class StreamsServiceTest extends AbstractEndpointTest {
     /** Hearthstone GameId */
     private static String hearthstoneGameId = "138585";
 
-     /** Overwatch GameId */
+    /** Overwatch GameId */
     private static String overwatchGameId = "488552";
 
     /**
@@ -76,55 +77,6 @@ public class StreamsServiceTest extends AbstractEndpointTest {
                 });
             });
         });
-    }
-
-    /**
-     * getAllStreamTags
-     */
-    @Test
-    @DisplayName("getAllStreamTags")
-    public void getAllStreamTags() {
-        // TestCase
-        StreamTagList resultList = testUtils.getTwitchHelixClient().getAllStreamTags(null, "", 100, null).execute();
-
-        // Test
-        assertTrue(resultList.getStreamTags().size() > 0, "Should at least find one stream tag!");
-        resultList.getStreamTags().forEach(tag -> {
-            assertTrue(tag.getTagId() != null, "TagId should not be null");
-        });
-    }
-
-    /**
-     * Gets stream tags which are active on the specified stream.
-     */
-    @Test
-    @DisplayName("getStreamTagsOfStream")
-    @Disabled
-    public void getStreamTagsOfStream() {
-        // TestCase
-        StreamTagList resultList = testUtils.getTwitchHelixClient().getStreamTags(null, twitchUserId).execute();
-
-        // Test
-        assertTrue(resultList.getStreamTags().size() == 1, "Should have exactly 1 stream tag!");
-        resultList.getStreamTags().forEach(tag -> {
-            assertTrue(tag.getTagId().equals(UUID.fromString("a59f1e4e-257b-4bd0-90c7-189c3efbf917")), "TagId doesn't match a59f1e4e-257b-4bd0-90c7-189c3efbf917");
-            assertTrue(tag.getLocalizationNames().get("en-us").equalsIgnoreCase("programming"), "tag en-us name should equal programming!");
-            assertTrue(tag.getLocalizationDescriptions().get("en-us").equalsIgnoreCase("For streams with an emphasis on the discussion or process of computer programming"), "tag en-us description doesn't match!");
-        });
-    }
-
-    /**
-     * replaceStreamTags
-     */
-    @Test
-    @DisplayName("replaceStreamTags")
-    @Disabled
-    public void replaceStreamTags() {
-        // TestCase
-        List<UUID> tagIds = new ArrayList<>();
-        tagIds.add(UUID.fromString("a59f1e4e-257b-4bd0-90c7-189c3efbf917"));
-
-        testUtils.getTwitchHelixClient().replaceStreamTags(testUtils.getCredential().getAccessToken(), twitchUserId, tagIds).execute();
     }
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate `TwitchHelix#getStreamTags` (just returns empty array as of today)
* Deprecate `TwitchHelix#getAllStreamTags` (just returns empty array as of today)
* Deprecate `TwitchHelix#replaceStreamTags` (decommissioned as of today)
* Propagate deprecated tag to return types
* Remove associated test cases

### Additional Information
2023-02-28 changelog entry: https://dev.twitch.tv/docs/change-log/
