### PR TITLE
chore(helix): deprecate entitlement code endpoints

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -593,7 +593,9 @@ public interface TwitchHelix {
      * @param code      The code to get the status of. 1-20 code parameters are allowed.
      * @param userId    Represents a numeric Twitch user ID. The user account which is going to receive the entitlement associated with the code.
      * @return CodeStatusList
+     * @deprecated Twitch decommissioned this endpoint on 2023-02-27.
      */
+    @Deprecated
     @RequestLine("GET /entitlements/codes?code={code}&user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<CodeStatusList> getCodeStatus(
@@ -611,7 +613,9 @@ public interface TwitchHelix {
      * @param code      The code to redeem to the authenticated user’s account. 1-20 code parameters are allowed.
      * @param userId    Represents a numeric Twitch user ID. The user account which is going to receive the entitlement associated with the code.
      * @return CodeStatusList
+     * @deprecated Twitch decommissioned this endpoint on 2023-02-27.
      */
+    @Deprecated
     @RequestLine("POST /entitlements/codes?code={code}&user_id={user_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<CodeStatusList> redeemCode(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatus.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatus.java
@@ -5,9 +5,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * @deprecated Twitch decommissioned entitlement code related endpoints on 2023-02-27.
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class CodeStatus {
     /**
      * The code to check the status of or to redeem.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatusList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CodeStatusList.java
@@ -9,9 +9,13 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * @deprecated Twitch decommissioned entitlement code related endpoints on 2023-02-27.
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class CodeStatusList {
 
     @NonNull


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Deprecate `TwitchHelix#getCodeStatus`
* Deprecate `TwitchHelix#redeemCode`

### Additional Information
2023-02-27 changelog entry: https://dev.twitch.tv/docs/change-log