### PR TITLE
feat(helix): allow querying multiple video ids

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2775,10 +2775,51 @@ public interface TwitchHelix {
      * Get Videos
      * <p>
      * Gets video information by video ID (one or more), user ID (one only), or game ID (one only).
-     * The response has a JSON payload with a data field containing an array of video elements. For lookup by user or game, pagination is available, along with several filters that can be specified as query string parameters.
-     * Using user-token or app-token to increase rate limits.
+     * The response has a JSON payload with a data field containing an array of video elements.
+     * For lookup by user or game, pagination is available, along with several filters that can be specified as query string parameters.
+     * <p>
+     * The id, user_id, and game_id parameters are mutually exclusive (but exactly one must be specified).
+     * <p>
+     * You may apply several filters to get a subset of the videos.
+     * The filters are applied as an AND operation to each video.
+     * The filters apply only if you get videos by user ID or game ID.
      *
-     * @param authToken User or App auth Token, for increased rate-limits
+     * @param authToken User or App Access Token
+     * @param id        Required: A list of IDs that identify the videos you want to get. Limit: 100. If this is specified, you cannot use any of the optional query string parameters below.
+     * @param userId    Required: The ID of the user whose list of videos you want to get.
+     * @param gameId    Required: A category or game ID. The response contains a maximum of 500 videos that show this content.
+     * @param language  Optional: Language of the video being queried (ISO 639-1 two-letter code, or "other" if the language is not supported by Twitch).
+     * @param period    Optional: Period during which the video was created. Valid values: "all", "day", "week", "month". Default: "all".
+     * @param sort      Optional: Sort order of the videos. Valid values: "time", "trending", "views". Default: "time".
+     * @param type      Optional: Type of video. Valid values: "all", "upload", "archive", "highlight". Default: "all".
+     * @param limit     Optional: Number of values to be returned when getting videos by user or game ID. Limit: 100. Default: 20.
+     * @param after     Optional: The cursor used to get the next page of results.
+     * @param before    Optional: The cursor used to get the previous page of results.
+     * @return {@link VideoList}
+     */
+    @RequestLine("GET /videos?id={id}&user_id={user_id}&game_id={game_id}&language={language}&period={period}&sort={sort}&type={type}&after={after}&before={before}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<VideoList> getVideos(
+        @Param("token") String authToken,
+        @Param("id") List<String> id,
+        @Param("user_id") String userId,
+        @Param("game_id") String gameId,
+        @Param("language") String language,
+        @Param("period") String period,
+        @Param("sort") String sort,
+        @Param("type") String type,
+        @Param("first") Integer limit,
+        @Param("after") String after,
+        @Param("before") String before
+    );
+
+    /**
+     * Get Videos
+     * <p>
+     * Gets video information by video ID (one or more), user ID (one only), or game ID (one only).
+     * The response has a JSON payload with a data field containing an array of video elements. For lookup by user or game, pagination is available, along with several filters that can be specified as query string parameters.
+     *
+     * @param authToken User or App Access Token
      * @param id        Required: ID of the video being queried. Limit: 100. If this is specified, you cannot use any of the optional query string parameters below.
      * @param userId    Required: ID of the user who owns the video. Limit 1.
      * @param gameId    Required: ID of the game the video is of. Limit 1.
@@ -2790,10 +2831,10 @@ public interface TwitchHelix {
      * @param before    Optional: Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
      * @param limit     Optional: Number of values to be returned when getting videos by user or game ID. Limit: 100. Default: 20.
      * @return VideoList
+     * @deprecated in favor of {@link #getVideos(String, List, String, String, String, String, String, String, Integer, String, String)}, which supports multiple video IDs
      */
-    @RequestLine("GET /videos?id={id}&user_id={user_id}&game_id={game_id}&language={language}&period={period}&sort={sort}&type={type}&after={after}&before={before}&first={first}")
-    @Headers("Authorization: Bearer {token}")
-    HystrixCommand<VideoList> getVideos(
+    @Deprecated
+    default HystrixCommand<VideoList> getVideos(
         @Param("token") String authToken,
         @Param("id") String id,
         @Param("user_id") String userId,
@@ -2805,7 +2846,9 @@ public interface TwitchHelix {
         @Param("after") String after,
         @Param("before") String before,
         @Param("first") Integer limit
-    );
+    ) {
+        return getVideos(authToken, Collections.singletonList(id), userId, gameId, language, period, sort, type, limit, after, before);
+    }
 
     /**
      * Deletes one or more videos. Videos are past broadcasts, Highlights, or uploads.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2805,9 +2805,9 @@ public interface TwitchHelix {
         @Param("user_id") String userId,
         @Param("game_id") String gameId,
         @Param("language") String language,
-        @Param("period") String period,
-        @Param("sort") String sort,
-        @Param("type") String type,
+        @Param("period") Video.SearchPeriod period,
+        @Param("sort") Video.SearchOrder sort,
+        @Param("type") Video.Type type,
         @Param("first") Integer limit,
         @Param("after") String after,
         @Param("before") String before
@@ -2831,7 +2831,7 @@ public interface TwitchHelix {
      * @param before    Optional: Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response.
      * @param limit     Optional: Number of values to be returned when getting videos by user or game ID. Limit: 100. Default: 20.
      * @return VideoList
-     * @deprecated in favor of {@link #getVideos(String, List, String, String, String, String, String, String, Integer, String, String)}, which supports multiple video IDs
+     * @deprecated in favor of {@link #getVideos(String, List, String, String, String, Video.SearchPeriod, Video.SearchOrder, Video.Type, Integer, String, String)}, which supports multiple video IDs
      */
     @Deprecated
     default HystrixCommand<VideoList> getVideos(
@@ -2847,7 +2847,10 @@ public interface TwitchHelix {
         @Param("before") String before,
         @Param("first") Integer limit
     ) {
-        return getVideos(authToken, Collections.singletonList(id), userId, gameId, language, period, sort, type, limit, after, before);
+        Video.SearchPeriod time = Video.SearchPeriod.MAPPINGS.get(period);
+        Video.SearchOrder order = Video.SearchOrder.MAPPINGS.get(sort);
+        Video.Type vidType = Video.Type.MAPPINGS.get(type);
+        return getVideos(authToken, Collections.singletonList(id), userId, gameId, language, time, order, vidType, limit, after, before);
     }
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
@@ -1,20 +1,24 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.util.EnumUtil;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Follow
+ * Video
  */
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -77,6 +81,13 @@ public class Video {
     private List<MutedSegment> mutedSegments;
 
     /**
+     * @return the {@link Type} of the video
+     */
+    public Type getParsedType() {
+        return Type.MAPPINGS.get(this.type);
+    }
+
+    /**
      * Gets the thumbnail url for specific dimensions.
      *
      * @param width  Thumbnail width.
@@ -124,6 +135,90 @@ public class Video {
          * Offset in the video at which the muted segment begins.
          */
         Integer offset;
+    }
+
+    /**
+     * The video's type.
+     */
+    public enum Type {
+
+        /**
+         * The default is “all,” which returns all video types.
+         */
+        @JsonEnumDefaultValue
+        ALL,
+
+        /**
+         * On-demand videos (VODs) of past streams.
+         */
+        ARCHIVE,
+
+        /**
+         * Highlight reels of past streams.
+         */
+        HIGHLIGHT,
+
+        /**
+         * External videos that the broadcaster uploaded using the Video Producer.
+         */
+        UPLOAD;
+
+        @ApiStatus.Internal
+        public static final Map<String, Type> MAPPINGS = EnumUtil.buildMapping(values());
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+    }
+
+    /**
+     * The order to sort the returned videos in.
+     */
+    public enum SearchOrder {
+
+        /**
+         * Sort the results in descending order by when they were created (i.e., latest video first).
+         */
+        @JsonEnumDefaultValue
+        TIME,
+
+        /**
+         * Sort the results in descending order by biggest gains in viewership (i.e., highest trending video first).
+         */
+        TRENDING,
+
+        /**
+         * Sort the results in descending order by most views (i.e., highest number of views first).
+         */
+        VIEWS;
+
+        @ApiStatus.Internal
+        public static final Map<String, SearchOrder> MAPPINGS = EnumUtil.buildMapping(values());
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+    }
+
+    /**
+     * A filter used to filter the list of videos by when they were published.
+     */
+    public enum SearchPeriod {
+        @JsonEnumDefaultValue
+        ALL,
+        DAY,
+        MONTH,
+        WEEK;
+
+        @ApiStatus.Internal
+        public static final Map<String, SearchPeriod> MAPPINGS = EnumUtil.buildMapping(values());
+
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
     }
 
 }

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class VideoServiceTest extends AbstractEndpointTest {
 
     /** Overwatch GameId */
-    private static String overwatchGameId = "488552";
+    private static final String overwatchGameId = "488552";
 
     /**
      * Get Videos
@@ -28,7 +28,7 @@ public class VideoServiceTest extends AbstractEndpointTest {
     @DisplayName("Fetch videos")
     public void getVideos() {
         // TestCase
-        VideoList resultList = testUtils.getTwitchHelixClient().getVideos(TestUtils.getCredential().getAccessToken(), null, null, overwatchGameId, null, null, null, null, null, null, 100).execute();
+        VideoList resultList = TestUtils.getTwitchHelixClient().getVideos(TestUtils.getCredential().getAccessToken(), null, null, overwatchGameId, null, null, null, null, 100, null, null).execute();
 
         // Test
         assertTrue(resultList.getVideos().size() > 0, "Should at least find one result from the videos method!");

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/VideoServiceTest.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.helix.endpoints;
 
 import com.github.twitch4j.helix.TestUtils;
 import com.github.twitch4j.helix.domain.DeletedVideoList;
+import com.github.twitch4j.helix.domain.Video;
 import com.github.twitch4j.helix.domain.VideoList;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -9,8 +10,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,14 +23,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class VideoServiceTest extends AbstractEndpointTest {
 
     /** Overwatch GameId */
-    private static final String overwatchGameId = "488552";
+    private static final String overwatchGameId = "515025";
+
+    @Test
+    @DisplayName("Fetch videos by ID")
+    public void getVideos() {
+        List<String> ids = Arrays.asList("806178786", "806178788");
+        List<Video> videos = TestUtils.getTwitchHelixClient().getVideos(TestUtils.getCredential().getAccessToken(), ids, null, null, null, null, null, null, null, null, null)
+            .execute()
+            .getVideos();
+        assertNotNull(videos);
+        assertEquals(ids.size(), videos.size());
+        videos.forEach(video -> {
+            assertNotNull(video.getId());
+            assertNotNull(video.getUserId());
+            assertNotNull(video.getUserName());
+        });
+    }
 
     /**
      * Get Videos
      */
     @Test
-    @DisplayName("Fetch videos")
-    public void getVideos() {
+    @DisplayName("Fetch videos by game ID")
+    public void getVideosByGame() {
         // TestCase
         VideoList resultList = TestUtils.getTwitchHelixClient().getVideos(TestUtils.getCredential().getAccessToken(), null, null, overwatchGameId, null, null, null, null, 100, null, null).execute();
 

--- a/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
+++ b/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.util;
 
 import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,7 +13,21 @@ import java.util.stream.Collectors;
 @UtilityClass
 public class EnumUtil {
 
-    public <E extends Enum<E>, K, V> Map<K, V> buildMapping(E[] values, Function<E, K> keySelector, Function<E, V> valueMapper) {
+    /**
+     * Transforms enum values to a key-value map based on the specified functions.
+     *
+     * @param values      the values within an enum to be transformed
+     * @param keySelector a function that derives a key associated to an enum entry
+     * @param valueMapper a function that yields a value for a given enum entry
+     * @param <E>         the type of enum
+     * @param <K>         the type of keys
+     * @param <V>         the type of values
+     * @return a {@link Map} of key-value associations from transforming the specified enum entries
+     * @apiNote The key derivation function should not yield collisions (even though we do not throw an exception upon a duplicate key).
+     * @implSpec The returned map is unmodifiable. The underlying map is {@link HashMap} so that null keys (and values) are supported.
+     * @implNote Enum#values is used instead of {@link Class#getEnumConstants()} to avoid reflection overhead.
+     */
+    public <E extends Enum<E>, K, V> Map<K, V> buildMapping(@NotNull E[] values, @NotNull Function<E, K> keySelector, @NotNull Function<E, V> valueMapper) {
         return Collections.unmodifiableMap(
             Arrays.stream(values).collect(
                 Collectors.toMap(keySelector, valueMapper, (a, b) -> a, HashMap::new)
@@ -20,11 +35,29 @@ public class EnumUtil {
         );
     }
 
-    public <E extends Enum<E>, K> Map<K, E> buildMapping(E[] values, Function<E, K> keySelector) {
+    /**
+     * Creates a mapping of enum values via an arbitrary key derivation function.
+     *
+     * @param values      the values within an enum to be mapped
+     * @param keySelector a function that derives a key associated to an enum value
+     * @param <E>         the type of enum
+     * @param <K>         the type of keys
+     * @return the mapping of enum values by the derived keys
+     * @see #buildMapping(Enum[], Function, Function)
+     */
+    public <E extends Enum<E>, K> Map<K, E> buildMapping(@NotNull E[] values, @NotNull Function<E, K> keySelector) {
         return buildMapping(values, keySelector, Function.identity());
     }
 
-    public <E extends Enum<E>> Map<String, E> buildMapping(E[] values) {
+    /**
+     * Creates a mapping of enum values by their string representation.
+     *
+     * @param values the values within an enum to be mapped
+     * @param <E>    the type of enum
+     * @return a mapping of {@link Enum#toString()} to the enum value itself
+     * @see #buildMapping(Enum[], Function)
+     */
+    public <E extends Enum<E>> Map<String, E> buildMapping(@NotNull E[] values) {
         return buildMapping(values, Enum::toString);
     }
 

--- a/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
+++ b/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class EnumUtil {
+
+    public <E extends Enum<E>, K, V> Map<K, V> buildMapping(E[] values, Function<E, K> keySelector, Function<E, V> valueMapper) {
+        return Collections.unmodifiableMap(
+            Arrays.stream(values).collect(
+                Collectors.toMap(keySelector, valueMapper, (a, b) -> a, HashMap::new)
+            )
+        );
+    }
+
+    public <E extends Enum<E>, K> Map<K, E> buildMapping(E[] values, Function<E, K> keySelector) {
+        return buildMapping(values, keySelector, Function.identity());
+    }
+
+    public <E extends Enum<E>> Map<String, E> buildMapping(E[] values) {
+        return buildMapping(values, Enum::toString);
+    }
+
+}

--- a/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
+++ b/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
@@ -26,7 +26,7 @@ public class EnumUtil {
      * @implNote Enum#values is used instead of {@link Class#getEnumConstants()} to avoid reflection overhead.
      */
     public <E extends Enum<E>, K, V> Map<K, V> buildMapping(@NotNull E[] values, @NotNull Function<E, K> keySelector, @NotNull Function<E, V> valueMapper) {
-        final Map<K, V> map = new HashMap<>();
+        final Map<K, V> map = new HashMap<>((values.length * 4 + 2) / 3);
         for (E e : values) {
             map.putIfAbsent(keySelector.apply(e), valueMapper.apply(e));
         }

--- a/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
+++ b/util/src/main/java/com/github/twitch4j/util/EnumUtil.java
@@ -3,12 +3,10 @@ package com.github.twitch4j.util;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @UtilityClass
 public class EnumUtil {
@@ -28,11 +26,11 @@ public class EnumUtil {
      * @implNote Enum#values is used instead of {@link Class#getEnumConstants()} to avoid reflection overhead.
      */
     public <E extends Enum<E>, K, V> Map<K, V> buildMapping(@NotNull E[] values, @NotNull Function<E, K> keySelector, @NotNull Function<E, V> valueMapper) {
-        return Collections.unmodifiableMap(
-            Arrays.stream(values).collect(
-                Collectors.toMap(keySelector, valueMapper, (a, b) -> a, HashMap::new)
-            )
-        );
+        final Map<K, V> map = new HashMap<>();
+        for (E e : values) {
+            map.putIfAbsent(keySelector.apply(e), valueMapper.apply(e));
+        }
+        return Collections.unmodifiableMap(map);
     }
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Update `TwitchHelix#getVideos` to allow a list of ID's to be queried in one call. Also we change the index of the `limit` argument to avoid "Ambiguous method reference" issues

### Additional Information
Reported by @Skillkiller 
