### PR TITLE
feat(chat): reply in thread when possible

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.ITwitchChat;
 import com.github.twitch4j.common.events.domain.EventChannel;
+import com.github.twitch4j.common.util.ChatReply;
 import com.github.twitch4j.common.util.CryptoUtils;
 
 @FunctionalInterface
@@ -20,7 +21,9 @@ public interface ReplyableEvent {
      * @param message the message to be sent.
      */
     default void reply(ITwitchChat chat, String message) {
-        chat.sendMessage(getChannel().getName(), message, CryptoUtils.generateNonce(32), getMessageEvent().getMessageId().orElse(null));
+        String replyId = getMessageEvent().getTagValue(ChatReply.REPLY_MSG_ID_TAG_NAME)
+            .orElseGet(() -> getMessageEvent().getMessageId().orElse(null));
+        chat.sendMessage(getChannel().getName(), message, CryptoUtils.generateNonce(32), replyId);
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* `ReplyableEvent#reply` should reply within existing threads when possible (otherwise, reply directly to the message)

### Additional Information
Requested by @MineTrainDevelopment
