### PR TITLE
refactor: use buildMapping util across enums

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
@@ -2,12 +2,10 @@ package com.github.twitch4j.chat.enums;
 
 import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
 import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.util.EnumUtil;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 // This class was largely auto-generated via:
 // Array.from(tbody.children).slice(1).map(o => {
@@ -826,7 +824,7 @@ public enum NoticeTag {
      */
     WHISPER_RESTRICTED_RECIPIENT;
 
-    private static final Map<String, NoticeTag> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(NoticeTag::toString, Function.identity()));
+    private static final Map<String, NoticeTag> MAPPINGS = EnumUtil.buildMapping(values());
 
     @Override
     public String toString() {

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/domain/SocketCloseReason.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/domain/SocketCloseReason.java
@@ -1,13 +1,10 @@
 package com.github.twitch4j.eventsub.socket.domain;
 
+import com.github.twitch4j.util.EnumUtil;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * The reasons for closing the eventsub websocket connection.
@@ -56,15 +53,9 @@ public enum SocketCloseReason {
      */
     INVALID_RECONNECT(4007);
 
-    public static final Map<Integer, SocketCloseReason> MAPPINGS;
+    public static final Map<Integer, SocketCloseReason> MAPPINGS = EnumUtil.buildMapping(values(), SocketCloseReason::getCode);
 
     @Getter
     private final int code;
 
-    static {
-        MAPPINGS = Collections.unmodifiableMap(
-            Arrays.stream(values())
-                .collect(Collectors.toMap(SocketCloseReason::getCode, Function.identity()))
-        );
-    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -1,18 +1,16 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.github.twitch4j.util.EnumUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
@@ -361,8 +359,7 @@ public class ChatModerationAction {
             this.twitchString = twitchString;
         }
 
-        private static final Map<String, ModerationAction> MAPPINGS = Arrays.stream(ModerationAction.values())
-            .collect(Collectors.toMap(ModerationAction::getTwitchString, Function.identity()));
+        private static final Map<String, ModerationAction> MAPPINGS = EnumUtil.buildMapping(values(), ModerationAction::getTwitchString);
 
         @JsonCreator
         public static ModerationAction fromString(String action) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommunityPointsGoal.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CommunityPointsGoal.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.util.EnumUtil;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,10 +10,7 @@ import lombok.experimental.Accessors;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -64,13 +62,13 @@ public class CommunityPointsGoal {
     public enum Type {
         BOOST, CREATOR, @JsonEnumDefaultValue UNKNOWN;
 
-        static final Map<String, Type> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+        static final Map<String, Type> MAPPINGS = EnumUtil.buildMapping(values());
     }
 
     public enum Status {
         ARCHIVED, ENDED, FULFILLED, STARTED, @JsonEnumDefaultValue UNKNOWN, UNSTARTED;
 
-        static final Map<String, Status> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+        static final Map<String, Status> MAPPINGS = EnumUtil.buildMapping(values());
     }
 
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/FriendshipData.java
@@ -1,11 +1,9 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.github.twitch4j.util.EnumUtil;
 import lombok.Data;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * @deprecated Friends are being removed by <a href="https://help.twitch.tv/s/article/how-to-use-the-friends-feature">Twitch</a> on 2022-05-25
@@ -36,7 +34,7 @@ public class FriendshipData {
             return this.name().toLowerCase();
         }
 
-        private static final Map<String, Change> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+        private static final Map<String, Change> MAPPINGS = EnumUtil.buildMapping(values());
 
         @Deprecated
         public static Change fromString(String change) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PollsEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PollsEvent.java
@@ -2,13 +2,11 @@ package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.domain.PollData;
+import com.github.twitch4j.util.EnumUtil;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -28,6 +26,6 @@ public class PollsEvent extends TwitchEvent {
         POLL_ARCHIVE,
         POLL_TERMINATE;
 
-        private static final Map<String, EventType> MAPPINGS = Arrays.stream(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
+        private static final Map<String, EventType> MAPPINGS = EnumUtil.buildMapping(values());
     }
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Cheermote.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Cheermote.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.util.EnumUtil;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,11 +9,8 @@ import lombok.NonNull;
 import lombok.Setter;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -60,7 +58,7 @@ public class Cheermote {
             return this.name().toLowerCase();
         }
 
-        private static final Map<String, Type> MAPPINGS = Arrays.stream(Type.values()).collect(Collectors.toMap(Type::toString, Function.identity()));
+        private static final Map<String, Type> MAPPINGS = EnumUtil.buildMapping(values());
 
         @Deprecated
         public static Type fromString(String type) {

--- a/twitch4j/src/main/java/com/github/twitch4j/internal/ChatCommandRegistry.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/internal/ChatCommandRegistry.java
@@ -15,6 +15,7 @@ import com.github.twitch4j.helix.domain.Moderator;
 import com.github.twitch4j.helix.domain.ModeratorList;
 import com.github.twitch4j.helix.domain.NamedUserChatColor;
 import com.github.twitch4j.helix.domain.User;
+import com.github.twitch4j.util.EnumUtil;
 import com.github.twitch4j.util.PaginationUtil;
 import io.github.xanthic.cache.api.Cache;
 import io.github.xanthic.cache.api.domain.ExpiryType;
@@ -28,14 +29,12 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
 @Slf4j
 enum ChatCommandRegistry {
@@ -44,8 +43,7 @@ enum ChatCommandRegistry {
     /**
      * Mapping of old chat names of common colors to their Helix equivalents.
      */
-    private static final Map<String, String> HELIX_COLORS_BY_LOWER_CHAT_NAME = Arrays.stream(NamedUserChatColor.values())
-        .collect(Collectors.toMap(c -> c.toString().replace("_", ""), NamedUserChatColor::toString));
+    private static final Map<String, String> HELIX_COLORS_BY_LOWER_CHAT_NAME = EnumUtil.buildMapping(NamedUserChatColor.values(), c -> c.toString().replace("_", ""), Enum::toString);
 
     /**
      * A cache of recent name => id queries.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Use `EnumUtil.buildMapping` across relevant enums (follow-up from #749)
