### PR TITLE
perf: optimize EscapeUtils#unescapeTagValue

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
@@ -1,7 +1,5 @@
 package com.github.twitch4j.common.util;
 
-import org.apache.commons.lang3.StringUtils;
-
 public class EscapeUtils {
 
     /**
@@ -68,23 +66,46 @@ public class EscapeUtils {
      * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Official spec</a>
      */
     public static String unescapeTagValue(String value) {
-        return StringUtils.replaceEach(
-            value,
-            new String[] {
-                "\\:",
-                "\\s",
-                "\\\\",
-                "\\r",
-                "\\n"
-            },
-            new String[] {
-                ";",
-                " ",
-                "\\",
-                "\r",
-                "\n"
+        final int start;
+        if (value == null || (start = value.indexOf('\\')) < 0)
+            return value;
+
+        final int len = value.length();
+        final StringBuilder sb = new StringBuilder(len - 1);
+        sb.append(value, 0, start);
+
+        boolean escapeNext = true;
+        for (int i = start + 1; i < len; i++) {
+            char c = value.charAt(i);
+            if (escapeNext) {
+                switch (c) {
+                    case ':':
+                        sb.append(';');
+                        break;
+                    case 's':
+                        sb.append(' ');
+                        break;
+                    case 'r':
+                        sb.append('\r');
+                        break;
+                    case 'n':
+                        sb.append('\n');
+                        break;
+                    default:
+                        sb.append(c);
+                        break;
+                }
+                escapeNext = false;
+            } else {
+                if (c == '\\') {
+                    escapeNext = true;
+                } else {
+                    sb.append(c);
+                }
             }
-        );
+        }
+
+        return sb.toString();
     }
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/EscapeUtils.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j.common.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class EscapeUtils {
 
     /**
@@ -65,10 +67,13 @@ public class EscapeUtils {
      * @return the unescaped value
      * @see <a href="https://ircv3.net/specs/extensions/message-tags.html">Official spec</a>
      */
-    public static String unescapeTagValue(String value) {
-        final int start;
-        if (value == null || (start = value.indexOf('\\')) < 0)
-            return value;
+    public static String unescapeTagValue(CharSequence value) {
+        if (value == null)
+            return null;
+
+        final int start = StringUtils.indexOf(value, '\\');
+        if (start < 0)
+            return value.toString();
 
         final int len = value.length();
         final StringBuilder sb = new StringBuilder(len - 1);

--- a/common/src/test/java/com/github/twitch4j/common/util/EscapeUtilsTest.java
+++ b/common/src/test/java/com/github/twitch4j/common/util/EscapeUtilsTest.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EscapeUtilsTest {
+
+    @Test
+    void unescapeTagValue() {
+        assertEquals("", EscapeUtils.unescapeTagValue(""));
+        assertEquals(" ", EscapeUtils.unescapeTagValue("\\s"));
+        assertEquals("  ", EscapeUtils.unescapeTagValue("\\s\\s"));
+        assertEquals(" . ", EscapeUtils.unescapeTagValue("\\s.\\s"));
+        assertEquals(". .", EscapeUtils.unescapeTagValue(".\\s."));
+        assertEquals(" ;\r\n\\", EscapeUtils.unescapeTagValue("\\s\\:\\r\\n\\\\"));
+        assertEquals(" ;\r\n\\ ", EscapeUtils.unescapeTagValue("\\s\\:\\r\\n\\\\\\s"));
+        assertEquals("\\s", EscapeUtils.unescapeTagValue("\\\\s"));
+        assertEquals("a", EscapeUtils.unescapeTagValue("\\a"));
+        assertEquals("aaa:", EscapeUtils.unescapeTagValue("\\aaa:"));
+        assertEquals("aaa;", EscapeUtils.unescapeTagValue("\\aaa\\:"));
+        assertEquals("HelloWorld!", EscapeUtils.unescapeTagValue("HelloWorld!"));
+        assertEquals("HelloWorld!", EscapeUtils.unescapeTagValue("HelloWorld!\\"));
+        assertEquals("HelloWorld!", EscapeUtils.unescapeTagValue("Hell\\oWorld!"));
+        assertEquals("Hello World!", EscapeUtils.unescapeTagValue("Hello\\sWorld!"));
+        assertEquals("Hello W world!", EscapeUtils.unescapeTagValue("Hello\\sW\\sworld!"));
+        assertEquals("Hello  World!", EscapeUtils.unescapeTagValue("Hello\\s\\sWorld!"));
+        assertEquals("Hello  World;", EscapeUtils.unescapeTagValue("Hello\\s\\sWorld\\:"));
+        assertEquals("Hello  World!", EscapeUtils.unescapeTagValue("Hello\\s\\sWorld!\\"));
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* `\a` should be unescaped as `a`
* `\` at end of string should be unescaped as empty string

(however, neither of these issues occur with observed twitch data)

### Changes Proposed
* Rewrite `EscapeUtils#unescapeTagValue`

### Additional Information
https://ircv3.net/specs/extensions/message-tags.html
