### PR TITLE
fix(chat): fire join events from 353 names list

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelJoinEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelJoinEvent.java
@@ -4,30 +4,28 @@ import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 
 /**
- * This event gets called when a client joins a channel.
+ * This event gets called when a user joins a channel.
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 public class ChannelJoinEvent extends AbstractChannelEvent {
 
-	/**
-	 * User
-	 */
-	private EventUser user;
+    /**
+     * User
+     */
+    EventUser user;
 
-	/**
-	 * Event Constructor
-	 *
-	 * @param channel     The channel that this event originates from.
-	 * @param user        The user triggering the event.
-	 */
-	public ChannelJoinEvent(EventChannel channel, EventUser user) {
-		super(channel);
-		this.user = user;
-	}
+    /**
+     * Event Constructor
+     *
+     * @param channel The channel that this event originates from.
+     * @param user    The user triggering the event.
+     */
+    public ChannelJoinEvent(EventChannel channel, EventUser user) {
+        super(channel);
+        this.user = user;
+    }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelLeaveEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelLeaveEvent.java
@@ -4,30 +4,28 @@ import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 
 /**
- * This event gets called when a client leaves the channel.
+ * This event gets called when a user leaves the channel.
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 public class ChannelLeaveEvent extends AbstractChannelEvent {
 
-	/**
-	 * User
-	 */
-	private EventUser user;
+    /**
+     * User
+     */
+    EventUser user;
 
-	/**
-	 * Event Constructor
-	 *
-	 * @param channel     The channel that this event originates from.
-	 * @param user        The user triggering the event.
-	 */
-	public ChannelLeaveEvent(EventChannel channel, EventUser user) {
-		super(channel);
-		this.user = user;
-	}
+    /**
+     * Event Constructor
+     *
+     * @param channel The channel that this event originates from.
+     * @param user    The user triggering the event.
+     */
+    public ChannelLeaveEvent(EventChannel channel, EventUser user) {
+        super(channel);
+        this.user = user;
+    }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -25,7 +25,7 @@ import com.google.code.regexp.Pattern;
 @EqualsAndHashCode(callSuper = false)
 public class IRCMessageEvent extends TwitchEvent {
 
-    private static final Pattern MESSAGE_PATTERN = Pattern.compile("^(?:@(?<tags>\\S+?)\\s)?(?<clientName>\\S+?)\\s(?<command>[A-Z0-9]+)\\s?(?:#(?<channel>\\S*?)\\s?)?(?<payload>[:\\-+](?<message>.+))?$");
+    private static final Pattern MESSAGE_PATTERN = Pattern.compile("^(?:@(?<tags>\\S+?)\\s)?(?<clientName>\\S+?)\\s(?<command>[A-Z0-9]+)\\s?(?:(?<login>\\S+)\\s=\\s)?(?:#(?<channel>\\S*?)\\s?)?(?<payload>[:\\-+](?<message>.+))?$");
     private static final Pattern WHISPER_PATTERN = Pattern.compile("^(?:@(?<tags>\\S+?)\\s)?:(?<clientName>\\S+?)!.+?\\s(?<command>[A-Z0-9]+)\\s(?:(?<channel>\\S*?)\\s?)??(?<payload>[:\\-+](?<message>.+))$");
     private static final Pattern CLIENT_PATTERN = Pattern.compile("^:(.*?)!(.*?)@(.*?).tmi.twitch.tv$");
 

--- a/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
@@ -142,6 +142,19 @@ public class IRCMessageEventTest {
         assertTrue(e.getBadgeInfo() == null || e.getBadgeInfo().isEmpty());
     }
 
+    @Test
+    @DisplayName("Test that 353 NAMES response is parsed by IRCMessageEvent")
+    void parseNamesResponse() {
+        IRCMessageEvent e = build(":justinfan77645.tmi.twitch.tv 353 justinfan77645 = #pajlada :vissb ogprodigy supabridge zneix suslada beatz pajbot");
+
+        assertEquals("353", e.getCommandType());
+        assertEquals("pajlada", e.getChannelName().orElse(null));
+        assertEquals("vissb ogprodigy supabridge zneix suslada beatz pajbot", e.getMessage().orElse(null));
+        assertTrue(e.getClientName().isPresent());
+        assertTrue(e.getBadges().isEmpty());
+        assertTrue(e.getBadgeInfo().isEmpty());
+    }
+
     private static IRCMessageEvent build(String raw) {
         return new IRCMessageEvent(raw, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet());
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Sometimes upon joining a channel, instead of twitch sending us many `JOIN`'s, we receive `NAMES` list. This PR converts the `NAMES` response into `ChannelJoinEvent`'s

### Additional Information
https://en.wikipedia.org/wiki/List_of_Internet_Relay_Chat_commands#NAMES
