### PR TITLE
fix(chat): read subscriber months for founders

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -271,7 +271,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return the exact number of months the user has been a subscriber, or empty if they are not subscribed
      */
     public OptionalInt getSubscriberMonths() {
-        final String monthsStr = badgeInfo.get("subscriber");
+        final String monthsStr = badgeInfo.getOrDefault("subscriber", badgeInfo.get("founder"));
 
         if (monthsStr != null) {
             try {
@@ -284,7 +284,7 @@ public class IRCMessageEvent extends TwitchEvent {
     }
 
     /**
-     * @return the tier at which the user is subscribed, or empty if they are not subscribed
+     * @return the tier at which the user is subscribed, or empty if they are not subscribed or have the founders badge equipped
      */
     public OptionalInt getSubscriptionTier() {
         final String subscriber = badges.get("subscriber");


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `getSubscriberMonths` yields empty for founders

### Changes Proposed
* Also read subscriber months from founders badge information

### Additional Information
The subscription tier is not sent by Twitch in the IRC message, so `getSubscriptionTier` will still yield empty
