### PR TITLE
perf(chat): avoid duplicated tags parsing

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -45,10 +45,12 @@ public class IRCMessageEvent extends TwitchEvent {
     @Unofficial
     public static final String NONCE_TAG_NAME = "client-nonce";
 
-	/**
-	 * Tags
-	 */
-	private Map<String, String> tags = new HashMap<>();
+    /**
+     * Tags
+     * <p>
+     * Most applications should utilize {@link #getTagValue(String)} rather than accessing this map directly.
+     */
+    private Map<String, String> tags = new HashMap<>();
 
 	/**
 	 * Badges

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -188,7 +188,7 @@ public class IRCMessageEvent extends TwitchEvent {
 		if(StringUtils.isBlank(raw)) return map;
 
 		for (String tag: raw.split(";")) {
-			String[] val = tag.split("=");
+			String[] val = tag.split("=", 2);
 			final String key = val[0];
 			String value = (val.length > 1) ? val[1] : null;
 			map.put(key, value);

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -48,11 +49,6 @@ public class IRCMessageEvent extends TwitchEvent {
 	 * Tags
 	 */
 	private Map<String, String> tags = new HashMap<>();
-
-    /**
-     * Raw Tags
-     */
-    private Map<String, Object> rawTags = new HashMap<>();
 
 	/**
 	 * Badges
@@ -159,7 +155,6 @@ public class IRCMessageEvent extends TwitchEvent {
 		if (matcher.matches()) {
 			// Parse Tags
 			tags = parseTags(matcher.group("tags"));
-            rawTags = parseTags(matcher.group("tags"));
 			clientName = parseClientName(matcher.group("clientName"));
 			commandType = matcher.group("command");
 			channelName = Optional.ofNullable(matcher.group("channel"));
@@ -173,7 +168,6 @@ public class IRCMessageEvent extends TwitchEvent {
 		if (matcherPM.matches()) {
 			// Parse Tags
 			tags = parseTags(matcherPM.group("tags"));
-			rawTags = parseTags(matcherPM.group("tags"));
 			clientName = parseClientName(matcherPM.group("clientName"));
 			commandType = matcherPM.group("command");
 			channelName = Optional.ofNullable(matcherPM.group("channel"));
@@ -188,7 +182,8 @@ public class IRCMessageEvent extends TwitchEvent {
 	 * @param raw The raw list of tags.
 	 * @return A key-value map of the tags.
 	 */
-	public Map parseTags(String raw) {
+    @ApiStatus.Internal
+	public Map<String, String> parseTags(String raw) {
 		Map<String, String> map = new HashMap<>();
 		if(StringUtils.isBlank(raw)) return map;
 
@@ -402,5 +397,14 @@ public class IRCMessageEvent extends TwitchEvent {
 	public EventChannel getChannel() {
 		return new EventChannel(getChannelId(), getChannelName().get());
 	}
+
+    /**
+     * @return IRCv3 tags
+     * @deprecated in favor of {@link #getTags()}
+     */
+    @Deprecated
+    public Map<String, Object> getRawTags() {
+        return Collections.unmodifiableMap(tags);
+    }
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -158,8 +158,8 @@ public class TwitchUtils {
         // Fix Whitespaces
         raw = EscapeUtils.unescapeTagValue(raw);
 
-        for (String tag : StringUtils.split(raw, ',')) {
-            String[] val = StringUtils.split(tag, "/", 2);
+        for (String tag : raw.split(",")) {
+            String[] val = tag.split("/", 2);
             final String key = val[0];
             String value = (val.length > 1) ? val[1] : null;
             map.put(key, value);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
* If a tag value included `=`, the value would be truncated

### Changes Proposed
* Remove `rawTags` field (avoids calling `parseTags` twice)
* Deprecate `getRawTags` (simply returns `tags` now)

### Additional Information
The maps assigned to `tags` and `rawTags` were equal, despite rawTags having `Object` values (they were all strings)
