### PR TITLE
chore(eventsub): define aliases for broadcaster event fields

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubChannelEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubChannelEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,16 +16,19 @@ public class EventSubChannelEvent extends EventSubEvent {
     /**
      * The requested broadcaster ID.
      */
+    @JsonAlias("broadcaster_id")
     private String broadcasterUserId;
 
     /**
      * The requested broadcaster display name.
      */
+    @JsonAlias("broadcaster_name")
     private String broadcasterUserName;
 
     /**
      * The requested broadcaster login name.
      */
+    @JsonAlias("broadcaster_login")
     private String broadcasterUserLogin;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubUserChannelEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubUserChannelEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,16 +16,19 @@ public class EventSubUserChannelEvent extends EventSubEvent {
     /**
      * The requested broadcaster ID.
      */
+    @JsonAlias("broadcaster_id")
     private String broadcasterUserId;
 
     /**
      * The requested broadcaster display name.
      */
+    @JsonAlias("broadcaster_name")
     private String broadcasterUserName;
 
     /**
      * The requested broadcaster login name.
      */
+    @JsonAlias("broadcaster_login")
     private String broadcasterUserLogin;
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issue
* https://github.com/twitchdev/issues/issues/738

### Changes Proposed
* Allow `broadcaster_X` to alias for `broadcaster_user_X` in eventsub events, given twitch documentation inconsistencies

### Additional Information
Inconsistency example: https://dev.twitch.tv/docs/eventsub/eventsub-reference/#charity-donation-event
