### PR TITLE
refactor(chat): treat tag value as CharSequence

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -31,7 +31,7 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      */
     @Nullable
     @Getter(lazy = true)
-    ChatReply replyInfo = ChatReply.parse(getMessageEvent().getTags());
+    ChatReply replyInfo = ChatReply.parse(getMessageEvent().getEscapedTags());
 
     /**
      * Information regarding any associated Crowd Chant for this message, if applicable.

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -12,6 +12,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -67,7 +68,7 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      */
     @Unofficial
     public boolean isHighlightedMessage() {
-        return "highlighted-message".equals(getMessageEvent().getTags().get("msg-id"));
+        return StringUtils.equals("highlighted-message", getMessageEvent().getRawTag("msg-id"));
     }
 
     /**
@@ -75,7 +76,7 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      */
     @Unofficial
     public boolean isSkipSubsModeMessage() {
-        return "skip-subs-mode-message".equals(getMessageEvent().getTags().get("msg-id"));
+        return StringUtils.equals("skip-subs-mode-message", getMessageEvent().getRawTag("msg-id"));
     }
 
     /**
@@ -93,7 +94,7 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      */
     @Unofficial
     public boolean isDesignatedFirstMessage() {
-        return "1".equals(getMessageEvent().getTags().get("first-msg"));
+        return StringUtils.equals("1", getMessageEvent().getRawTag("first-msg"));
     }
 
     /**
@@ -103,7 +104,7 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      */
     @Unofficial
     public boolean isUserIntroduction() {
-        return "user-intro".equals(getMessageEvent().getTags().get("msg-id"));
+        return StringUtils.equals("user-intro", getMessageEvent().getRawTag("msg-id"));
     }
 
     /**
@@ -113,27 +114,24 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      */
     @Unofficial
     public Optional<DonationAmount> getElevatedChatPayment() {
-        final Map<String, String> tags = getMessageEvent().getTags();
+        final Map<String, CharSequence> tags = getMessageEvent().getEscapedTags();
 
-        String amount = tags.get("pinned-chat-paid-amount");
+        CharSequence amount = tags.get("pinned-chat-paid-amount");
         if (amount == null) {
             amount = tags.get("pinned-chat-paid-canonical-amount");
-            if (amount != null) {
-                amount += "00";
-            }
         }
 
         return Optional.ofNullable(amount)
             .map(amt -> {
                 try {
-                    return Long.parseLong(amt);
+                    return Long.parseLong(amt.toString());
                 } catch (Exception e) {
                     return null;
                 }
             })
             .map(amt -> {
-                String currency = tags.getOrDefault("pinned-chat-paid-currency", "USD");
-                String exponentStr = tags.getOrDefault("pinned-chat-paid-exponent", "2");
+                String currency = tags.getOrDefault("pinned-chat-paid-currency", "USD").toString();
+                String exponentStr = tags.getOrDefault("pinned-chat-paid-exponent", "2").toString();
                 int exponent;
                 try {
                     exponent = Integer.parseInt(exponentStr);

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/CharityDonationEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/CharityDonationEvent.java
@@ -43,9 +43,9 @@ public class CharityDonationEvent extends AbstractChannelEvent {
         this.badges = rawEvent.getClientPermissions();
         this.charityName = rawEvent.getTagValue("msg-param-charity-name").orElse(null);
 
-        Long amount = Long.parseLong(rawEvent.getTags().get("msg-param-donation-amount"));
+        Long amount = Long.parseLong(rawEvent.getTagValue("msg-param-donation-amount").orElse("0"));
         String currency = rawEvent.getTagValue("msg-param-donation-currency").orElse("USD");
-        Integer decimals = Integer.parseInt(rawEvent.getTags().getOrDefault("msg-param-exponent", "2"));
+        Integer decimals = Integer.parseInt(rawEvent.getTagValue("msg-param-exponent").orElse("2"));
         this.amount = new DonationAmount(amount, decimals, currency);
 
         this.systemMessage = rawEvent.getTagValue("system-msg").orElseGet(

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftedMultiMonthSubCourtesyEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftedMultiMonthSubCourtesyEvent.java
@@ -6,6 +6,7 @@ import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
 
 import static com.github.twitch4j.common.util.TwitchUtils.ANONYMOUS_GIFTER;
 
@@ -80,15 +81,15 @@ public class GiftedMultiMonthSubCourtesyEvent extends AbstractChannelEvent {
         this.messageEvent = event;
         this.user = event.getUser();
         this.message = event.getMessage().orElse(null);
-        this.subscriptionPlan = SubscriptionPlan.fromString(event.getTags().getOrDefault("msg-param-sub-plan", "1000"));
-        this.wasAnonymous = "true".equalsIgnoreCase(event.getTags().get("msg-param-anon-gift"));
+        this.subscriptionPlan = SubscriptionPlan.fromString(event.getTagValue("msg-param-sub-plan").orElse("1000"));
+        this.wasAnonymous = StringUtils.equalsIgnoreCase("true", event.getRawTag("msg-param-anon-gift"));
         this.gifter = wasAnonymous ? ANONYMOUS_GIFTER : new EventUser(
-            event.getTags().get("msg-param-gifter-id"),
+            event.getRawTagString("msg-param-gifter-id"),
             event.getTagValue("msg-param-gifter-login").orElse(event.getTagValue("msg-param-gifter-name").orElse(null))
         );
-        this.giftMonths = Integer.parseInt(event.getTags().getOrDefault("msg-param-gift-months", "0"));
-        this.redeemedMonth = Integer.parseInt(event.getTags().getOrDefault("msg-param-gift-month-being-redeemed", "0"));
-        this.cumulativeMonths = Integer.parseInt(event.getTags().getOrDefault("msg-param-cumulative-months", "0"));
+        this.giftMonths = Integer.parseInt(event.getTagValue("msg-param-gift-months").orElse("0"));
+        this.redeemedMonth = Integer.parseInt(event.getTagValue("msg-param-gift-month-being-redeemed").orElse("0"));
+        this.cumulativeMonths = Integer.parseInt(event.getTagValue("msg-param-cumulative-months").orElse("0"));
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -62,7 +62,7 @@ public class IRCMessageEvent extends TwitchEvent {
     /**
      * Metadata related to the chat badges in the badges tag
      */
-    private Map<String, String> badgeInfo = new HashMap<>();
+    private Map<String, String> badgeInfo = null;
 
 	/**
 	 * Client
@@ -138,7 +138,18 @@ public class IRCMessageEvent extends TwitchEvent {
 
         // permissions and badges
         getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds));
-        getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
+    }
+
+    /**
+     * @return metadata related to the chat badges in the badges tag
+     */
+    public Map<String, String> getBadgeInfo() {
+        Map<String, String> info = badgeInfo;
+        if (info == null) {
+            this.badgeInfo = info = new HashMap<>();
+            getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
+        }
+        return info;
     }
 
 	/**
@@ -291,6 +302,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return the exact number of months the user has been a subscriber, or empty if they are not subscribed
      */
     public OptionalInt getSubscriberMonths() {
+        Map<String, String> badgeInfo = getBadgeInfo();
         final String monthsStr = badgeInfo.getOrDefault("subscriber", badgeInfo.get("founder"));
 
         if (monthsStr != null) {
@@ -356,7 +368,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return the title of the choice this user is predicting, in an optional wrapper
      */
     public Optional<String> getPredictedChoiceTitle() {
-        return Optional.ofNullable(badgeInfo.get("predictions")).map(EscapeUtils::unescapeTagValue);
+        return Optional.ofNullable(getBadgeInfo().get("predictions")).map(EscapeUtils::unescapeTagValue);
     }
 
 	/**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -18,6 +18,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +27,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -50,7 +53,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * <p>
      * Most applications should utilize {@link #getTagValue(String)} rather than accessing this map directly.
      */
-    private Map<String, String> tags = new HashMap<>();
+    private Map<String, CharSequence> escapedTags = Collections.emptyMap();
 
 	/**
 	 * Badges
@@ -123,9 +126,7 @@ public class IRCMessageEvent extends TwitchEvent {
 		this.parseRawMessage();
 
         // set channel id
-        if (channelId == null) {
-            channelId = tags.get("room-id");
-        }
+        channelId = getRawTagString("room-id");
 
         // provide channel id or name from cache if the event was missing one
         if (!channelName.isPresent() && channelId != null) {
@@ -167,7 +168,7 @@ public class IRCMessageEvent extends TwitchEvent {
 		Matcher matcher = MESSAGE_PATTERN.matcher(rawMessage);
 		if (matcher.matches()) {
 			// Parse Tags
-			tags = parseTags(matcher.group("tags"));
+            escapedTags = parseTags(matcher.group("tags"));
 			clientName = parseClientName(matcher.group("clientName"));
 			commandType = matcher.group("command");
 			channelName = Optional.ofNullable(matcher.group("channel"));
@@ -180,7 +181,7 @@ public class IRCMessageEvent extends TwitchEvent {
 		Matcher matcherPM = WHISPER_PATTERN.matcher(rawMessage);
 		if (matcherPM.matches()) {
 			// Parse Tags
-			tags = parseTags(matcherPM.group("tags"));
+            escapedTags = parseTags(matcherPM.group("tags"));
 			clientName = parseClientName(matcherPM.group("clientName"));
 			commandType = matcherPM.group("command");
 			channelName = Optional.ofNullable(matcherPM.group("channel"));
@@ -196,8 +197,8 @@ public class IRCMessageEvent extends TwitchEvent {
 	 * @return A key-value map of the tags.
 	 */
     @ApiStatus.Internal
-	public Map<String, String> parseTags(String raw) {
-		Map<String, String> map = new HashMap<>();
+	public Map<String, CharSequence> parseTags(String raw) {
+		Map<String, CharSequence> map = new HashMap<>();
 		if(StringUtils.isBlank(raw)) return map;
 
 		for (String tag: raw.split(";")) {
@@ -235,7 +236,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return Long userId
 	 */
 	public String getUserId() {
-		return tags.get("user-id");
+		return getRawTagString("user-id");
 	}
 
     /**
@@ -245,7 +246,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @apiNote This getter returns the login name when available
      */
 	public String getUserName() {
-        String login = tags.get("login");
+        String login = getRawTagString("login");
 		if (login != null) {
 			return login;
 		}
@@ -275,7 +276,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return Long targetUserId
      */
     public String getTargetUserId() {
-        return tags.get("target-user-id");
+        return getRawTagString("target-user-id");
     }
 
     /**
@@ -375,7 +376,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return String tagValue
 	 */
 	public Optional<String> getTagValue(String tagName) {
-	    return Optional.ofNullable(tags.get(tagName))
+	    return Optional.ofNullable(getRawTag(tagName))
             .filter(StringUtils::isNotBlank)
             .map(EscapeUtils::unescapeTagValue);
 	}
@@ -412,13 +413,32 @@ public class IRCMessageEvent extends TwitchEvent {
 		return new EventChannel(getChannelId(), getChannelName().get());
 	}
 
+    @Nullable
+    @ApiStatus.Internal
+    public CharSequence getRawTag(@NotNull String name) {
+        return escapedTags.get(name);
+    }
+
+    @Nullable
+    @ApiStatus.Internal
+    public String getRawTagString(@NotNull String name) {
+        return Objects.toString(getRawTag(name), null);
+    }
+
+    @Deprecated
+    public Map<String, String> getTags() {
+        final Map<String, String> t = new HashMap<>(escapedTags.size() * 4 / 3 + 1);
+        escapedTags.forEach((k, v) -> t.put(k, Objects.toString(v, null)));
+        return Collections.unmodifiableMap(t);
+    }
+
     /**
      * @return IRCv3 tags
-     * @deprecated in favor of {@link #getTags()}
+     * @deprecated in favor of {@link #getEscapedTags()}
      */
     @Deprecated
     public Map<String, Object> getRawTags() {
-        return Collections.unmodifiableMap(tags);
+        return Collections.unmodifiableMap(escapedTags);
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -413,18 +413,34 @@ public class IRCMessageEvent extends TwitchEvent {
 		return new EventChannel(getChannelId(), getChannelName().get());
 	}
 
+    /**
+     * @param name the tag key
+     * @return the (not escaped) tag value associated with the specified key, in {@link CharSequence} form
+     * @implNote This method is faster than {@link #getRawTagString(String)}
+     * @apiNote This method is primarily intended for internal use by the library; please open an issue if a common tag is missing.
+     */
     @Nullable
     @ApiStatus.Internal
     public CharSequence getRawTag(@NotNull String name) {
         return escapedTags.get(name);
     }
 
+    /**
+     * @param name the tag key
+     * @return the (not escaped) tag value associated with the specified key, in {@link String} form
+     * @implNote This method is slower than {@link #getRawTag(String)}
+     * @apiNote This method is primarily intended for internal use by the library; please open an issue if a common tag is missing.
+     */
     @Nullable
     @ApiStatus.Internal
     public String getRawTagString(@NotNull String name) {
         return Objects.toString(getRawTag(name), null);
     }
 
+    /**
+     * @return raw (i.e., not unescaped) IRCv3 tags
+     * @deprecated in favor of {@link #getTagValue(String)} or {@link #getEscapedTags()}
+     */
     @Deprecated
     public Map<String, String> getTags() {
         final Map<String, String> t = new HashMap<>(escapedTags.size() * 4 / 3 + 1);

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -44,15 +45,12 @@ public class IRCMessageEvent extends TwitchEvent {
     @Unofficial
     public static final String NONCE_TAG_NAME = "client-nonce";
 
-	/**
-	 * Tags
-	 */
-	private Map<String, String> tags = new HashMap<>();
-
     /**
-     * Raw Tags
+     * Tags
+     * <p>
+     * Most applications should utilize {@link #getTagValue(String)} rather than accessing this map directly.
      */
-    private Map<String, Object> rawTags = new HashMap<>();
+    private Map<String, String> tags = new HashMap<>();
 
 	/**
 	 * Badges
@@ -170,7 +168,6 @@ public class IRCMessageEvent extends TwitchEvent {
 		if (matcher.matches()) {
 			// Parse Tags
 			tags = parseTags(matcher.group("tags"));
-            rawTags = parseTags(matcher.group("tags"));
 			clientName = parseClientName(matcher.group("clientName"));
 			commandType = matcher.group("command");
 			channelName = Optional.ofNullable(matcher.group("channel"));
@@ -184,7 +181,6 @@ public class IRCMessageEvent extends TwitchEvent {
 		if (matcherPM.matches()) {
 			// Parse Tags
 			tags = parseTags(matcherPM.group("tags"));
-			rawTags = parseTags(matcherPM.group("tags"));
 			clientName = parseClientName(matcherPM.group("clientName"));
 			commandType = matcherPM.group("command");
 			channelName = Optional.ofNullable(matcherPM.group("channel"));
@@ -199,12 +195,13 @@ public class IRCMessageEvent extends TwitchEvent {
 	 * @param raw The raw list of tags.
 	 * @return A key-value map of the tags.
 	 */
-	public Map parseTags(String raw) {
+    @ApiStatus.Internal
+	public Map<String, String> parseTags(String raw) {
 		Map<String, String> map = new HashMap<>();
 		if(StringUtils.isBlank(raw)) return map;
 
 		for (String tag: raw.split(";")) {
-			String[] val = tag.split("=");
+			String[] val = tag.split("=", 2);
 			final String key = val[0];
 			String value = (val.length > 1) ? val[1] : null;
 			map.put(key, value);
@@ -414,5 +411,14 @@ public class IRCMessageEvent extends TwitchEvent {
 	public EventChannel getChannel() {
 		return new EventChannel(getChannelId(), getChannelName().get());
 	}
+
+    /**
+     * @return IRCv3 tags
+     * @deprecated in favor of {@link #getTags()}
+     */
+    @Deprecated
+    public Map<String, Object> getRawTags() {
+        return Collections.unmodifiableMap(tags);
+    }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/util/ChatCrowdChant.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/ChatCrowdChant.java
@@ -7,6 +7,7 @@ import com.github.twitch4j.common.util.CryptoUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.LinkedHashMap;
@@ -79,7 +80,7 @@ public class ChatCrowdChant {
         String message = event.getMessage().orElse(null);
         if (message == null) return null;
 
-        if ("crowd-chant".equals(event.getTags().get("msg-id"))) {
+        if (StringUtils.equals("crowd-chant", event.getRawTag("msg-id"))) {
             return event.getMessageId()
                 .map(id -> new ChatCrowdChant(id, message, true, channelName))
                 .orElse(null);

--- a/chat/src/test/java/com/github/twitch4j/chat/TwitchChatTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/TwitchChatTest.java
@@ -94,7 +94,7 @@ public class TwitchChatTest {
         Assertions.assertTrue(event.getPermissions().contains(CommandPermission.EVERYONE));
         Assertions.assertEquals("twitch4j", event.getChannel().getName());
         Assertions.assertEquals("twitch4j", event.getUser().getName());
-        Assertions.assertEquals("Twitch4J", event.getMessageEvent().getTags().get("display-name"));
+        Assertions.assertEquals("Twitch4J", event.getMessageEvent().getRawTagString("display-name"));
         Assertions.assertEquals("hello world", event.getMessage());
     }
 

--- a/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
@@ -74,7 +74,7 @@ public class IRCMessageEventTest {
 
         assertEquals("NOTICE", e.getCommandType());
         assertEquals("bar", e.getChannelName().orElse(null));
-        assertEquals("delete_message_success", e.getTags().get("msg-id"));
+        assertEquals("delete_message_success", e.getRawTagString("msg-id"));
         assertEquals("The message from foo is now deleted.", e.getMessage().orElse(null));
     }
 
@@ -92,8 +92,8 @@ public class IRCMessageEventTest {
         assertEquals("ROOMSTATE", e.getCommandType());
         assertEquals("bar", e.getChannelName().orElse(null));
         assertEquals("12345678", e.getChannelId());
-        assertEquals("0", e.getTags().get("emote-only"));
-        assertEquals("-1", e.getTags().get("followers-only"));
+        assertEquals("0", e.getRawTagString("emote-only"));
+        assertEquals("-1", e.getRawTagString("followers-only"));
     }
 
     @Test

--- a/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
@@ -2,8 +2,10 @@ package com.github.twitch4j.common.util;
 
 import lombok.NonNull;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static com.github.twitch4j.common.util.EscapeUtils.unescapeTagValue;
 
@@ -47,16 +49,17 @@ public class ChatReply {
      * @param tags the message tags associated with a reply.
      * @return the parsed {@link ChatReply}, or null if unsuccessful
      */
-    public static ChatReply parse(final Map<String, String> tags) {
-        final String msgId;
-        if (tags == null || (msgId = tags.get(REPLY_MSG_ID_TAG_NAME)) == null || msgId.isEmpty())
+    @ApiStatus.Internal
+    public static ChatReply parse(final Map<String, CharSequence> tags) {
+        final CharSequence msgId;
+        if (tags == null || (msgId = tags.get(REPLY_MSG_ID_TAG_NAME)) == null || msgId.length() == 0)
             return null;
 
         return new ChatReply(
-            msgId,
+            msgId.toString(),
             unescapeTagValue(tags.get("reply-parent-msg-body")),
-            tags.get("reply-parent-user-id"),
-            tags.get("reply-parent-user-login"),
+            Objects.toString(tags.get("reply-parent-user-id"), null),
+            Objects.toString(tags.get("reply-parent-user-login"), null),
             unescapeTagValue(tags.get("reply-parent-display-name"))
         );
     }

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -158,8 +158,8 @@ public class TwitchUtils {
         // Fix Whitespaces
         raw = EscapeUtils.unescapeTagValue(raw);
 
-        for (String tag : StringUtils.split(raw, ',')) {
-            String[] val = StringUtils.split(tag, "/", 2);
+        for (String tag : raw.split(",")) {
+            String[] val = tag.split("/", 2);
             final String key = val[0];
             String value = (val.length > 1) ? val[1] : null;
             map.put(key, value);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Convert `IRCMessageEvent#tags` from `Map<String, String>` to `Map<String, CharSequence>`

### Additional Information
Depends upon #791

Preemptive refactor that enables a faster implementation of `parseRawMessage` in another PR; this PR does not contain any `String` -> `CharBuffer` micro-optimizations

#### Before
```
Benchmark                               Mode  Cnt   Score   Error  Units
MessageParserBenchmark.parse1kMessages  avgt    4  14.704 ± 1.010  us/op
MessageParserBenchmark.parse1kTags      avgt    4   3.241 ± 0.155  us/op
```

#### After
```
Benchmark                               Mode  Cnt   Score   Error  Units
MessageParserBenchmark.parse1kMessages  avgt    4  14.745 ± 0.442  us/op
MessageParserBenchmark.parse1kTags      avgt    4   3.254 ± 0.050  us/op
```
