### PR TITLE
chore: deprecate soundtrack apis

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -6,6 +6,7 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.util.CryptoUtils;
 import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import com.github.twitch4j.pubsub.enums.PubSubType;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -535,6 +536,7 @@ public interface ITwitchPubSub extends AutoCloseable {
      */
     @Unofficial
     @Deprecated
+    @ApiStatus.ScheduledForRemoval
     default PubSubSubscription listenForRadioEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "radio-events-v1." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -525,7 +525,16 @@ public interface ITwitchPubSub extends AutoCloseable {
         return listenOnTopic(PubSubType.LISTEN, credential, "presence." + userId);
     }
 
+    /**
+     * Unofficial: Listen for soundtrack events
+     *
+     * @param credential User Access Token
+     * @param channelId  Target Channel Id
+     * @return PubSubSubscription
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+     */
     @Unofficial
+    @Deprecated
     default PubSubSubscription listenForRadioEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "radio-events-v1." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -733,6 +733,7 @@ public class TwitchPubSub implements ITwitchPubSub {
                         log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
                     }
                 } else if ("radio-events-v1".equals(topicName)) {
+                    // noinspection deprecation
                     eventManager.publish(new RadioEvent(TypeConvert.jsonToObject(rawMessage, RadioData.class)));
                 } else if ("shield-mode".equals(topicName) && topicParts.length == 3) {
                     String userId = topicParts[1];

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioData.java
@@ -9,8 +9,12 @@ import lombok.Setter;
 
 import java.time.Instant;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class RadioData {
 
     @JsonProperty("userID")

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioTrack.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/RadioTrack.java
@@ -7,8 +7,12 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class RadioTrack {
 
     private String asin;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RadioEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/RadioEvent.java
@@ -5,8 +5,12 @@ import com.github.twitch4j.pubsub.domain.RadioData;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Value
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class RadioEvent extends TwitchEvent {
     RadioData data;
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -18,6 +18,7 @@ import feign.Param;
 import feign.RequestLine;
 import feign.Response;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -1120,6 +1121,7 @@ public interface TwitchHelix {
      * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval
     @RequestLine("GET /soundtrack/current_track?broadcaster_id={broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SoundtrackCurrentTrackWrapper> getSoundtrackCurrentTrack(
@@ -1138,6 +1140,7 @@ public interface TwitchHelix {
      * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval
     @RequestLine("GET /soundtrack/playlist?id={id}&first={first}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SoundtrackPlaylistTracksList> getSoundtrackPlaylist(
@@ -1161,6 +1164,7 @@ public interface TwitchHelix {
      * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval
     @RequestLine("GET /soundtrack/playlists?id={id}&first={first}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SoundtrackPlaylistMetadataList> getSoundtrackPlaylists(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1117,8 +1117,9 @@ public interface TwitchHelix {
      * @param authToken     App access token or User access token.
      * @param broadcasterId The ID of the broadcaster that’s playing a Soundtrack track.
      * @return SoundtrackCurrentTrackWrapper
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
      */
-    @Unofficial // beta
+    @Deprecated
     @RequestLine("GET /soundtrack/current_track?broadcaster_id={broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SoundtrackCurrentTrackWrapper> getSoundtrackCurrentTrack(
@@ -1134,8 +1135,9 @@ public interface TwitchHelix {
      * @param limit     Optional: The maximum number of tracks to return for this playlist in the response. The minimum number of tracks is 1 and the maximum is 50. The default is 20.
      * @param after     Optional: The cursor used to get the next page of tracks for this playlist. The Pagination object in the response contains the cursor’s value.
      * @return SoundtrackPlaylistTracksList
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
      */
-    @Unofficial // beta
+    @Deprecated
     @RequestLine("GET /soundtrack/playlist?id={id}&first={first}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SoundtrackPlaylistTracksList> getSoundtrackPlaylist(
@@ -1156,8 +1158,9 @@ public interface TwitchHelix {
      * @param limit     Optional: The maximum number of playlists to return in the response. The minimum number of playlists is 1 and the maximum is 50. The default is 20.
      * @param after     Optional: The cursor used to get the next page of playlists. The Pagination object in the response contains the cursor’s value.
      * @return SoundtrackPlaylistMetadataList
+     * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
      */
-    @Unofficial // beta
+    @Deprecated
     @RequestLine("GET /soundtrack/playlists?id={id}&first={first}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SoundtrackPlaylistMetadataList> getSoundtrackPlaylists(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackAlbum.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackAlbum.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackAlbum {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackArtist.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackArtist.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackArtist {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrack.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrack.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackCurrentTrack {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
@@ -7,8 +7,12 @@ import lombok.Setter;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackCurrentTrackWrapper {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadata.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadata.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackPlaylistMetadata {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadataList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistMetadataList.java
@@ -8,8 +8,12 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackPlaylistMetadataList {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistTracksList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackPlaylistTracksList.java
@@ -7,8 +7,12 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackPlaylistTracksList {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackSource.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackSource.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackSource {
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackTrack.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackTrack.java
@@ -7,8 +7,12 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
+@Deprecated
 public class SoundtrackTrack {
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate `getSoundtrackCurrentTrack`, `getSoundtrackPlaylist`, `getSoundtrackPlaylists` helix endpoints due to Twitch EOL

### Additional Information
https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/
