### PR TITLE
chore(eventsub): promote channel.update from beta to v2

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUpdateEvent.java
@@ -9,11 +9,15 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
+/**
+ * @deprecated in favor of {@link ChannelUpdateV2Event}
+ */
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
+@Deprecated
 public class ChannelUpdateEvent extends EventSubChannelEvent {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUpdateV2Event.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelUpdateV2Event.java
@@ -15,7 +15,7 @@ import java.util.Set;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class BetaChannelUpdateEvent extends EventSubChannelEvent {
+public class ChannelUpdateV2Event extends EventSubChannelEvent {
 
     /**
      * The channel’s stream title.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelUpdateType.java
@@ -7,7 +7,10 @@ import com.github.twitch4j.eventsub.events.ChannelUpdateEvent;
  * A broadcaster updates their channel properties e.g., category, title, mature flag, broadcast, or language.
  * <p>
  * No authorization required.
+ *
+ * @deprecated in favor of {@link ChannelUpdateV2Type}
  */
+@Deprecated
 public class ChannelUpdateType implements SubscriptionType<ChannelUpdateCondition, ChannelUpdateCondition.ChannelUpdateConditionBuilder<?, ?>, ChannelUpdateEvent> {
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelUpdateV2Type.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelUpdateV2Type.java
@@ -1,18 +1,14 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
 import com.github.twitch4j.eventsub.condition.ChannelUpdateCondition;
-import com.github.twitch4j.eventsub.events.BetaChannelUpdateEvent;
-import org.jetbrains.annotations.ApiStatus;
+import com.github.twitch4j.eventsub.events.ChannelUpdateV2Event;
 
 /**
  * A broadcaster updates their channel properties e.g., category, title, content classification labels, or broadcast language.
  * <p>
  * No authorization required.
- * <p>
- * This subscription type is in open beta since 2023-06-29.
  */
-@ApiStatus.Experimental
-public class BetaChannelUpdateType implements SubscriptionType<ChannelUpdateCondition, ChannelUpdateCondition.ChannelUpdateConditionBuilder<?, ?>, BetaChannelUpdateEvent> {
+public class ChannelUpdateV2Type implements SubscriptionType<ChannelUpdateCondition, ChannelUpdateCondition.ChannelUpdateConditionBuilder<?, ?>, ChannelUpdateV2Event> {
 
     @Override
     public String getName() {
@@ -21,7 +17,7 @@ public class BetaChannelUpdateType implements SubscriptionType<ChannelUpdateCond
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "2";
     }
 
     @Override
@@ -30,8 +26,8 @@ public class BetaChannelUpdateType implements SubscriptionType<ChannelUpdateCond
     }
 
     @Override
-    public Class<BetaChannelUpdateEvent> getEventClass() {
-        return BetaChannelUpdateEvent.class;
+    public Class<ChannelUpdateV2Event> getEventClass() {
+        return ChannelUpdateV2Event.class;
     }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
 import lombok.experimental.UtilityClass;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
 import java.util.Map;
@@ -38,8 +37,8 @@ public class SubscriptionTypes {
     public final ChannelSubscriptionGiftType CHANNEL_SUBSCRIPTION_GIFT;
     public final ChannelSubscriptionMessageType CHANNEL_SUBSCRIPTION_MESSAGE;
     public final ChannelUnbanType CHANNEL_UNBAN;
-    public final ChannelUpdateType CHANNEL_UPDATE;
-    public final @ApiStatus.Experimental BetaChannelUpdateType BETA_CHANNEL_UPDATE;
+    public final @Deprecated ChannelUpdateType CHANNEL_UPDATE;
+    public final ChannelUpdateV2Type CHANNEL_UPDATE_V2;
     public final DropEntitlementGrantType DROP_ENTITLEMENT_GRANT;
     public final ExtensionBitsTransactionCreateType EXTENSION_BITS_TRANSACTION_CREATE;
     public final HypeTrainBeginType HYPE_TRAIN_BEGIN;
@@ -94,7 +93,7 @@ public class SubscriptionTypes {
                 CHANNEL_SUBSCRIPTION_MESSAGE = new ChannelSubscriptionMessageType(),
                 CHANNEL_UNBAN = new ChannelUnbanType(),
                 CHANNEL_UPDATE = new ChannelUpdateType(),
-                BETA_CHANNEL_UPDATE = new BetaChannelUpdateType(),
+                CHANNEL_UPDATE_V2 = new ChannelUpdateV2Type(),
                 DROP_ENTITLEMENT_GRANT = new DropEntitlementGrantType(),
                 EXTENSION_BITS_TRANSACTION_CREATE = new ExtensionBitsTransactionCreateType(),
                 HYPE_TRAIN_BEGIN = new HypeTrainBeginType(),

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.eventsub.events;
 
 import com.github.twitch4j.common.enums.SubscriptionPlan;
+import com.github.twitch4j.eventsub.domain.ContentClassification;
 import com.github.twitch4j.eventsub.domain.Contribution;
 import com.github.twitch4j.eventsub.domain.PollStatus;
 import com.github.twitch4j.eventsub.domain.PredictionColor;
@@ -13,6 +14,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.github.twitch4j.common.util.TypeConvert.jsonToObject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -292,11 +297,11 @@ public class EventSubEventTest {
     }
 
     @Test
-    @DisplayName("Deserialize ChannelUpdateEvent")
+    @DisplayName("Deserialize ChannelUpdateV2Event")
     public void deserializeComplexChannelEvent() {
-        ChannelUpdateEvent event = jsonToObject(
-            "{\"broadcaster_user_id\":\"1337\",\"broadcaster_user_name\":\"cool_user\",\"title\":\"Best Stream Ever\",\"language\":\"en\",\"category_id\":\"21779\",\"category_name\":\"Fortnite\",\"is_mature\":false}",
-            ChannelUpdateEvent.class
+        ChannelUpdateV2Event event = jsonToObject(
+            "{\"broadcaster_user_id\":\"1337\",\"broadcaster_user_name\":\"cool_user\",\"title\":\"Best Stream Ever\",\"language\":\"en\",\"category_id\":\"21779\",\"category_name\":\"Fortnite\",\"content_classification_labels\":[\"MatureGame\"]}",
+            ChannelUpdateV2Event.class
         );
 
         assertEquals("1337", event.getBroadcasterUserId());
@@ -305,7 +310,7 @@ public class EventSubEventTest {
         assertEquals("en", event.getLanguage());
         assertEquals("21779", event.getCategoryId());
         assertEquals("Fortnite", event.getCategoryName());
-        assertEquals(false, event.isMature());
+        assertEquals(new HashSet<>(Collections.singletonList(ContentClassification.MATURE_GAME)), event.getContentClassificationLabels());
     }
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Update `channel.update` beta eventsub type to v2

### Additional Information
2023-07-17 changelog entry: https://dev.twitch.tv/docs/change-log/
