### PR TITLE
chore(eventsub): upgrade to non-beta websocket url

### DIFF
--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
@@ -70,7 +70,7 @@ public final class TwitchEventSocket implements IEventSubSocket {
     /**
      * The WebSocket Server
      */
-    public static final String WEB_SOCKET_SERVER = "wss://eventsub-beta.wss.twitch.tv/ws";
+    public static final String WEB_SOCKET_SERVER = "wss://eventsub.wss.twitch.tv/ws";
 
     /**
      * Helix API instance


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Migrate to `wss://eventsub.wss.twitch.tv/ws` (requires t4j release before May 15)

### Additional Information
https://discuss.dev.twitch.tv/t/update-required-for-eventsub-websockets-beta-connection-url
