### PR TITLE
feat(eventsub): add channel.update beta subscription type

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ContentClassification.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ContentClassification.java
@@ -1,0 +1,53 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Content classification tags that indicate that a stream may not be suitable for certain viewers.
+ *
+ * @see <a href="https://safety.twitch.tv/s/article/Content-Classification-Guidelines?language=en_US">Official Guidelines</a>
+ */
+public enum ContentClassification {
+
+    /**
+     * Excessive tobacco glorification or promotion, any marijuana consumption/use,
+     * legal drug and alcohol induced intoxication, discussions of illegal drugs.
+     */
+    @JsonProperty("DrugsIntoxication")
+    DRUGS,
+
+    /**
+     * Participating in online or in-person gambling, poker or fantasy sports,
+     * that involve the exchange of real money.
+     */
+    @JsonProperty("Gambling")
+    GAMBLING,
+
+    /**
+     * Games that are rated Mature or less suitable for a younger audience.
+     * <p>
+     * This tag is automatically applied based on the stream category.
+     */
+    @JsonProperty("MatureGame")
+    MATURE,
+
+    /**
+     * Prolonged, and repeated use of obscenities, profanities, and vulgarities,
+     * especially as a regular part of speech.
+     */
+    @JsonProperty("ProfanityVulgarity")
+    PROFANITY,
+
+    /**
+     * Content that focuses on sexualized physical attributes and activities, sexual topics, or experiences.
+     */
+    @JsonProperty("SexualThemes")
+    SEXUAL,
+
+    /**
+     * Simulations and/or depictions of realistic violence, gore, extreme injury, or death.
+     */
+    @JsonProperty("ViolentGraphic")
+    VIOLENCE
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ContentClassification.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ContentClassification.java
@@ -30,7 +30,7 @@ public enum ContentClassification {
      * This tag is automatically applied based on the stream category.
      */
     @JsonProperty("MatureGame")
-    MATURE,
+    MATURE_GAME,
 
     /**
      * Prolonged, and repeated use of obscenities, profanities, and vulgarities,

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ContentClassification.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/ContentClassification.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -48,6 +49,13 @@ public enum ContentClassification {
      * Simulations and/or depictions of realistic violence, gore, extreme injury, or death.
      */
     @JsonProperty("ViolentGraphic")
-    VIOLENCE
+    VIOLENCE,
+
+    /**
+     * The channel has a content classification label that is unrecognized by the library;
+     * Please file an issue on our GitHub repository.
+     */
+    @JsonEnumDefaultValue
+    UNKNOWN;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/BetaChannelUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/BetaChannelUpdateEvent.java
@@ -1,0 +1,45 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.ContentClassification;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Set;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class BetaChannelUpdateEvent extends EventSubChannelEvent {
+
+    /**
+     * The channel’s stream title.
+     */
+    private String title;
+
+    /**
+     * The channel’s broadcast language.
+     */
+    private String language;
+
+    /**
+     * The channel’s category ID.
+     */
+    private String categoryId;
+
+    /**
+     * The category name.
+     */
+    private String categoryName;
+
+    /**
+     * Content classification label IDs currently applied on the channel.
+     */
+    private Set<ContentClassification> contentClassificationLabels;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelUpdateType.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelUpdateCondition;
+import com.github.twitch4j.eventsub.events.BetaChannelUpdateEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A broadcaster updates their channel properties e.g., category, title, content classification labels, or broadcast language.
+ * <p>
+ * No authorization required.
+ * <p>
+ * This subscription type is in open beta since 2023-06-29.
+ */
+@ApiStatus.Experimental
+public class BetaChannelUpdateType implements SubscriptionType<ChannelUpdateCondition, ChannelUpdateCondition.ChannelUpdateConditionBuilder<?, ?>, BetaChannelUpdateEvent> {
+
+    @Override
+    public String getName() {
+        return "channel.update";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelUpdateCondition.ChannelUpdateConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelUpdateCondition.builder();
+    }
+
+    @Override
+    public Class<BetaChannelUpdateEvent> getEventClass() {
+        return BetaChannelUpdateEvent.class;
+    }
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
 import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
 import java.util.Map;
@@ -38,6 +39,7 @@ public class SubscriptionTypes {
     public final ChannelSubscriptionMessageType CHANNEL_SUBSCRIPTION_MESSAGE;
     public final ChannelUnbanType CHANNEL_UNBAN;
     public final ChannelUpdateType CHANNEL_UPDATE;
+    public final @ApiStatus.Experimental BetaChannelUpdateType BETA_CHANNEL_UPDATE;
     public final DropEntitlementGrantType DROP_ENTITLEMENT_GRANT;
     public final ExtensionBitsTransactionCreateType EXTENSION_BITS_TRANSACTION_CREATE;
     public final HypeTrainBeginType HYPE_TRAIN_BEGIN;
@@ -92,6 +94,7 @@ public class SubscriptionTypes {
                 CHANNEL_SUBSCRIPTION_MESSAGE = new ChannelSubscriptionMessageType(),
                 CHANNEL_UNBAN = new ChannelUnbanType(),
                 CHANNEL_UPDATE = new ChannelUpdateType(),
+                BETA_CHANNEL_UPDATE = new BetaChannelUpdateType(),
                 DROP_ENTITLEMENT_GRANT = new DropEntitlementGrantType(),
                 EXTENSION_BITS_TRANSACTION_CREATE = new ExtensionBitsTransactionCreateType(),
                 HYPE_TRAIN_BEGIN = new HypeTrainBeginType(),


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `channel.update` beta eventsub subscription type

### Additional Information
2023-06-29 changelog entry https://dev.twitch.tv/docs/change-log/

Docs are lacking & I had to determine the possible `content_classification_labels` empirically. Also these values don't follow eventsub's `lower_snake_case` standard for enums, so I suspect they may change in the future
