### PR TITLE
chore: update badge parsing test

### DIFF
--- a/common/src/test/java/com/github/twitch4j/common/util/TwitchUtilsTest.java
+++ b/common/src/test/java/com/github/twitch4j/common/util/TwitchUtilsTest.java
@@ -27,7 +27,8 @@ class TwitchUtilsTest {
         assertEquals(singletonMap("a b", "c d"), parseBadges("a\\sb/c\\sd"));
 
         assertEquals(mapOf("subscriber", "18", "no_audio", "1"), parseBadges("subscriber/18,no_audio/1"));
-        assertEquals(mapOf("subscriber", "19", "no_audio", null), parseBadges("subscriber/19,no_audio/"));
+        assertEquals(mapOf("subscriber", "19", "no_audio", null), parseBadges("subscriber/19,no_audio"));
+        assertEquals(mapOf("subscriber", "19", "no_audio", ""), parseBadges("subscriber/19,no_audio/"));
         assertEquals(mapOf("follower", "20", "no_video", null), parseBadges("follower/20,no_video"));
     }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Failure from TwitchUtilsTest L30

### Changes Proposed
* Badge without `/` is treated as mapping to null. Badge with `/` but empty string following is treated as mapping to empty string

### Additional Information
Caused by https://github.com/twitch4j/twitch4j/pull/792/files#diff-a9e9acd3d58099d349009372f2077b33189d03474a18543dbca513925f4b1541L162 (quirky implementation differences of `String#split` and `StringUtils#split`)
