### PR TITLE
perf(chat): remove regex from message parsing

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -18,6 +18,7 @@ import com.github.twitch4j.chat.events.channel.ChannelNoticeEvent;
 import com.github.twitch4j.chat.events.channel.ChannelStateEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.chat.events.channel.UserStateEvent;
+import com.github.twitch4j.chat.util.MessageParser;
 import com.github.twitch4j.client.websocket.WebsocketConnection;
 import com.github.twitch4j.client.websocket.domain.WebsocketConnectionState;
 import com.github.twitch4j.common.config.ProxyConfig;
@@ -566,12 +567,12 @@ public class TwitchChat implements ITwitchChat {
                     // - Parse IRC Message
                     else {
                         try {
-                            IRCMessageEvent event = new IRCMessageEvent(message, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+                            IRCMessageEvent event = MessageParser.parse(message, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
 
-                            if (event.isValid()) {
+                            if (event != null) {
                                 eventManager.publish(event);
                             } else {
-                                log.trace("Can't parse {}", event.getRawMessage());
+                                log.trace("Can't parse {}", message);
                             }
                         } catch (Exception ex) {
                             log.error(ex.getMessage(), ex);

--- a/chat/src/main/java/com/github/twitch4j/chat/events/TwitchEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/TwitchEvent.java
@@ -5,6 +5,8 @@ import com.github.twitch4j.chat.TwitchChat;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.time.Instant;
+
 @Data
 @EqualsAndHashCode(callSuper=false)
 public abstract class TwitchEvent extends Event {
@@ -15,6 +17,16 @@ public abstract class TwitchEvent extends Event {
 	public TwitchEvent() {
 		super();
 	}
+
+    /**
+     * Constructor
+     *
+     * @param eventId Unique event id
+     * @param firedAt Timestamp of the event firing
+     */
+    public TwitchEvent(String eventId, Instant firedAt) {
+        super(eventId, firedAt);
+    }
 
 	/**
      * Get TwitchChat

--- a/chat/src/main/java/com/github/twitch4j/chat/events/TwitchEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/TwitchEvent.java
@@ -8,15 +8,15 @@ import lombok.EqualsAndHashCode;
 import java.time.Instant;
 
 @Data
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 public abstract class TwitchEvent extends Event {
 
-	/**
-	 * Constructor
-	 */
-	public TwitchEvent() {
-		super();
-	}
+    /**
+     * Constructor
+     */
+    public TwitchEvent() {
+        super();
+    }
 
     /**
      * Constructor
@@ -28,12 +28,12 @@ public abstract class TwitchEvent extends Event {
         super(eventId, firedAt);
     }
 
-	/**
+    /**
      * Get TwitchChat
      *
      * @return TwitchChat Instance
-	 */
-	public TwitchChat getTwitchChat() {
-	    return getServiceMediator().getService(TwitchChat.class, "twitch4j-chat");
+     */
+    public TwitchChat getTwitchChat() {
+        return getServiceMediator().getService(TwitchChat.class, "twitch4j-chat");
     }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -55,52 +55,52 @@ public class IRCMessageEvent extends TwitchEvent {
      */
     private final Map<String, CharSequence> escapedTags;
 
-	/**
-	 * Badges
-	 */
-	private Map<String, String> badges = null;
+    /**
+     * Badges
+     */
+    private Map<String, String> badges = null;
 
     /**
      * Metadata related to the chat badges in the badges tag
      */
     private Map<String, String> badgeInfo = null;
 
-	/**
-	 * Client
-	 */
-	private final CharSequence clientName;
+    /**
+     * Client
+     */
+    private final CharSequence clientName;
 
-	/**
-	 * Message Type
-	 */
-	private final String commandType;
+    /**
+     * Message Type
+     */
+    private final String commandType;
 
     /**
      * Channel Id
      */
     private String channelId;
 
-	/**
-	 * Channel Name
-	 */
+    /**
+     * Channel Name
+     */
     @Nullable
-	private String channelName;
+    private String channelName;
 
-	/**
-	 * Message
-	 */
+    /**
+     * Message
+     */
     @Nullable
-	private final String message;
+    private final String message;
 
-	/**
-	 * IRC Command Payload
-	 */
-	private final CharSequence payload;
+    /**
+     * IRC Command Payload
+     */
+    private final CharSequence payload;
 
-	/**
-	 * Client Permissions
-	 */
-	private Set<CommandPermission> clientPermissions = null;
+    /**
+     * Client Permissions
+     */
+    private Set<CommandPermission> clientPermissions = null;
 
     /**
      * AutoMod Message Flag Indicators, relevant for PRIVMSG and USERNOTICE
@@ -109,10 +109,10 @@ public class IRCMessageEvent extends TwitchEvent {
     @Getter(lazy = true)
     private final List<AutoModFlag> flags = FlagParser.parseFlags(this);
 
-	/**
-	 * RAW Message
-	 */
-	private final String rawMessage;
+    /**
+     * RAW Message
+     */
+    private final String rawMessage;
 
     @Nullable
     @Getter(AccessLevel.NONE)
@@ -146,15 +146,15 @@ public class IRCMessageEvent extends TwitchEvent {
     /**
      * Event Constructor
      *
-     * @param rawMessage  The raw message.
+     * @param rawMessage             The raw message.
      * @param channelIdToChannelName Mapping used to lookup a missing channel name in the event
      * @param channelNameToChannelId Mapping used to lookup a missing channel id in the event
-     * @param botOwnerIds The bot owner ids.
+     * @param botOwnerIds            The bot owner ids.
      * @deprecated Use {@link MessageParser#parse(String, Map, Map, Collection)} to create {@link IRCMessageEvent} instances
      */
     @Deprecated
-	public IRCMessageEvent(String rawMessage, Map<String, String> channelIdToChannelName, Map<String, String> channelNameToChannelId, Collection<String> botOwnerIds) {
-		this(Optional.ofNullable(MessageParser.parse(rawMessage, channelIdToChannelName, channelNameToChannelId, botOwnerIds)).orElse(failure(rawMessage)), channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+    public IRCMessageEvent(String rawMessage, Map<String, String> channelIdToChannelName, Map<String, String> channelNameToChannelId, Collection<String> botOwnerIds) {
+        this(Optional.ofNullable(MessageParser.parse(rawMessage, channelIdToChannelName, channelNameToChannelId, botOwnerIds)).orElse(failure(rawMessage)), channelIdToChannelName, channelNameToChannelId, botOwnerIds);
     }
 
     private IRCMessageEvent(@NotNull IRCMessageEvent copy, @NotNull Map<String, String> channelIdToChannelName, @NotNull Map<String, String> channelNameToChannelId, @Nullable Collection<String> botOwnerIds) {
@@ -198,69 +198,70 @@ public class IRCMessageEvent extends TwitchEvent {
         return clientPermissions;
     }
 
-	/**
-	 * Checks if the Event was parsed correctly.
-	 * @return Is the Event valid?
+    /**
+     * Checks if the Event was parsed correctly.
+     *
+     * @return Is the Event valid?
      * @deprecated {@link MessageParser#parse(String)} yields null for invalid messages
-	 */
+     */
     @Deprecated
-	public Boolean isValid() {
-		return !getCommandType().equals("UNKNOWN");
-	}
+    public Boolean isValid() {
+        return !getCommandType().equals("UNKNOWN");
+    }
 
-	/**
-	 * Parse Tags from raw list
-	 *
-	 * @param raw The raw list of tags.
-	 * @return A key-value map of the tags.
+    /**
+     * Parse Tags from raw list
+     *
+     * @param raw The raw list of tags.
+     * @return A key-value map of the tags.
      * @deprecated This method is no longer used by twitch4j
-	 */
+     */
     @Deprecated
     @ApiStatus.ScheduledForRemoval
-	public static Map<String, CharSequence> parseTags(String raw) {
-		Map<String, CharSequence> map = new HashMap<>();
-		if(StringUtils.isBlank(raw)) return map;
+    public static Map<String, CharSequence> parseTags(String raw) {
+        Map<String, CharSequence> map = new HashMap<>();
+        if (StringUtils.isBlank(raw)) return map;
 
-		for (String tag: raw.split(";")) {
-			String[] val = tag.split("=", 2);
-			final String key = val[0];
-			String value = (val.length > 1) ? val[1] : null;
-			map.put(key, value);
-		}
+        for (String tag : raw.split(";")) {
+            String[] val = tag.split("=", 2);
+            final String key = val[0];
+            String value = (val.length > 1) ? val[1] : null;
+            map.put(key, value);
+        }
 
-		return Collections.unmodifiableMap(map); // formatting to Read-Only Map
-	}
+        return Collections.unmodifiableMap(map); // formatting to Read-Only Map
+    }
 
-	/**
-	 * Gets the ClientName from the IRC User Identifier (:user!user@user.tmi.twitch.tv)
-	 *
-	 * @param raw Raw ClientName
-	 * @return Client name, or empty.
+    /**
+     * Gets the ClientName from the IRC User Identifier (:user!user@user.tmi.twitch.tv)
+     *
+     * @param raw Raw ClientName
+     * @return Client name, or empty.
      * @deprecated This method is no longer used by twitch4j
-	 */
+     */
     @Deprecated
     @ApiStatus.ScheduledForRemoval
-	public static Optional<String> parseClientName(String raw) {
-		if(raw.equals(":tmi.twitch.tv") || raw.equals(":jtv")) {
-			return Optional.empty();
-		}
+    public static Optional<String> parseClientName(String raw) {
+        if (raw.equals(":tmi.twitch.tv") || raw.equals(":jtv")) {
+            return Optional.empty();
+        }
 
-		Matcher matcher = CLIENT_PATTERN.matcher(raw);
-		if(matcher.matches()) {
-			return Optional.ofNullable(matcher.group(1));
-		}
+        Matcher matcher = CLIENT_PATTERN.matcher(raw);
+        if (matcher.matches()) {
+            return Optional.ofNullable(matcher.group(1));
+        }
 
-		return Optional.ofNullable(raw);
-	}
+        return Optional.ofNullable(raw);
+    }
 
-	/**
-	 * Gets the User Id (from Tags)
+    /**
+     * Gets the User Id (from Tags)
      *
      * @return Long userId
-	 */
-	public String getUserId() {
-		return getRawTagString("user-id");
-	}
+     */
+    public String getUserId() {
+        return getRawTagString("user-id");
+    }
 
     /**
      * Gets the User Name (from Tags)
@@ -268,16 +269,16 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return String userName
      * @apiNote This getter returns the login name when available
      */
-	public String getUserName() {
+    public String getUserName() {
         String login = getRawTagString("login");
-		if (login != null) {
-			return login;
-		}
+        if (login != null) {
+            return login;
+        }
 
-		return getClientName()
+        return getClientName()
             .filter(StringUtils::isNotBlank)
             .orElseGet(() -> getUserDisplayName().orElse(null));
-	}
+    }
 
     /**
      * @return the display name of the user who sent this message, if applicable
@@ -392,30 +393,30 @@ public class IRCMessageEvent extends TwitchEvent {
         return Optional.ofNullable(getBadgeInfo().get("predictions")).map(EscapeUtils::unescapeTagValue);
     }
 
-	/**
-	 * Gets a optional tag from the irc message
+    /**
+     * Gets a optional tag from the irc message
      *
      * @param tagName The tag of the irc message
      * @return String tagValue
-	 */
-	public Optional<String> getTagValue(String tagName) {
-	    return Optional.ofNullable(getRawTag(tagName))
+     */
+    public Optional<String> getTagValue(String tagName) {
+        return Optional.ofNullable(getRawTag(tagName))
             .filter(StringUtils::isNotBlank)
             .map(EscapeUtils::unescapeTagValue);
-	}
+    }
 
-	/**
-	 * Get User
+    /**
+     * Get User
      *
      * @return ChatUser
-	 */
-	public EventUser getUser() {
-	    if (getUserId() != null || getUserName() != null) {
+     */
+    public EventUser getUser() {
+        if (getUserId() != null || getUserName() != null) {
             return new EventUser(getUserId(), getUserName());
         }
 
-		return null;
-	}
+        return null;
+    }
 
     /**
      * Get Target User
@@ -426,14 +427,14 @@ public class IRCMessageEvent extends TwitchEvent {
         return new EventUser(getTargetUserId(), getCommandType().equalsIgnoreCase("CLEARCHAT") ? getMessage().get() : null);
     }
 
-	/**
-	 * Get ChatChannel
+    /**
+     * Get ChatChannel
      *
      * @return ChatChannel
-	 */
-	public EventChannel getChannel() {
-		return new EventChannel(getChannelId(), channelName);
-	}
+     */
+    public EventChannel getChannel() {
+        return new EventChannel(getChannelId(), channelName);
+    }
 
     /**
      * @return the channel name associated with this event, if applicable

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -217,7 +217,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @deprecated This method is no longer used by twitch4j
      */
     @Deprecated
-    @ApiStatus.ScheduledForRemoval
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public static Map<String, CharSequence> parseTags(String raw) {
         Map<String, CharSequence> map = new HashMap<>();
         if (StringUtils.isBlank(raw)) return map;
@@ -240,7 +240,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @deprecated This method is no longer used by twitch4j
      */
     @Deprecated
-    @ApiStatus.ScheduledForRemoval
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public static Optional<String> parseClientName(String raw) {
         if (raw.equals(":tmi.twitch.tv") || raw.equals(":jtv")) {
             return Optional.empty();

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -3,10 +3,12 @@ package com.github.twitch4j.chat.events.channel;
 import com.github.twitch4j.chat.events.TwitchEvent;
 import com.github.twitch4j.chat.flag.AutoModFlag;
 import com.github.twitch4j.chat.flag.FlagParser;
+import com.github.twitch4j.chat.util.MessageParser;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
+import com.github.twitch4j.common.util.CryptoUtils;
 import com.github.twitch4j.common.util.EscapeUtils;
 import com.github.twitch4j.common.util.TwitchUtils;
 import com.google.code.regexp.Matcher;
@@ -21,9 +23,9 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,8 +43,6 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = false)
 public class IRCMessageEvent extends TwitchEvent {
 
-    private static final Pattern MESSAGE_PATTERN = Pattern.compile("^(?:@(?<tags>\\S+?)\\s)?(?<clientName>\\S+?)\\s(?<command>[A-Z0-9]+)\\s?(?:(?<login>\\S+)\\s=\\s)?(?:#(?<channel>\\S*?)\\s?)?(?<payload>[:\\-+](?<message>.+))?$");
-    private static final Pattern WHISPER_PATTERN = Pattern.compile("^(?:@(?<tags>\\S+?)\\s)?:(?<clientName>\\S+?)!.+?\\s(?<command>[A-Z0-9]+)\\s(?:(?<channel>\\S*?)\\s?)??(?<payload>[:\\-+](?<message>.+))$");
     private static final Pattern CLIENT_PATTERN = Pattern.compile("^:(.*?)!(.*?)@(.*?).tmi.twitch.tv$");
 
     @Unofficial
@@ -53,12 +53,12 @@ public class IRCMessageEvent extends TwitchEvent {
      * <p>
      * Most applications should utilize {@link #getTagValue(String)} rather than accessing this map directly.
      */
-    private Map<String, CharSequence> escapedTags = Collections.emptyMap();
+    private final Map<String, CharSequence> escapedTags;
 
 	/**
 	 * Badges
 	 */
-	private Map<String, String> badges = new HashMap<>();
+	private Map<String, String> badges = null;
 
     /**
      * Metadata related to the chat badges in the badges tag
@@ -68,12 +68,12 @@ public class IRCMessageEvent extends TwitchEvent {
 	/**
 	 * Client
 	 */
-	private Optional<String> clientName = Optional.empty();
+	private final CharSequence clientName;
 
 	/**
 	 * Message Type
 	 */
-	private String commandType = "UNKNOWN";
+	private final String commandType;
 
     /**
      * Channel Id
@@ -83,22 +83,24 @@ public class IRCMessageEvent extends TwitchEvent {
 	/**
 	 * Channel Name
 	 */
-	private Optional<String> channelName = Optional.empty();
+    @Nullable
+	private String channelName;
 
 	/**
 	 * Message
 	 */
-	private Optional<String> message = Optional.empty();
+    @Nullable
+	private final String message;
 
 	/**
 	 * IRC Command Payload
 	 */
-	private Optional<String> payload = Optional.empty();
+	private final CharSequence payload;
 
 	/**
 	 * Client Permissions
 	 */
-	private final Set<CommandPermission> clientPermissions = EnumSet.noneOf(CommandPermission.class);
+	private Set<CommandPermission> clientPermissions = null;
 
     /**
      * AutoMod Message Flag Indicators, relevant for PRIVMSG and USERNOTICE
@@ -112,6 +114,34 @@ public class IRCMessageEvent extends TwitchEvent {
 	 */
 	private final String rawMessage;
 
+    @Nullable
+    private final Collection<String> botOwnerIds;
+
+    @ApiStatus.Internal
+    public IRCMessageEvent(@NotNull String rawMessage, @NotNull Map<String, CharSequence> escapedTags, CharSequence clientName, @NotNull String commandType, @Nullable String channelName, @Nullable CharSequence payload, @Nullable String message,
+                           @NotNull Map<String, String> channelIdToChannelName, @NotNull Map<String, String> channelNameToChannelId, @Nullable Collection<String> botOwnerIds) {
+        super(getEventId(escapedTags), getEventTime(escapedTags));
+        this.rawMessage = rawMessage;
+        this.escapedTags = escapedTags;
+        this.clientName = clientName;
+        this.commandType = commandType;
+        this.channelName = channelName;
+        this.payload = payload;
+        this.message = message;
+        this.botOwnerIds = botOwnerIds;
+
+        // set channel id and name from tags or cache
+        if (channelName == null) {
+            this.channelId = getRawTagString("room-id");
+            this.channelName = channelIdToChannelName.get(channelId);
+        } else {
+            this.channelId = channelNameToChannelId.get(channelName);
+            if (channelId == null) {
+                this.channelId = getRawTagString("room-id");
+            }
+        }
+    }
+
     /**
      * Event Constructor
      *
@@ -119,24 +149,19 @@ public class IRCMessageEvent extends TwitchEvent {
      * @param channelIdToChannelName Mapping used to lookup a missing channel name in the event
      * @param channelNameToChannelId Mapping used to lookup a missing channel id in the event
      * @param botOwnerIds The bot owner ids.
+     * @deprecated Use {@link MessageParser#parse(String, Map, Map, Collection)} to create {@link IRCMessageEvent} instances
      */
+    @Deprecated
 	public IRCMessageEvent(String rawMessage, Map<String, String> channelIdToChannelName, Map<String, String> channelNameToChannelId, Collection<String> botOwnerIds) {
-		this.rawMessage = rawMessage;
+		this(Optional.ofNullable(MessageParser.parse(rawMessage, channelIdToChannelName, channelNameToChannelId, botOwnerIds)).orElse(failure(rawMessage)), channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+    }
 
-		this.parseRawMessage();
+    private IRCMessageEvent(@NotNull IRCMessageEvent copy, @NotNull Map<String, String> channelIdToChannelName, @NotNull Map<String, String> channelNameToChannelId, @Nullable Collection<String> botOwnerIds) {
+        this(copy.rawMessage, copy.escapedTags, copy.clientName, copy.commandType, copy.channelName, copy.payload, copy.message, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+    }
 
-        // set channel id
-        channelId = getRawTagString("room-id");
-
-        // provide channel id or name from cache if the event was missing one
-        if (!channelName.isPresent() && channelId != null) {
-            channelName = Optional.ofNullable(channelIdToChannelName.get(channelId));
-        } else if (channelName.isPresent() && channelId == null) {
-            channelId = channelNameToChannelId.get(channelName.get());
-        }
-
-        // permissions and badges
-        getClientPermissions().addAll(TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds));
+    private static IRCMessageEvent failure(String raw) {
+        return new IRCMessageEvent(raw, Collections.emptyMap(), null, "UNKNOWN", null, null, null, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet());
     }
 
     /**
@@ -144,50 +169,42 @@ public class IRCMessageEvent extends TwitchEvent {
      */
     public Map<String, String> getBadgeInfo() {
         Map<String, String> info = badgeInfo;
-        if (info == null) {
-            this.badgeInfo = info = new HashMap<>();
-            getTagValue("badge-info").map(TwitchUtils::parseBadges).ifPresent(map -> badgeInfo.putAll(map));
+        if (info != null) return info;
+        return this.badgeInfo = getTagValue("badge-info")
+            .map(TwitchUtils::parseBadges)
+            .orElse(Collections.emptyMap());
+    }
+
+    /**
+     * @return the visible chat badges parsed from tags
+     */
+    public Map<String, String> getBadges() {
+        Map<String, String> badges = this.badges;
+        if (badges == null) {
+            this.badges = badges = new HashMap<>();
+            this.clientPermissions = TwitchUtils.getPermissionsFromTags(getRawTags(), badges, botOwnerIds != null ? getUserId() : null, botOwnerIds);
         }
-        return info;
+        return badges;
+    }
+
+    /**
+     * @return the permissions of the client that sent this message, based on visible badges
+     */
+    public Set<CommandPermission> getClientPermissions() {
+        if (clientPermissions == null) {
+            getBadges(); // initializes clientPermissions
+        }
+        return clientPermissions;
     }
 
 	/**
 	 * Checks if the Event was parsed correctly.
 	 * @return Is the Event valid?
+     * @deprecated {@link MessageParser#parse(String)} yields null for invalid messages
 	 */
+    @Deprecated
 	public Boolean isValid() {
 		return !getCommandType().equals("UNKNOWN");
-	}
-
-	/**
-	 * Parse RAW Message
-	 */
-	@SuppressWarnings("unchecked")
-	private void parseRawMessage() {
-		// Parse Message
-		Matcher matcher = MESSAGE_PATTERN.matcher(rawMessage);
-		if (matcher.matches()) {
-			// Parse Tags
-            escapedTags = parseTags(matcher.group("tags"));
-			clientName = parseClientName(matcher.group("clientName"));
-			commandType = matcher.group("command");
-			channelName = Optional.ofNullable(matcher.group("channel"));
-			message = Optional.ofNullable(matcher.group("message"));
-			payload = Optional.ofNullable(matcher.group("payload"));
-			return;
-		}
-
-		// Parse Message - Whisper
-		Matcher matcherPM = WHISPER_PATTERN.matcher(rawMessage);
-		if (matcherPM.matches()) {
-			// Parse Tags
-            escapedTags = parseTags(matcherPM.group("tags"));
-			clientName = parseClientName(matcherPM.group("clientName"));
-			commandType = matcherPM.group("command");
-			channelName = Optional.ofNullable(matcherPM.group("channel"));
-			message = Optional.ofNullable(matcherPM.group("message"));
-			payload = Optional.ofNullable(matcherPM.group("payload"));
-		}
 	}
 
 	/**
@@ -195,8 +212,10 @@ public class IRCMessageEvent extends TwitchEvent {
 	 *
 	 * @param raw The raw list of tags.
 	 * @return A key-value map of the tags.
+     * @deprecated This method is no longer used by twitch4j
 	 */
-    @ApiStatus.Internal
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval
 	public static Map<String, CharSequence> parseTags(String raw) {
 		Map<String, CharSequence> map = new HashMap<>();
 		if(StringUtils.isBlank(raw)) return map;
@@ -216,8 +235,11 @@ public class IRCMessageEvent extends TwitchEvent {
 	 *
 	 * @param raw Raw ClientName
 	 * @return Client name, or empty.
+     * @deprecated This method is no longer used by twitch4j
 	 */
-	public Optional<String> parseClientName(String raw) {
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval
+	public static Optional<String> parseClientName(String raw) {
 		if(raw.equals(":tmi.twitch.tv") || raw.equals(":jtv")) {
 			return Optional.empty();
 		}
@@ -317,7 +339,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return the tier at which the user is subscribed, or empty if they are not subscribed or have the founders badge equipped
      */
     public OptionalInt getSubscriptionTier() {
-        final String subscriber = badges.get("subscriber");
+        final String subscriber = getBadges().get("subscriber");
 
         if (subscriber != null) {
             try {
@@ -333,7 +355,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return the tier of the bits badge of the user, or empty if there is no bits badge present (which can also occur for bits leaders)
      */
     public OptionalInt getCheererTier() {
-        final String bits = badges.get("bits");
+        final String bits = getBadges().get("bits");
 
         if (bits != null) {
             try {
@@ -349,7 +371,7 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return the index of the choice this user is predicting, in an optional wrapper
      */
     public OptionalInt getPredictedChoiceIndex() {
-        String predictions = badges.get("predictions");
+        String predictions = getBadges().get("predictions");
 
         if (predictions != null) {
             int delim = predictions.indexOf('-');
@@ -410,8 +432,39 @@ public class IRCMessageEvent extends TwitchEvent {
      * @return ChatChannel
 	 */
 	public EventChannel getChannel() {
-		return new EventChannel(getChannelId(), getChannelName().get());
+		return new EventChannel(getChannelId(), channelName);
 	}
+
+    /**
+     * @return the channel name associated with this event, if applicable
+     */
+    public Optional<String> getChannelName() {
+        return Optional.ofNullable(channelName);
+    }
+
+    /**
+     * @return IRC message payload, which includes a colon prefix, unlike {@link #getMessage()}
+     */
+    public Optional<String> getPayload() {
+        return Optional.ofNullable(payload).map(CharSequence::toString);
+    }
+
+    /**
+     * @return the message sent by a user to an IRC channel
+     */
+    public Optional<String> getMessage() {
+        return Optional.ofNullable(message);
+    }
+
+    /**
+     * @return the client name associated with the message, excluding the hostname
+     */
+    public Optional<String> getClientName() {
+        return Optional.ofNullable(clientName)
+            .filter(client -> !StringUtils.equals(client, "tmi.twitch.tv"))
+            .filter(client -> !StringUtils.equals(client, "jtv"))
+            .map(CharSequence::toString);
+    }
 
     /**
      * @param name the tag key
@@ -455,6 +508,16 @@ public class IRCMessageEvent extends TwitchEvent {
     @Deprecated
     public Map<String, Object> getRawTags() {
         return Collections.unmodifiableMap(escapedTags);
+    }
+
+    private static String getEventId(Map<String, CharSequence> tags) {
+        CharSequence id = tags.get("id");
+        return id != null ? id.toString() : CryptoUtils.generateNonce(32);
+    }
+
+    private static Instant getEventTime(Map<String, CharSequence> tags) {
+        CharSequence ts = tags.get("tmi-sent-ts");
+        return ts != null ? Instant.ofEpochMilli(Long.parseLong(ts.toString())) : Instant.now();
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -115,6 +115,7 @@ public class IRCMessageEvent extends TwitchEvent {
 	private final String rawMessage;
 
     @Nullable
+    @Getter(AccessLevel.NONE)
     private final Collection<String> botOwnerIds;
 
     @ApiStatus.Internal
@@ -424,7 +425,6 @@ public class IRCMessageEvent extends TwitchEvent {
     public EventUser getTargetUser() {
         return new EventUser(getTargetUserId(), getCommandType().equalsIgnoreCase("CLEARCHAT") ? getMessage().get() : null);
     }
-
 
 	/**
 	 * Get ChatChannel

--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -97,28 +97,32 @@ public class MessageParser {
     public int parseTags(String input, Map<String, CharSequence> output) {
         final int len = input.length();
         int i = 0;
+        int delim = -1;
         for (int j = i + 1; j < len; j++) {
             final char c = input.charAt(j);
-            final boolean delim = c == ';';
-            if (delim || c == ' ') {
-                final CharSequence tag = CharBuffer.wrap(input, i + 1, j);
-                parseTag(output, tag);
+            final boolean boundary = c == ';';
+            if (boundary || c == ' ') {
+                final int tagStart = i + 1;
+                final CharSequence tag = CharBuffer.wrap(input, tagStart, j);
+                parseTag(output, tag, delim - tagStart);
                 i = j;
-                if (!delim) break;
+                delim = -1;
+                if (!boundary) break;
+            } else if (c == '=' && delim < 0) {
+                delim = j;
             }
         }
         return ++i;
     }
 
-    private void parseTag(Map<String, CharSequence> tags, CharSequence tag) {
-        final int i = StringUtils.indexOf(tag, '=');
+    private void parseTag(Map<String, CharSequence> tags, CharSequence tag, int delim) {
         final CharSequence key, value;
-        if (i < 0) {
+        if (delim < 0) {
             key = tag;
             value = null;
         } else {
-            key = tag.subSequence(0, i);
-            value = tag.subSequence(i + 1, tag.length());
+            key = tag.subSequence(0, delim);
+            value = tag.subSequence(delim + 1, tag.length());
         }
         tags.put(key.toString(), value);
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -95,15 +95,16 @@ public class MessageParser {
 
     @VisibleForTesting
     public int parseTags(String input, Map<String, CharSequence> output) {
-        final int len = input.length();
+        final char[] inputChars = input.toCharArray(); // more memory yet 20% faster (HeapCharBuffer vs StringCharBuffer)
+        final int len = inputChars.length;
         int i = 0;
         int delim = -1;
         for (int j = i + 1; j < len; j++) {
-            final char c = input.charAt(j);
+            final char c = inputChars[j];
             final boolean boundary = c == ';';
             if (boundary || c == ' ') {
                 final int tagStart = i + 1;
-                final CharSequence tag = CharBuffer.wrap(input, tagStart, j);
+                final CharSequence tag = CharBuffer.wrap(inputChars, tagStart, j - tagStart);
                 parseTag(output, tag, delim - tagStart);
                 i = j;
                 delim = -1;

--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -1,0 +1,126 @@
+package com.github.twitch4j.chat.util;
+
+import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.nio.CharBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@UtilityClass
+public class MessageParser {
+
+    @Nullable
+    @VisibleForTesting
+    public IRCMessageEvent parse(@NotNull String rawMessage) {
+        return parse(rawMessage, Collections.emptyMap(), Collections.emptyMap(), null);
+    }
+
+    @Nullable
+    @ApiStatus.Internal
+    public IRCMessageEvent parse(@NotNull String raw, @NotNull Map<String, String> channelIdToChannelName, @NotNull Map<String, String> channelNameToChannelId, @Nullable Collection<String> botOwnerIds) {
+        final int len = raw.length();
+        int i = 0;
+
+        // Tags
+        final Map<String, CharSequence> tags;
+        if (raw.startsWith("@")) {
+            tags = new HashMap<>(32);
+            i = parseTags(raw, tags);
+        } else {
+            tags = Collections.emptyMap();
+        }
+
+        // Client
+        if (raw.charAt(i) == ':') i++;
+        int exclamation = -1;
+        int space = -1;
+        for (int j = i; j < len; j++) {
+            final char c = raw.charAt(j);
+            if (c == '!') {
+                if (exclamation < 0)
+                    exclamation = j;
+            } else if (c == ' ') {
+                space = j;
+                break;
+            }
+        }
+        if (space < 0 || space + 1 >= len) return null;
+        final int clientNameEnd = exclamation > 0 ? exclamation : space;
+        final CharSequence clientName = CharBuffer.wrap(raw, i, clientNameEnd);
+        i = space + 1;
+
+        // Command
+        int commandEnd = raw.indexOf(' ', i);
+        if (commandEnd < 0) {
+            commandEnd = len;
+        }
+        final String commandType = raw.substring(i, commandEnd);
+        i = commandEnd + 1;
+
+        if (i >= len) {
+            return new IRCMessageEvent(raw, tags, clientName, commandType, null, null, null, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+        }
+
+        // Channel
+        int messageStart = raw.indexOf(" :", i);
+        if (messageStart < 0) {
+            messageStart = len;
+        }
+        final CharSequence channel = CharBuffer.wrap(raw, i, messageStart);
+        final int chanDelim = StringUtils.indexOf(channel, " = "); // handle 353 NAMES
+        final CharSequence channelPart = chanDelim < 0 ? channel : channel.subSequence(chanDelim + " = ".length(), channel.length());
+        final String channelName = (
+            channelPart.length() > 0 && channelPart.charAt(0) == '#'
+                ? channelPart.subSequence(1, channelPart.length())
+                : channelPart
+        ).toString();
+
+        // Message
+        messageStart++;
+        if (messageStart >= len) {
+            return new IRCMessageEvent(raw, tags, clientName, commandType, channelName, null, null, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+        }
+        final CharSequence payload = CharBuffer.wrap(raw, messageStart, len);
+        final String message = raw.substring(messageStart + 1);
+        return new IRCMessageEvent(raw, tags, clientName, commandType, channelName, payload, message, channelIdToChannelName, channelNameToChannelId, botOwnerIds);
+    }
+
+    @VisibleForTesting
+    public int parseTags(String input, Map<String, CharSequence> output) {
+        final int len = input.length();
+        int i = 0;
+        for (int j = i + 1; j < len; j++) {
+            final char c = input.charAt(j);
+            final boolean delim = c == ';';
+            if (delim || c == ' ') {
+                final CharSequence tag = CharBuffer.wrap(input, i + 1, j);
+                parseTag(output, tag);
+                i = j;
+                if (!delim) break;
+            }
+        }
+        return ++i;
+    }
+
+    private void parseTag(Map<String, CharSequence> tags, CharSequence tag) {
+        final int i = StringUtils.indexOf(tag, '=');
+        final CharSequence key, value;
+        if (i < 0) {
+            key = tag;
+            value = null;
+        } else {
+            key = tag.subSequence(0, i);
+            value = tag.subSequence(i + 1, tag.length());
+        }
+        tags.put(key.toString(), value);
+    }
+
+}

--- a/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/ChatJoinRetryTest.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.chat.events.channel.ChannelJoinFailureEvent;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import com.github.twitch4j.chat.util.MessageParser;
 import com.github.twitch4j.chat.util.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +43,7 @@ public class ChatJoinRetryTest {
     }
 
     private static IRCMessageEvent testIRCMessageEvent(String raw) {
-        return new IRCMessageEvent(raw, Collections.singletonMap("149223493", FAKE_CHANNEL_NAME), Collections.singletonMap(FAKE_CHANNEL_NAME, "149223493"), null);
+        return MessageParser.parse(raw, Collections.singletonMap("149223493", FAKE_CHANNEL_NAME), Collections.singletonMap(FAKE_CHANNEL_NAME, "149223493"), null);
     }
 
     @Test

--- a/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
+import static com.github.twitch4j.chat.util.MessageParser.parse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,7 +15,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that CLEARCHAT is parsed by IRCMessageEvent")
     void parseChatClear() {
-        IRCMessageEvent e = build("@room-id=12345678;tmi-sent-ts=1642715756806 :tmi.twitch.tv CLEARCHAT #dallas");
+        IRCMessageEvent e = parse("@room-id=12345678;tmi-sent-ts=1642715756806 :tmi.twitch.tv CLEARCHAT #dallas");
 
         assertEquals("CLEARCHAT", e.getCommandType());
         assertEquals("dallas", e.getChannelName().orElse(null));
@@ -26,7 +25,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that CLEARMSG is parsed by IRCMessageEvent")
     void parseMessageDeletion() {
-        IRCMessageEvent e = build("@login=foo;room-id=;target-msg-id=94e6c7ff-bf98-4faa-af5d-7ad633a158a9;tmi-sent-ts=1642720582342 :tmi.twitch.tv CLEARMSG #bar :what a great day");
+        IRCMessageEvent e = parse("@login=foo;room-id=;target-msg-id=94e6c7ff-bf98-4faa-af5d-7ad633a158a9;tmi-sent-ts=1642720582342 :tmi.twitch.tv CLEARMSG #bar :what a great day");
 
         assertEquals("foo", e.getUserName());
         assertEquals("bar", e.getChannelName().orElse(null));
@@ -38,7 +37,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that GLOBALUSERSTATE is parsed by IRCMessageEvent")
     void parseGlobalUserState() {
-        IRCMessageEvent e = build("@badge-info=subscriber/8;badges=subscriber/6;color=#0D4200;display-name=dallas;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;turbo=0;user-id=12345678;user-type=admin " +
+        IRCMessageEvent e = parse("@badge-info=subscriber/8;badges=subscriber/6;color=#0D4200;display-name=dallas;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;turbo=0;user-id=12345678;user-type=admin " +
             ":tmi.twitch.tv GLOBALUSERSTATE");
 
         assertEquals("GLOBALUSERSTATE", e.getCommandType());
@@ -51,7 +50,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Test that normal messages are parsed by IRCMessageEvent")
     void parseMessage() {
-        IRCMessageEvent e = build("@badge-info=;badges=broadcaster/1;client-nonce=459e3142897c7a22b7d275178f2259e0;color=#0000FF;display-name=lovingt3s;emote-only=1;emotes=62835:0-10;first-msg=0;flags=;" +
+        IRCMessageEvent e = parse("@badge-info=;badges=broadcaster/1;client-nonce=459e3142897c7a22b7d275178f2259e0;color=#0000FF;display-name=lovingt3s;emote-only=1;emotes=62835:0-10;first-msg=0;flags=;" +
             "id=885196de-cb67-427a-baa8-82f9b0fcd05f;mod=0;room-id=713936733;subscriber=0;tmi-sent-ts=1643904084794;turbo=0;user-id=713936733;user-type= " +
             ":lovingt3s!lovingt3s@lovingt3s.tmi.twitch.tv PRIVMSG #lovingt3s :bleedPurple");
 
@@ -70,7 +69,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that NOTICE is parsed by IRCMessageEvent")
     void parseNotice() {
-        IRCMessageEvent e = build("@msg-id=delete_message_success :tmi.twitch.tv NOTICE #bar :The message from foo is now deleted.");
+        IRCMessageEvent e = parse("@msg-id=delete_message_success :tmi.twitch.tv NOTICE #bar :The message from foo is now deleted.");
 
         assertEquals("NOTICE", e.getCommandType());
         assertEquals("bar", e.getChannelName().orElse(null));
@@ -81,14 +80,14 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that RECONNECT is parsed by IRCMessageEvent")
     void parseReconnect() {
-        IRCMessageEvent e = build(":tmi.twitch.tv RECONNECT");
+        IRCMessageEvent e = parse(":tmi.twitch.tv RECONNECT");
         assertEquals("RECONNECT", e.getCommandType());
     }
 
     @Test
     @DisplayName("Tests that ROOMSTATE is parsed by IRCMessageEvent")
     void parseRoomState() {
-        IRCMessageEvent e = build("@emote-only=0;followers-only=-1;r9k=0;rituals=0;room-id=12345678;slow=0;subs-only=0 :tmi.twitch.tv ROOMSTATE #bar");
+        IRCMessageEvent e = parse("@emote-only=0;followers-only=-1;r9k=0;rituals=0;room-id=12345678;slow=0;subs-only=0 :tmi.twitch.tv ROOMSTATE #bar");
         assertEquals("ROOMSTATE", e.getCommandType());
         assertEquals("bar", e.getChannelName().orElse(null));
         assertEquals("12345678", e.getChannelId());
@@ -99,7 +98,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that USERNOTICE is parsed by IRCMessageEvent")
     void parseUserNotice() {
-        IRCMessageEvent e = build("@badge-info=;badges=staff/1,premium/1;color=#0000FF;display-name=TWW2;emotes=;id=e9176cd8-5e22-4684-ad40-ce53c2561c5e;login=tww2;mod=0;msg-id=subgift;" +
+        IRCMessageEvent e = parse("@badge-info=;badges=staff/1,premium/1;color=#0000FF;display-name=TWW2;emotes=;id=e9176cd8-5e22-4684-ad40-ce53c2561c5e;login=tww2;mod=0;msg-id=subgift;" +
             "msg-param-months=1;msg-param-recipient-display-name=Mr_Woodchuck;msg-param-recipient-id=55554444;msg-param-recipient-name=mr_woodchuck;msg-param-sub-plan-name=House\\sof\\sNyoro~n;msg-param-sub-plan=1000;" +
             "room-id=12345678;subscriber=0;system-msg=TWW2\\sgifted\\sa\\sTier\\s1\\ssub\\sto\\sMr_Woodchuck!;tmi-sent-ts=1521159445153;turbo=0;user-id=87654321;user-type=staff :tmi.twitch.tv USERNOTICE #forstycup");
 
@@ -116,7 +115,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Tests that USERSTATE is parsed by IRCMessageEevent")
     void parseUserState() {
-        IRCMessageEvent e = build("@badge-info=;badges=staff/1;color=#0D4200;display-name=ronni;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;mod=1;subscriber=1;turbo=1;user-type=staff " +
+        IRCMessageEvent e = parse("@badge-info=;badges=staff/1;color=#0D4200;display-name=ronni;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;mod=1;subscriber=1;turbo=1;user-type=staff " +
             ":tmi.twitch.tv USERSTATE #dallas");
 
         assertEquals("USERSTATE", e.getCommandType());
@@ -129,7 +128,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Test that whispers are parsed by IRCMessageEvent")
     void parseWhisper() {
-        IRCMessageEvent e = build("@badges=;color=;display-name=HexaFice;emotes=;message-id=103;thread-id=142621956_149223493;turbo=0;user-id=142621956;user-type= " +
+        IRCMessageEvent e = parse("@badges=;color=;display-name=HexaFice;emotes=;message-id=103;thread-id=142621956_149223493;turbo=0;user-id=142621956;user-type= " +
             ":hexafice!hexafice@hexafice.tmi.twitch.tv WHISPER twitch4j :test 123");
 
         assertEquals("test 123", e.getMessage().orElse(null));
@@ -145,7 +144,7 @@ public class IRCMessageEventTest {
     @Test
     @DisplayName("Test that 353 NAMES response is parsed by IRCMessageEvent")
     void parseNamesResponse() {
-        IRCMessageEvent e = build(":justinfan77645.tmi.twitch.tv 353 justinfan77645 = #pajlada :vissb ogprodigy supabridge zneix suslada beatz pajbot");
+        IRCMessageEvent e = parse(":justinfan77645.tmi.twitch.tv 353 justinfan77645 = #pajlada :vissb ogprodigy supabridge zneix suslada beatz pajbot");
 
         assertEquals("353", e.getCommandType());
         assertEquals("pajlada", e.getChannelName().orElse(null));
@@ -153,10 +152,6 @@ public class IRCMessageEventTest {
         assertTrue(e.getClientName().isPresent());
         assertTrue(e.getBadges().isEmpty());
         assertTrue(e.getBadgeInfo().isEmpty());
-    }
-
-    private static IRCMessageEvent build(String raw) {
-        return new IRCMessageEvent(raw, Collections.emptyMap(), Collections.emptyMap(), Collections.emptySet());
     }
 
 }

--- a/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
@@ -154,4 +154,22 @@ public class IRCMessageEventTest {
         assertTrue(e.getBadgeInfo().isEmpty());
     }
 
+    @Test
+    @DisplayName("Test that JOIN is parsed by IRCMessageEvent")
+    void parseJoin() {
+        IRCMessageEvent e = parse(":ogprodigy!ogprodigy@ogprodigy.tmi.twitch.tv JOIN #twitchdev");
+        assertEquals("JOIN", e.getCommandType());
+        assertEquals("twitchdev", e.getChannelName().orElse(null));
+        assertEquals("ogprodigy", e.getUserName());
+    }
+
+    @Test
+    @DisplayName("Test that PART is parsed by IRCMessageEvent")
+    void parsePart() {
+        IRCMessageEvent e = parse(":ogprodigy!ogprodigy@ogprodigy.tmi.twitch.tv PART #twitchdev");
+        assertEquals("PART", e.getCommandType());
+        assertEquals("twitchdev", e.getChannelName().orElse(null));
+        assertEquals("ogprodigy", e.getUserName());
+    }
+
 }

--- a/kotlin/src/test/kotlin/com/github/twitch4j/kotlin/chat/ChatExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/com/github/twitch4j/kotlin/chat/ChatExtensionsTest.kt
@@ -3,7 +3,7 @@ package com.github.twitch4j.kotlin.chat
 import com.github.twitch4j.chat.events.AbstractChannelEvent
 import com.github.twitch4j.chat.events.channel.ChannelJoinEvent
 import com.github.twitch4j.chat.events.channel.ChannelMessageEvent
-import com.github.twitch4j.chat.events.channel.IRCMessageEvent
+import com.github.twitch4j.chat.util.MessageParser
 import com.github.twitch4j.common.events.domain.EventChannel
 import com.github.twitch4j.common.events.domain.EventUser
 import com.github.twitch4j.kotlin.mock.MockChat
@@ -171,12 +171,12 @@ class ChatExtensionsTest {
     private val testChannel2 = EventChannel(testChannelId2, testChannelName2)
     private val testUser = EventUser("testUserId", "testUserName")
 
-    private val testMessage = "TestMessage"
-    private val testIrcMessageEvent = IRCMessageEvent(testMessage, emptyMap(), emptyMap(), mutableListOf())
+    private val testMessage = ":awakenedredstone PRIVMSG #twitch4j :TestMessage"
+    private val testIrcMessageEvent = MessageParser.parse(testMessage)
     private val testChannelJoinEvent1 = ChannelJoinEvent(testChannel1, testUser)
     private val testChannelJoinEvent2 = ChannelJoinEvent(testChannel2, testUser)
     private val testChannelMessageEvent1 =
-        ChannelMessageEvent(testChannel1, testIrcMessageEvent, testUser, testMessage, emptySet())
+        ChannelMessageEvent(testChannel1, testIrcMessageEvent, testUser, "TestMessage", emptySet())
     private val testChannelMessageEvent2 =
-        ChannelMessageEvent(testChannel2, testIrcMessageEvent, testUser, testMessage, emptySet())
+        ChannelMessageEvent(testChannel2, testIrcMessageEvent, testUser, "TestMessage", emptySet())
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Rewrite IRC message parsing approach from regex to manual splitting

### Additional Information

#### Before (`81ea5969f6c22d7efc73474a2a770bd56b844986`)
```
Benchmark                               Mode  Cnt   Score   Error  Units
MessageParserBenchmark.parse1kMessages  avgt    4  13.751 ± 0.088  us/op
MessageParserBenchmark.parse1kTags      avgt    4   2.620 ± 0.130  us/op
```

#### After (`b9f03c9e4018715c85c7841fc2b5417bd69c8618`)
```
Benchmark                               Mode  Cnt  Score   Error  Units
MessageParserBenchmark.parse1kMessages  avgt    4  1.702 ± 0.038  us/op
MessageParserBenchmark.parse1kTags      avgt    4  1.007 ± 0.008  us/op
```
