### PR TITLE
fix: avoid NPE when forwarder is missing token

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -32,6 +32,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -294,7 +295,7 @@ public class TwitchChatBuilder {
      * Only intended for internal use by twitch4j.
      */
     @Getter(AccessLevel.PRIVATE)
-    @With(onMethod_ = { @Deprecated }) // try to discourage calls from outside the library
+    @With(onMethod_ = { @Deprecated, @ApiStatus.Internal }) // try to discourage calls from outside the library
     private BiPredicate<TwitchChat, String> outboundCommandFilter = null;
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -493,7 +493,7 @@ public class TwitchClientBuilder {
                 .withProxyConfig(proxyConfig)
                 .withMaxJoinRetries(chatMaxJoinRetries)
                 .withOutboundCommandFilter(
-                    chatCommandsViaHelix && enableHelix ? new ChatCommandHelixForwarder(
+                    chatCommandsViaHelix && enableHelix && (chatAccount != null || defaultAuthToken != null) ? new ChatCommandHelixForwarder(
                         helix,
                         chatAccount != null ? chatAccount : defaultAuthToken,
                         credentialManager.getIdentityProviderByName("twitch", TwitchIdentityProvider.class).orElse(null),

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -497,7 +497,7 @@ public class TwitchClientPoolBuilder {
 
         // Module: Chat
         ITwitchChat chat = null;
-        ChatCommandHelixForwarder forwarder = chatCommandsViaHelix && enableHelix && (enableChat || enableChatPool) ?
+        ChatCommandHelixForwarder forwarder = chatCommandsViaHelix && enableHelix && (enableChat || enableChatPool) && (chatAccount != null || defaultAuthToken != null) ?
             new ChatCommandHelixForwarder(
                 helix,
                 chatAccount != null ? chatAccount : defaultAuthToken,

--- a/twitch4j/src/main/java/com/github/twitch4j/internal/ChatCommandHelixForwarder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/internal/ChatCommandHelixForwarder.java
@@ -97,7 +97,7 @@ public final class ChatCommandHelixForwarder implements BiPredicate<TwitchChat, 
             spec.expiryTime(Duration.ofNanos(this.channelHelixLimit.getRefillPeriodNanos() * 2));
             spec.maxSize(2048L);
         });
-        if (StringUtils.isEmpty(token.getUserId())) {
+        if (token != null && StringUtils.isEmpty(token.getUserId())) {
             TwitchIdentityProvider tip = identityProvider != null ? identityProvider : new TwitchIdentityProvider(null, null, null);
             tip.getAdditionalCredentialInformation(token).ifPresent(token::updateCredential);
             if (StringUtils.isEmpty(token.getUserId())) log.warn("ChatCommandHelixForwarder requires a valid user access token to function correctly.");


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* When helix, chat, and chat-command-to-helix forwarder are enabled without `chatAccount` or `defeaultAuthToken` specified, a NPE was thrown.

### Changes Proposed
* Don't instantiate `ChatCommandHelixForwarder` if no token is specified (as all of the calls require an user access token, so automatic app access token couldn't be used)
