### PR TITLE
fix(helix): avoid NPE from withClientId(null)

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.Objects;
 
 @Slf4j
 public final class TwitchHelixTokenManager {
@@ -62,7 +63,7 @@ public final class TwitchHelixTokenManager {
         this.defaultAuthToken = defaultAuthToken;
 
         if (defaultAuthToken != null) {
-            this.defaultClientId = defaultAuthToken.getContext().getOrDefault(CLIENT_ID_CONTEXT, clientId).toString();
+            this.defaultClientId = Objects.toString(defaultAuthToken.getContext().getOrDefault(CLIENT_ID_CONTEXT, clientId), null);
             twitchIdentityProvider.getAdditionalCredentialInformation(defaultAuthToken).ifPresent(oauth -> {
                 populateCache(oauth);
                 this.defaultClientId = extractClientId(oauth);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* NPE in `TwitchHelixTokenManager` caused by `withClientId(null)` from bad user code (or lack of a default client id in `TwitchEventSocket`)

### Changes Proposed
* Avoid stringifying a null client_id passed to helix
