### PR TITLE
chore: deprecate mod commands in AbstractChannelEvent

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
@@ -4,6 +4,7 @@ import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.util.ChatReply;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
@@ -127,6 +128,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean setSlowMode(String channel, int seconds) {
         if (seconds <= 0)
             return this.sendMessage(channel, "/slowoff");
@@ -147,6 +149,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean setFollowersOnly(String channel, Duration time) {
         if (time == null || time.isNegative())
             return this.sendMessage(channel, "/followersoff");
@@ -163,6 +166,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean setSubscribersOnly(String channel, boolean enable) {
         return this.sendMessage(channel, enable ? "/subscribers" : "/subscribersoff");
     }
@@ -176,6 +180,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean setUniqueChat(String channel, boolean enable) {
         return this.sendMessage(channel, enable ? "/uniquechat" : "/uniquechatoff");
     }
@@ -189,6 +194,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#updateChatSettings
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean setEmoteOnly(String channel, boolean enable) {
         return this.sendMessage(channel, enable ? "/emoteonly" : "/emoteonlyoff");
     }
@@ -201,6 +207,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#deleteChatMessages
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean clearChat(String channel) {
         return this.sendMessage(channel, "/clear");
     }
@@ -215,6 +222,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#deleteChatMessages
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean delete(String channel, String targetMsgId) {
         return this.sendMessage(channel, String.format("/delete %s", targetMsgId));
     }
@@ -230,6 +238,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean timeout(String channel, String user, Duration duration, String reason) {
         StringBuilder sb = new StringBuilder(user).append(' ').append(duration.getSeconds());
         if (reason != null) {
@@ -249,6 +258,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean ban(String channel, String user, String reason) {
         StringBuilder sb = new StringBuilder(user);
         if (reason != null) {
@@ -267,6 +277,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#unbanUser
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean unban(String channel, String user) {
         return this.sendMessage(channel, String.format("/unban %s", user));
     }
@@ -282,6 +293,7 @@ public interface ITwitchChat extends AutoCloseable {
      */
     @Unofficial
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default boolean sendAnnouncement(String channel, String message) {
         return this.sendMessage(channel, String.format("/announce %s", message));
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/ITwitchChat.java
@@ -264,7 +264,7 @@ public interface ITwitchChat extends AutoCloseable {
      * @param channel channel
      * @param user    username
      * @return whether the command was added to the queue
-     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#banUser
+     * @deprecated Twitch will decommission this method on February 18, 2023; migrate to TwitchHelix#unbanUser
      */
     @Deprecated
     default boolean unban(String channel, String user) {

--- a/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelEvent.java
@@ -7,6 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Duration;
 
@@ -44,6 +45,7 @@ public class AbstractChannelEvent extends TwitchEvent {
      * @deprecated Twitch decommissioned this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public void timeout(String user, Duration duration, String reason) {
         StringBuilder sb = new StringBuilder()
             .append(duration.getSeconds());
@@ -61,6 +63,7 @@ public class AbstractChannelEvent extends TwitchEvent {
      * @deprecated Twitch decommissioned this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public void ban(String user, String reason) {
         StringBuilder sb = new StringBuilder(user);
         if (reason != null) {
@@ -77,6 +80,7 @@ public class AbstractChannelEvent extends TwitchEvent {
      * @deprecated Twitch decommissioned this method on February 18, 2023; migrate to TwitchHelix#unbanUser
      */
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public void unban(String user) {
         getTwitchChat().sendMessage(channel.getName(), String.format("/unban %s", user));
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelEvent.java
@@ -41,7 +41,9 @@ public class AbstractChannelEvent extends TwitchEvent {
      * @param user     username
      * @param duration duration
      * @param reason   reason
+     * @deprecated Twitch decommissioned this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
+    @Deprecated
     public void timeout(String user, Duration duration, String reason) {
         StringBuilder sb = new StringBuilder()
             .append(duration.getSeconds());
@@ -56,7 +58,9 @@ public class AbstractChannelEvent extends TwitchEvent {
      *
      * @param user   username
      * @param reason reason
+     * @deprecated Twitch decommissioned this method on February 18, 2023; migrate to TwitchHelix#banUser
      */
+    @Deprecated
     public void ban(String user, String reason) {
         StringBuilder sb = new StringBuilder(user);
         if (reason != null) {
@@ -70,7 +74,9 @@ public class AbstractChannelEvent extends TwitchEvent {
      * Unban a user
      *
      * @param user username
+     * @deprecated Twitch decommissioned this method on February 18, 2023; migrate to TwitchHelix#unbanUser
      */
+    @Deprecated
     public void unban(String user) {
         getTwitchChat().sendMessage(channel.getName(), String.format("/unban %s", user));
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Deprecate `AbstractChannelEvent#ban`, `AbstractChannelEvent#timeout`, `AbstractChannelEvent#unban`
