### PR TITLE
fix(eventsub): avoid NPE when subscription type is unknown

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/util/EventSubConditionConverter.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/util/EventSubConditionConverter.java
@@ -20,7 +20,7 @@ public class EventSubConditionConverter {
     }
 
     public EventSubCondition getCondition(SubscriptionType<?, ?, ?> type, Map<String, Object> condition) {
-        return getCondition(type.getConditionClass(), condition);
+        return getCondition(type != null ? type.getConditionClass() : null, condition);
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Possible NPE if a user manually subscribes to an eventsub type that does not have library support yet

### Changes Proposed
* Don't call `SubscriptionType#getConditionClass` in `EventSubConditionConverter.getCondition` if the subscription type is null

### Additional Information
Caused by https://github.com/twitch4j/twitch4j/blob/c8599cc47e4defa66c0f043f77dcab00c29ff12a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscription.java#L105-L106 (`SubscriptionTypes.getSubscriptionType` can yield null, and the value is still passed to `EventSubConditionConverter.getCondition`)
