### PR TITLE
feat(helix): include new badge fields

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadge.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadge.java
@@ -4,32 +4,60 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
 public class ChatBadge {
 
     /**
-     * ID of the chat badge version.
+     * An ID that identifies this version of the badge.
+     * The ID can be any value.
+     * For example, for Bits, the ID is the Bits tier level, but for World of Warcraft, it could be Alliance or Horde.
      */
     private String id;
 
     /**
-     * Small image URL.
+     * A URL to the small version (18px x 18px) of the badge.
      */
     @JsonProperty("image_url_1x")
     private String smallImageUrl;
 
     /**
-     * Medium image URL.
+     * A URL to the medium version (36px x 36px) of the badge.
      */
     @JsonProperty("image_url_2x")
     private String mediumImageUrl;
 
     /**
-     * Large image URL.
+     * A URL to the large version (72px x 72px) of the badge.
      */
     @JsonProperty("image_url_4x")
     private String largeImageUrl;
+
+    /**
+     * The title of the badge.
+     */
+    private String title;
+
+    /**
+     * The description of the badge.
+     */
+    private String description;
+
+    /**
+     * The action to take when clicking on the badge.
+     * Set to null if no action is specified.
+     * Examples include "subscribe_to_channel" and "visit_url"
+     */
+    @Nullable
+    private String clickAction;
+
+    /**
+     * The URL to navigate to when clicking on the badge.
+     * Set to null if no URL is specified.
+     */
+    @Nullable
+    private String clickUrl;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSet.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSet.java
@@ -11,12 +11,16 @@ import java.util.List;
 public class ChatBadgeSet {
 
     /**
-     * ID for the chat badge set.
+     * An ID that identifies this set of chat badges.
+     * <p>
+     * For example, Bits or Subscriber.
      */
     private String setId;
 
     /**
      * Contains chat badge objects for the set.
+     * <p>
+     * The list is sorted in ascending order by {@link ChatBadge#getId()}.
      */
     private List<ChatBadge> versions;
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSetList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatBadgeSetList.java
@@ -13,6 +13,8 @@ public class ChatBadgeSetList {
 
     /**
      * The chat badge sets.
+     * <p>
+     * The list is sorted in ascending order by {@link ChatBadgeSet#getSetId()}.
      */
     @JsonProperty("data")
     private List<ChatBadgeSet> badgeSets;

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterface.java
@@ -14,13 +14,20 @@ import java.util.function.Supplier;
 
 /**
  * Twitch - Messaging Interface
+ *
+ * @deprecated All of these endpoints have been (or will be) decommissioned by Twitch.
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated
 public interface TwitchMessagingInterface {
 
     /**
      * The default baseUrl to pass to {@link #getGlobalBadges(URI, String)} and {@link #getChannelBadges(URI, String, String)}
+     *
+     * @deprecated Twitch will decommission this namespace on 2023-06-01
      */
     @Unofficial
+    @Deprecated
     URI BADGES_BASE_URL = ((Supplier<URI>) () -> {
         try {
             return new URI("https://badges.twitch.tv/v1");
@@ -31,7 +38,6 @@ public interface TwitchMessagingInterface {
 
     @Unofficial
     @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @RequestLine("GET /badges/global/display?language={language}")
     HystrixCommand<BadgeSets> getGlobalBadges(
         URI baseUrl,
@@ -43,15 +49,17 @@ public interface TwitchMessagingInterface {
      *
      * @param language Two-letter language code. Default: en.
      * @return BadgeSets
+     * @see <a href="https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621">Deprecation Announcement</a>
+     * @deprecated Twitch will decommission this endpoint on 2023-06-01; do migrate to {@code TwitchHelix#getGlobalChatBadges(String)}
      */
     @Unofficial
+    @Deprecated
     default HystrixCommand<BadgeSets> getGlobalBadges(String language) {
         return getGlobalBadges(BADGES_BASE_URL, language);
     }
 
     @Unofficial
     @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @RequestLine("GET /badges/channels/{channel_id}/display?language={language}")
     HystrixCommand<BadgeSets> getChannelBadges(
         URI baseUrl,
@@ -65,8 +73,11 @@ public interface TwitchMessagingInterface {
      * @param channelId The ID of the channel to query the badges of.
      * @param language  Two-letter language code. Default: en.
      * @return BadgeSets
+     * @see <a href="https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621">Deprecation Announcement</a>
+     * @deprecated Twitch will decommission this endpoint on 2023-06-01; do migrate to {@code TwitchHelix#getChannelChatBadges(String, String)}
      */
     @Unofficial
+    @Deprecated
     default HystrixCommand<BadgeSets> getChannelBadges(String channelId, String language) {
         return getChannelBadges(BADGES_BASE_URL, channelId, language);
     }

--- a/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
+++ b/rest-tmi/src/main/java/com/github/twitch4j/tmi/TwitchMessagingInterfaceBuilder.java
@@ -88,7 +88,9 @@ public class TwitchMessagingInterfaceBuilder {
      * Twitch API Client (Helix)
      *
      * @return TwitchHelix
+     * @deprecated All of the {@link TwitchMessagingInterfaceBuilder} endpoints have been (or will be) decommissioned by Twitch.
      */
+    @Deprecated
     public TwitchMessagingInterface build() {
         log.debug("TMI: Initializing Module ...");
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -120,8 +120,11 @@ public class TwitchClientBuilder {
 
     /**
      * Enabled: TMI
+     *
+     * @deprecated All of the {@link TwitchMessagingInterfaceBuilder} endpoints have been (or will be) decommissioned by Twitch.
      */
     @With
+    @Deprecated
     private Boolean enableTMI = false;
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -119,14 +119,20 @@ public class TwitchClientPoolBuilder {
 
     /**
      * Enabled: Kraken
+     *
+     * @deprecated Twitch shutdown the Kraken API in 2022.
      */
     @With
+    @Deprecated
     private Boolean enableKraken = false;
 
     /**
      * Enabled: TMI
+     *
+     * @deprecated All of the {@link TwitchMessagingInterfaceBuilder} endpoints have been (or will be) decommissioned by Twitch.
      */
     @With
+    @Deprecated
     private Boolean enableTMI = false;
 
     /**

--- a/twitch4j/src/test/java/com/github/twitch4j/TwitchClientTest.java
+++ b/twitch4j/src/test/java/com/github/twitch4j/TwitchClientTest.java
@@ -31,7 +31,6 @@ public class TwitchClientTest {
         TwitchClient twitchClient = TwitchClientBuilder.builder()
             .withEventManager(eventManager)
             .withEnableHelix(true)
-            .withEnableKraken(true)
             .withEnableChat(false)
             .build();
     }
@@ -57,7 +56,6 @@ public class TwitchClientTest {
         // construct twitchClient
         TwitchClient twitchClient = TwitchClientBuilder.builder()
             .withEnableHelix(true)
-            .withEnableKraken(true)
             .withEnableChat(false)
             .withScheduledThreadPoolExecutor(scheduledThreadPoolExecutor)
             .build();
@@ -74,7 +72,6 @@ public class TwitchClientTest {
         // construct twitchClient
         TwitchClient twitchClient = TwitchClientBuilder.builder()
             .withEnableHelix(true)
-            .withEnableKraken(true)
             .withEnableChat(false)
             .withScheduledThreadPoolExecutor(new ScheduledThreadPoolExecutor(1))
             .build();
@@ -94,8 +91,6 @@ public class TwitchClientTest {
         TwitchClient twitchClient = TwitchClientBuilder.builder()
             .withEventManager(null)
             .withEnableHelix(true)
-            .withEnableKraken(false)
-            .withEnableTMI(false)
             .withEnableChat(true)
             .withChatAccount(TestUtils.getCredential())
             .withDefaultAuthToken(TestUtils.getCredential())


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `title`, `description`, `click_action`, and `click_url` to helix badge POJO
* Update javadocs for helix badge classes
* Deprecate undocumented badges endpoints in `TwitchMessagingInterface`
* Deprecate full `TwitchMessagingInterface` module

### Additional Information
https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621
