### PR TITLE
fix: allow IEventSubSocket#register with null transport

### DIFF
--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
@@ -1,9 +1,14 @@
 package com.github.twitch4j.eventsub.socket;
 
 import com.github.twitch4j.eventsub.EventSubSubscription;
+import com.github.twitch4j.eventsub.EventSubSubscriptionStatus;
+import com.github.twitch4j.eventsub.EventSubTransport;
 import com.github.twitch4j.eventsub.condition.EventSubCondition;
+import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+
+import java.time.Instant;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -15,13 +20,52 @@ class SubscriptionWrapper extends EventSubSubscription {
     EventSubCondition condition;
 
     private SubscriptionWrapper(EventSubSubscription sub) {
-        super(sub.getId(), sub.getStatus(), sub.getType(), sub.getCondition(),
-            sub.getCreatedAt(), sub.getTransport(), sub.getCost(), sub.isBatchingEnabled(),
-            sub.getRawType(), sub.getRawVersion());
+        super();
         this.subscription = sub;
         this.rawType = sub.getRawType();
         this.rawVersion = sub.getRawVersion();
         this.condition = sub.getCondition();
+    }
+
+    @Override
+    public String getId() {
+        return subscription.getId();
+    }
+
+    @Override
+    public EventSubSubscriptionStatus getStatus() {
+        return subscription.getStatus();
+    }
+
+    @Override
+    public SubscriptionType<?, ?, ?> getType() {
+        return subscription.getType();
+    }
+
+    @Override
+    public Instant getCreatedAt() {
+        return subscription.getCreatedAt();
+    }
+
+    @Override
+    public EventSubTransport getTransport() {
+        return subscription.getTransport();
+    }
+
+    @Override
+    @Deprecated
+    public void setTransport(EventSubTransport transport) {
+        subscription.setTransport(transport);
+    }
+
+    @Override
+    public Integer getCost() {
+        return subscription.getCost();
+    }
+
+    @Override
+    public Boolean isBatchingEnabled() {
+        return subscription.isBatchingEnabled();
     }
 
     static SubscriptionWrapper wrap(EventSubSubscription sub) {

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
@@ -11,20 +11,31 @@ import lombok.Value;
 import java.time.Instant;
 
 @Value
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 class SubscriptionWrapper extends EventSubSubscription {
-    @EqualsAndHashCode.Exclude
     EventSubSubscription subscription;
-    String rawType;
-    String rawVersion;
-    EventSubCondition condition;
 
     private SubscriptionWrapper(EventSubSubscription sub) {
         super();
         this.subscription = sub;
-        this.rawType = sub.getRawType();
-        this.rawVersion = sub.getRawVersion();
-        this.condition = sub.getCondition();
+    }
+
+    @Override
+    @EqualsAndHashCode.Include
+    public String getRawType() {
+        return subscription.getRawType();
+    }
+
+    @Override
+    @EqualsAndHashCode.Include
+    public String getRawVersion() {
+        return subscription.getRawVersion();
+    }
+
+    @Override
+    @EqualsAndHashCode.Include
+    public EventSubCondition getCondition() {
+        return subscription.getCondition();
     }
 
     @Override

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/SubscriptionWrapper.java
@@ -11,7 +11,7 @@ import lombok.Value;
 import java.time.Instant;
 
 @Value
-@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false, cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
 class SubscriptionWrapper extends EventSubSubscription {
     EventSubSubscription subscription;
 

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocket.java
@@ -370,6 +370,7 @@ public final class TwitchEventSocket implements IEventSubSocket {
         return subscriptions.remove(SubscriptionWrapper.wrap(remove));
     }
 
+    @Synchronized
     private void onInitialConnection(final String websocketId) {
         final Collection<EventSubSubscription> oldSubs = new ArrayDeque<>(subscriptions.size());
         subscriptions.keySet().removeIf(oldSubs::add);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Allow eventsub subscriptions to be registered with null EventSubTransport (`EventSubSubscription#setTransport` in `TwitchEventSocket#register` was not reflected in `SubscriptionWrapper`)

### Changes Proposed
* `SubscriptionWrapper` should delegate getters to the held `EventSubSubscription` rather than copying the fields, which ensures any setters called on the underlying subscription are reflected in the wrapper (and reduces memory consumption)
