### PR TITLE
feat: migrate client helper to new followers endpoint

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/FollowEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/FollowEvent.java
@@ -4,13 +4,19 @@ import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.Value;
 
 /**
- * This event gets called when a user gets a new followers
+ * This event gets called when a channel gets a new follower.
+ * <p>
+ * Note: Despite the chat package, this event is <i>not</i> fired by IRC.
+ * Instead, this event requires {@code TwitchClientHelper#enableFollowEventListener}
+ * and the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
  */
 @Value
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class FollowEvent extends AbstractChannelEvent {
 
 	/**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2659,7 +2659,6 @@ public interface TwitchHelix {
      * Further, Twitch will shutdown this endpoint on 2023-08-03 in favor of {@link #getChannelFollowers(String, String, String, Integer, String)} and {@link #getFollowedChannels(String, String, String, Integer, String)}.
      */
     @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<FollowList> getFollowers(

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/endpoints/UsersServiceTest.java
@@ -4,7 +4,7 @@ import com.github.twitch4j.helix.TestUtils;
 import com.github.twitch4j.helix.domain.BlockedUserList;
 import com.github.twitch4j.helix.domain.ExtensionActiveList;
 import com.github.twitch4j.helix.domain.ExtensionList;
-import com.github.twitch4j.helix.domain.FollowList;
+import com.github.twitch4j.helix.domain.OutboundFollowing;
 import com.github.twitch4j.helix.domain.UserList;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -52,16 +52,16 @@ public class UsersServiceTest extends AbstractEndpointTest {
     @DisplayName("Fetch followers")
     public void getFollowers() {
         // TestCase
-        FollowList resultList = testUtils.getTwitchHelixClient().getFollowers(testUtils.getCredential().getAccessToken(), twitchUserId, null, null, 100).execute();
+        OutboundFollowing resultList = testUtils.getTwitchHelixClient().getFollowedChannels(testUtils.getCredential().getAccessToken(), twitchUserId, null, 100, null).execute();
 
         // Test
-        assertTrue(resultList.getFollows().size() > 0, "Should at least find one result from the followers method!");
-        resultList.getFollows().forEach(follow -> {
-            assertNotNull(follow.getFromId(), "FromId should not be null!");
-            assertNotNull(follow.getFromName(), "FromName should not be null!");
-            assertNotNull(follow.getToId(), "ToId should not be null!");
-            assertNotNull(follow.getToName(), "ToName should not be null!");
-        });
+        assertTrue(resultList.getTotal() > 0, "Should at least find one result from the followers method!");
+        if (resultList.getFollows() != null) {
+            resultList.getFollows().forEach(follow -> {
+                assertNotNull(follow.getBroadcasterId(), "ToId should not be null!");
+                assertNotNull(follow.getBroadcasterLogin(), "ToName should not be null!");
+            });
+        }
     }
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
@@ -1,8 +1,10 @@
 package com.github.twitch4j;
 
+import com.github.twitch4j.chat.events.channel.FollowEvent;
 import com.github.twitch4j.common.util.CollectionUtils;
 import com.github.twitch4j.common.util.ExponentialBackoffStrategy;
 import com.github.twitch4j.domain.ChannelCache;
+import com.github.twitch4j.events.ChannelFollowCountUpdateEvent;
 import com.github.twitch4j.helix.TwitchHelix;
 import com.github.twitch4j.helix.domain.User;
 import com.github.twitch4j.helix.domain.UserList;
@@ -42,7 +44,10 @@ public interface IClientHelper extends AutoCloseable {
     /**
      * Enable Follow Listener, without invoking a Helix API call
      * <p>
-     * WARNING: This will eventually require defaultAuthToken to represent the channel (or a moderator), due to Twitch scope changes.
+     * For {@link FollowEvent} to fire, defaultAuthToken must be a user access token from a moderator of the channel
+     * with the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
+     * Otherwise, the client helper can only fire {@link ChannelFollowCountUpdateEvent}
+     * due to Twitch restrictions implemented on 2023-08-03.
      *
      * @param channelId   Channel Id
      * @param channelName Channel Name
@@ -160,7 +165,10 @@ public interface IClientHelper extends AutoCloseable {
     /**
      * Enable Follow Listener for the given channel name
      * <p>
-     * WARNING: This will eventually require defaultAuthToken to represent the channel (or a moderator), due to Twitch scope changes.
+     * For {@link FollowEvent} to fire, defaultAuthToken must be a user access token from a moderator of the channel
+     * with the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
+     * Otherwise, the client helper can only fire {@link ChannelFollowCountUpdateEvent}
+     * due to Twitch restrictions implemented on 2023-08-03.
      *
      * @param channelName Channel Name
      */
@@ -182,7 +190,10 @@ public interface IClientHelper extends AutoCloseable {
     /**
      * Enable Follow Listener for the given channel names
      * <p>
-     * WARNING: This will eventually require defaultAuthToken to represent the channel (or a moderator), due to Twitch scope changes.
+     * For {@link FollowEvent} to fire, defaultAuthToken must be a user access token from a moderator of the channel
+     * with the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
+     * Otherwise, the client helper can only fire {@link ChannelFollowCountUpdateEvent}
+     * due to Twitch restrictions implemented on 2023-08-03.
      *
      * @param channelNames the channel names to be added
      */

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClient.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j;
 
+import com.github.philippheuer.credentialmanager.CredentialManager;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.common.annotation.Unofficial;
@@ -98,8 +100,11 @@ public class TwitchClient implements ITwitchClient {
      * @param graphql            TwitchGraphQL
      * @param eventSocket        Twitch EventSub over Websocket
      * @param threadPoolExecutor ScheduledThreadPoolExecutor
+     * @param credentialManager  CredentialManager
+     * @param defaultAuthToken   OAuth2Credential
      */
-    public TwitchClient(EventManager eventManager, TwitchExtensions extensions, TwitchHelix helix, TwitchKraken kraken, TwitchMessagingInterface messagingInterface, TwitchChat chat, TwitchPubSub pubsub, TwitchGraphQL graphql, IEventSubSocket eventSocket, ScheduledThreadPoolExecutor threadPoolExecutor) {
+    @ApiStatus.Internal
+    public TwitchClient(EventManager eventManager, TwitchExtensions extensions, TwitchHelix helix, TwitchKraken kraken, TwitchMessagingInterface messagingInterface, TwitchChat chat, TwitchPubSub pubsub, TwitchGraphQL graphql, IEventSubSocket eventSocket, ScheduledThreadPoolExecutor threadPoolExecutor, CredentialManager credentialManager, OAuth2Credential defaultAuthToken) {
         this.eventManager = eventManager;
         this.extensions = extensions;
         this.helix = helix;
@@ -109,7 +114,7 @@ public class TwitchClient implements ITwitchClient {
         this.eventSocket = eventSocket;
         this.pubsub = pubsub;
         this.graphql = graphql;
-        this.clientHelper = new TwitchClientHelper(helix, eventManager, threadPoolExecutor);
+        this.clientHelper = new TwitchClientHelper(helix, eventManager, threadPoolExecutor, credentialManager, defaultAuthToken);
         this.scheduledThreadPoolExecutor = threadPoolExecutor;
 
         // module loader

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -40,6 +40,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -265,6 +266,7 @@ public class TwitchClientBuilder {
      * CredentialManager
      */
     @With
+    @NotNull
     private CredentialManager credentialManager = CredentialManagerBuilder.builder().build();
 
     /**
@@ -549,7 +551,7 @@ public class TwitchClientBuilder {
         }
 
         // Module: TwitchClient & ClientHelper
-        final TwitchClient client = new TwitchClient(eventManager, extensions, helix, kraken, tmi, chat, pubSub, graphql, eventSocket, scheduledThreadPoolExecutor);
+        final TwitchClient client = new TwitchClient(eventManager, extensions, helix, kraken, tmi, chat, pubSub, graphql, eventSocket, scheduledThreadPoolExecutor, credentialManager, defaultAuthToken);
         client.getClientHelper().setThreadDelay(helperThreadDelay);
 
         // Return new Client Instance

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -297,7 +297,12 @@ public class TwitchClientHelper implements IClientHelper {
                     }
 
                     // Individual Follow Events
-                    if (followList != null) {
+                    if (followList == null || (followList.isEmpty() && followCount != null && followCount > 0)) {
+                        log.trace("Unable to read individual followers of {} due to insufficient authorization " +
+                                "(token does not represent a moderator of the channel or lacks 'moderator:read:followers' scope)",
+                            channel
+                        );
+                    } else {
                         for (InboundFollow follow : followList) {
                             // update lastFollowDate
                             if (lastFollowDate == null || follow.getFollowedAt().isAfter(lastFollowDate)) {
@@ -311,11 +316,6 @@ public class TwitchClientHelper implements IClientHelper {
                                 eventManager.publish(event);
                             }
                         }
-                    } else {
-                        log.trace("Unable to read individual followers of {} due to insufficient authorization " +
-                                "(token does not represent a moderator of the channel or lacks 'moderator:read:followers' scope)",
-                            channel
-                        );
                     }
                 } else {
                     nextRequestCanBeImmediate = true; // No API call was made

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPool.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPool.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j;
 
+import com.github.philippheuer.credentialmanager.CredentialManager;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.chat.ITwitchChat;
 import com.github.twitch4j.common.annotation.Unofficial;
@@ -101,8 +103,11 @@ public class TwitchClientPool implements ITwitchClient {
      * @param graphql            TwitchGraphQL
      * @param eventSocket        Twitch EventSub over WebSocket
      * @param threadPoolExecutor ScheduledThreadPoolExecutor
+     * @param credentialManager  CredentialManager
+     * @param defaultAuthToken   OAuth2Credential
      */
-    public TwitchClientPool(EventManager eventManager, TwitchExtensions extensions, TwitchHelix helix, TwitchKraken kraken, TwitchMessagingInterface messagingInterface, ITwitchChat chat, ITwitchPubSub pubsub, TwitchGraphQL graphql, IEventSubSocket eventSocket, ScheduledThreadPoolExecutor threadPoolExecutor) {
+    @ApiStatus.Internal
+    public TwitchClientPool(EventManager eventManager, TwitchExtensions extensions, TwitchHelix helix, TwitchKraken kraken, TwitchMessagingInterface messagingInterface, ITwitchChat chat, ITwitchPubSub pubsub, TwitchGraphQL graphql, IEventSubSocket eventSocket, ScheduledThreadPoolExecutor threadPoolExecutor, CredentialManager credentialManager, OAuth2Credential defaultAuthToken) {
         this.eventManager = eventManager;
         this.extensions = extensions;
         this.helix = helix;
@@ -112,7 +117,7 @@ public class TwitchClientPool implements ITwitchClient {
         this.eventSocket = eventSocket;
         this.pubsub = pubsub;
         this.graphql = graphql;
-        this.clientHelper = new TwitchClientHelper(helix, eventManager, threadPoolExecutor);
+        this.clientHelper = new TwitchClientHelper(helix, eventManager, threadPoolExecutor, credentialManager, defaultAuthToken);
         this.scheduledThreadPoolExecutor = threadPoolExecutor;
 
         // module loader

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -49,6 +49,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -285,6 +286,7 @@ public class TwitchClientPoolBuilder {
      * CredentialManager
      */
     @With
+    @NotNull
     private CredentialManager credentialManager = CredentialManagerBuilder.builder().build();
 
     /**
@@ -609,7 +611,7 @@ public class TwitchClientPoolBuilder {
         }
 
         // Module: TwitchClientPool & ClientHelper
-        final TwitchClientPool client = new TwitchClientPool(eventManager, extensions, helix, kraken, tmi, chat, pubSub, graphql, eventSocket, scheduledThreadPoolExecutor);
+        final TwitchClientPool client = new TwitchClientPool(eventManager, extensions, helix, kraken, tmi, chat, pubSub, graphql, eventSocket, scheduledThreadPoolExecutor, credentialManager, defaultAuthToken);
         client.getClientHelper().setThreadDelay(helperThreadDelay);
 
         // Return new Client Instance


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Client helper would've stopped tracking followers come August 3rd

### Changes Proposed
* Use `TwitchHelix#getFollowedChannels` in `TwitchClientHelper` (rather than the deprecated `TwitchHelix#getFollowers`)

### Additional Information
https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322
