### PR TITLE
chore: add shield mode scopes to enum

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -46,6 +46,8 @@ public enum TwitchScopes {
     HELIX_CHAT_MESSAGES_MANAGE("moderator:manage:chat_messages"),
     HELIX_CHAT_SETTINGS_MANAGE("moderator:manage:chat_settings"),
     HELIX_CHAT_SETTINGS_READ("moderator:read:chat_settings"),
+    HELIX_SHIELD_MODE_MANAGE("moderator:manage:shield_mode"),
+    HELIX_SHIELD_MODE_READ("moderator:read:shield_mode"),
     HELIX_SHOUTOUTS_MANAGE("moderator:manage:shoutouts"),
     HELIX_SHOUTOUTS_READ("moderator:read:shoutouts"),
     HELIX_USER_COLOR_MANAGE("user:manage:chat_color"),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeBeginType.java
@@ -9,6 +9,9 @@ import com.github.twitch4j.eventsub.events.ShieldModeBeginEvent;
  * This event informs the subscriber that the broadcaster’s moderation settings were changed based on the broadcaster’s Shield Mode configuration settings.
  * <p>
  * Requires the moderator:read:shield_mode or moderator:manage:shield_mode scope.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_READ
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_MANAGE
  */
 public class ShieldModeBeginType implements SubscriptionType<ShieldModeCondition, ShieldModeCondition.ShieldModeConditionBuilder<?, ?>, ShieldModeBeginEvent> {
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeEndType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ShieldModeEndType.java
@@ -9,6 +9,9 @@ import com.github.twitch4j.eventsub.events.ShieldModeEndEvent;
  * This event informs the subscriber that the broadcaster’s moderation settings were changed based on the broadcaster’s Shield Mode configuration settings.
  * <p>
  * Requires the moderator:read:shield_mode or moderator:manage:shield_mode scope.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_READ
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_MANAGE
  */
 public class ShieldModeEndType implements SubscriptionType<ShieldModeCondition, ShieldModeCondition.ShieldModeConditionBuilder<?, ?>, ShieldModeEndEvent> {
     @Override

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1921,6 +1921,8 @@ public interface TwitchHelix {
      * @param broadcasterId The ID of the broadcaster whose Shield Mode activation status you want to get.
      * @param moderatorId   The ID of the broadcaster or a user that is one of the broadcaster’s moderators. This ID must match the user ID in the access token.
      * @return ShieldModeStatusWrapper
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_READ
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_MANAGE
      */
     @RequestLine("GET /moderation/shield_mode?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
     @Headers("Authorization: Bearer {token}")
@@ -1938,6 +1940,7 @@ public interface TwitchHelix {
      * @param moderatorId   The ID of the broadcaster or a user that is one of the broadcaster’s moderators. This ID must match the user ID in the access token.
      * @param active        A Boolean value that determines whether to activate Shield Mode.
      * @return ShieldModeStatusWrapper
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_SHIELD_MODE_MANAGE
      */
     @RequestLine("PUT /moderation/shield_mode?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
     @Headers({


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `moderator:read:shield_mode` & `moderator:manage:shield_mode` to `TwitchScopes`
