### PR TITLE
fix: detect whether founders are subscribed or not

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -9,12 +9,24 @@ import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import com.github.twitch4j.common.util.EscapeUtils;
 import com.github.twitch4j.common.util.TwitchUtils;
-import lombok.*;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.*;
 import com.google.code.regexp.Matcher;
 import com.google.code.regexp.Pattern;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
 
 /**
  * This event gets called when we receive a raw irc message.
@@ -127,10 +139,6 @@ public class IRCMessageEvent extends TwitchEvent {
         // permissions and badges
         getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds));
         getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
-        if ("1".equals(tags.get("subscriber"))) {
-            // allows for accurate sub detection when user has founder badge equipped
-            clientPermissions.add(CommandPermission.SUBSCRIBER);
-        }
     }
 
 	/**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -125,9 +125,13 @@ public class IRCMessageEvent extends TwitchEvent {
         }
 
         // permissions and badges
-		getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds));
-		getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
-	}
+        getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds));
+        getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
+        if ("1".equals(tags.get("subscriber"))) {
+            // allows for accurate sub detection when user has founder badge equipped
+            clientPermissions.add(CommandPermission.SUBSCRIBER);
+        }
+    }
 
 	/**
 	 * Checks if the Event was parsed correctly.

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -32,7 +32,12 @@ public class TwitchUtils {
     public static Set<CommandPermission> getPermissionsFromTags(@NonNull Map<String, Object> tags, @NonNull Map<String, String> badges, String userId, Collection<String> botOwnerIds) {
         Set<CommandPermission> permissionSet = EnumSet.of(CommandPermission.EVERYONE);
 
-        // Check for Permissions
+        // check tags
+        if ("1".equals(tags.get("subscriber"))) { // allows for accurate sub detection when user has the founder badge equipped
+            permissionSet.add(CommandPermission.SUBSCRIBER);
+        }
+
+        // check badges
         if (tags.containsKey("badges")) {
             if (tags.get("badges") instanceof String) {
                 // needed for irc

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -88,7 +88,6 @@ public class TwitchUtils {
             // Founder
             if (badges.containsKey("founder")) {
                 permissionSet.add(CommandPermission.FOUNDER);
-                permissionSet.add(CommandPermission.SUBSCRIBER);
 
                 // also contains info about the tier if needed
                 /*


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* All founders were assumed to be active subscribers

### Changes Proposed
* Use `subscriber` tag to assign `CommandPermission.SUBSCRIBER`
