### PR TITLE
feat(pubsub): add auth revoke event

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -949,8 +949,10 @@ public class TwitchPubSub implements ITwitchPubSub {
 
     @Override
     public PubSubSubscription listenOnTopic(PubSubRequest request) {
-        if (subscribedTopics.add(request))
+        if (subscribedTopics.add(request)) {
+            checkListenCount(request);
             queueRequest(request);
+        }
         return new PubSubSubscription(request);
     }
 
@@ -991,6 +993,14 @@ public class TwitchPubSub implements ITwitchPubSub {
             heartbeatTask.cancel(false);
             queueTask.cancel(false);
             connection.close();
+        }
+    }
+
+    private void checkListenCount(PubSubRequest request) {
+        Object topics = request.getData().get("topics");
+        if (topics instanceof Collection && ((Collection<?>) topics).size() > 1) {
+            log.warn("Listening to multiple PubSub topics in a single request is not recommended; " +
+                "automatic topic management can degrade upon PubSubAuthRevokeEvent");
         }
     }
 

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/enums/PubSubType.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/enums/PubSubType.java
@@ -8,4 +8,5 @@ public enum PubSubType {
     UNLISTEN,
     RESPONSE,
     MESSAGE,
+    AUTH_REVOKED,
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubAuthRevokeEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubAuthRevokeEvent.java
@@ -2,10 +2,14 @@ package com.github.twitch4j.pubsub.events;
 
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.ITwitchPubSub;
+import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Fired when a user access token had outstanding PubSub subscriptions, but was revoked.
@@ -19,5 +23,9 @@ import java.util.Collection;
 @EqualsAndHashCode(callSuper = false)
 public class PubSubAuthRevokeEvent extends TwitchEvent {
     ITwitchPubSub socket;
-    Collection<String> revokedTopics;
+    Map<@NotNull String, @Nullable PubSubRequest> revokedListensByTopic;
+
+    public Collection<String> getTopicNames() {
+        return revokedListensByTopic.keySet();
+    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubAuthRevokeEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubAuthRevokeEvent.java
@@ -1,10 +1,13 @@
 package com.github.twitch4j.pubsub.events;
 
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.ITwitchPubSub;
 import com.github.twitch4j.pubsub.domain.PubSubRequest;
+import com.github.twitch4j.pubsub.enums.PubSubType;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,9 +25,27 @@ import java.util.Map;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class PubSubAuthRevokeEvent extends TwitchEvent {
+    /**
+     * The PubSub websocket that was subscribed to these revoked topics.
+     */
     ITwitchPubSub socket;
+
+    /**
+     * Mappings of revoked topic names to the associated {@link PubSubRequest} (LISTEN).
+     * <p>
+     * Warning: Values can be null if you manually call
+     * {@link ITwitchPubSub#listenOnTopic(PubSubRequest)} or
+     * {@link ITwitchPubSub#listenOnTopic(PubSubType, OAuth2Credential, Collection)}
+     * with requests that contain <b>more than</b> one topic in a <i>single</i> {@link PubSubType#LISTEN}.
+     */
+    @NotNull
+    @ApiStatus.Experimental
     Map<@NotNull String, @Nullable PubSubRequest> revokedListensByTopic;
 
+    /**
+     * @return the topics that were revoked (including the user id's)
+     */
+    @NotNull
     public Collection<String> getTopicNames() {
         return revokedListensByTopic.keySet();
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubAuthRevokeEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/PubSubAuthRevokeEvent.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.ITwitchPubSub;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import java.util.Collection;
+
+/**
+ * Fired when a user access token had outstanding PubSub subscriptions, but was revoked.
+ * <p>
+ * An authorization can be revoked at any time for a number of reasons,
+ * such a user disconnecting from an app through <a href="https://www.twitch.tv/settings/connections">Connections Settings</a>.
+ * <p>
+ * Topics associated with the authorization will automatically be unlistened to.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class PubSubAuthRevokeEvent extends TwitchEvent {
+    ITwitchPubSub socket;
+    Collection<String> revokedTopics;
+}

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/RevocationTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/RevocationTest.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.enums.PubSubType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RevocationTest {
+
+    @Test
+    void parseAsResponse() {
+        String json = "{\"type\":\"AUTH_REVOKED\",\"data\":{\"topics\":[\"channel-bits-events-v1.44322889\"]}}";
+        PubSubResponse message = TypeConvert.jsonToObject(json, PubSubResponse.class);
+        assertNotNull(message);
+        assertEquals(PubSubType.AUTH_REVOKED, message.getType());
+    }
+
+    @Test
+    void parseAsRequest() {
+        String json = "{\"type\":\"AUTH_REVOKED\",\"data\":{\"topics\":[\"channel-bits-events-v1.44322889\"]}}";
+        PubSubRequest message = TypeConvert.jsonToObject(json, PubSubRequest.class);
+        assertNotNull(message);
+        assertEquals(PubSubType.AUTH_REVOKED, message.getType());
+        assertEquals(Collections.singletonList("channel-bits-events-v1.44322889"), message.getData().get("topics"));
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* Don't try to LISTEN to revoked topics on reconnects

### Changes Proposed
* Handle and fire event on new PubSub `AUTH_REVOKED` message type

### Additional Information
https://dev.twitch.tv/docs/pubsub/#authorization-revoked (added on 2023-06-15)
