### PR TITLE
feat: parse viewer milestone events sent to chat

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -85,6 +85,7 @@ public class IRCEventHandler {
         eventManager.onEvent("twitch4j-chat-delete-trigger", IRCMessageEvent.class, this::onMessageDeleteResponse);
         eventManager.onEvent("twitch4j-chat-userstate-trigger", IRCMessageEvent.class, this::onUserState);
         eventManager.onEvent("twitch4j-chat-globaluserstate-trigger", IRCMessageEvent.class, this::onGlobalUserState);
+        eventManager.onEvent("twitch4j-chat-viewermilestone-trigger", IRCMessageEvent.class, this::onViewerMilestone);
     }
 
     @Unofficial
@@ -682,6 +683,13 @@ public class IRCEventHandler {
     public void onGlobalUserState(IRCMessageEvent event) {
         if ("GLOBALUSERSTATE".equals(event.getCommandType())) {
             eventManager.publish(new GlobalUserStateEvent(event));
+        }
+    }
+
+    @Unofficial
+    private void onViewerMilestone(IRCMessageEvent event) {
+        if ("USERNOTICE".equals(event.getCommandType()) && ViewerMilestoneEvent.USERNOTICE_ID.equals(event.getTags().get("msg-id"))) {
+            eventManager.publish(new ViewerMilestoneEvent(event));
         }
     }
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ViewerMilestoneEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ViewerMilestoneEvent.java
@@ -1,0 +1,60 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.common.events.domain.EventUser;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.OptionalInt;
+
+@Value
+@Unofficial
+@ApiStatus.Experimental
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ViewerMilestoneEvent extends AbstractChannelEvent {
+
+    public static final String USERNOTICE_ID = "viewermilestone";
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    IRCMessageEvent messageEvent;
+
+    EventUser user;
+
+    String systemMessage; // e.g., "DisplayName watched 3 consecutive streams this month and sparked a watch streak!"
+
+    String milestoneUniqueId; // e.g., "c2eb863f-317e-440f-9a69-fc149b1abfcc"
+
+    String milestoneCategory; // e.g., "watch-streak"
+
+    String milestoneValue; // e.g., "3"
+
+    @ApiStatus.Internal
+    public ViewerMilestoneEvent(@NotNull IRCMessageEvent messageEvent) {
+        super(messageEvent.getChannel());
+        this.messageEvent = messageEvent;
+        this.user = messageEvent.getUser();
+        this.systemMessage = messageEvent.getTagValue("system-msg").orElse(null);
+        this.milestoneUniqueId = messageEvent.getTagValue("msg-param-id").orElse(null);
+        this.milestoneCategory = messageEvent.getTagValue("msg-param-category").orElse(null);
+        this.milestoneValue = messageEvent.getTagValue("msg-param-value").orElse(null);
+    }
+
+    public boolean isWatchStreak() {
+        return "watch-streak".equalsIgnoreCase(milestoneCategory);
+    }
+
+    public OptionalInt parseValue() {
+        try {
+            return OptionalInt.of(Integer.parseInt(milestoneValue));
+        } catch (Exception e) {
+            return OptionalInt.empty();
+        }
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Fire `ViewerMilestoneEvent` unofficial chat event

### Additional Information
https://help.twitch.tv/s/article/experiments?language=en_US
```
Viewer Milestone Cues: This experiment will highlight viewer milestones, if they opt in, to streamers so they can give a shoutout to their viewers accomplishments, like watch streaks, possibly creating more personalized relationships with their viewers.
```
