### PR TITLE
feat: add hype chat level and duration to ChannelMessageEvent

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -112,7 +112,7 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      * Hype Chat Contribution
      *
      * @return the payment information related to this hype chat, if applicable.
-     * @see <a href ="https://blog.twitch.tv/en/2023/06/22/introducing-hype-chat-a-new-way-to-stand-out/">Twitch Announcement</a>
+     * @see <a href="https://blog.twitch.tv/en/2023/06/22/introducing-hype-chat-a-new-way-to-stand-out/">Twitch Announcement</a>
      */
     public Optional<DonationAmount> getElevatedChatPayment() {
         final Map<String, CharSequence> tags = getMessageEvent().getEscapedTags();

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -4,6 +4,7 @@ import com.github.twitch4j.chat.events.AbstractChannelMessageEvent;
 import com.github.twitch4j.chat.util.ChatCrowdChant;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
+import com.github.twitch4j.common.enums.HypeChatLevel;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import com.github.twitch4j.common.util.ChatReply;
@@ -13,12 +14,8 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.time.Duration;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -30,16 +27,6 @@ import java.util.Set;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class ChannelMessageEvent extends AbstractChannelMessageEvent {
-
-    /**
-     * @see <a href="https://dev.twitch.tv/docs/irc/tags/#privmsg-tags">Documentation</a>
-     */
-    private static final Map<String, Integer> HYPE_CHAT_LEVELS;
-
-    /**
-     * @see <a href="https://help.twitch.tv/s/article/hype-chat-by-twitch">Documentation</a>
-     */
-    private static final Duration[] HYPE_CHAT_DURATION;
 
     /**
      * Information regarding the parent message being replied to, if applicable.
@@ -157,51 +144,13 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
     }
 
     /**
-     * @return the level associated with the hype chat contribution (determines how long the paid message is pinned).
+     * @return the {@link HypeChatLevel} associated with the hype chat contribution.
      * @see #getElevatedChatPayment()
      */
-    public Optional<Integer> getHypeChatLevel() {
+    public Optional<HypeChatLevel> getHypeChatLevel() {
         return getMessageEvent()
             .getTagValue("pinned-chat-paid-level")
-            .map(HYPE_CHAT_LEVELS::get);
+            .map(HypeChatLevel.MAPPINGS::get);
     }
 
-    /**
-     * @return the amount of time this hype chat message is pinned to the top of chat.
-     * @see #getHypeChatLevel()
-     */
-    @ApiStatus.Experimental // in case twitch allows channels to modify the default durations
-    public Optional<Duration> getHypeChatPinDuration() {
-        return getHypeChatLevel()
-            .filter(i -> i >= 1 && i <= HYPE_CHAT_DURATION.length)
-            .map(i -> HYPE_CHAT_DURATION[i - 1]);
-    }
-
-    static {
-        Map<String, Integer> levels = new HashMap<>();
-        levels.put("ONE", 1);
-        levels.put("TWO", 2);
-        levels.put("THREE", 3);
-        levels.put("FOUR", 4);
-        levels.put("FIVE", 5);
-        levels.put("SIX", 6);
-        levels.put("SEVEN", 7);
-        levels.put("EIGHT", 8);
-        levels.put("NINE", 9);
-        levels.put("TEN", 10);
-        HYPE_CHAT_LEVELS = Collections.unmodifiableMap(levels);
-
-        HYPE_CHAT_DURATION = new Duration[] {
-            Duration.ofSeconds(30L),
-            Duration.ofSeconds(150L),
-            Duration.ofMinutes(5L),
-            Duration.ofMinutes(10L),
-            Duration.ofMinutes(30L),
-            Duration.ofHours(1L),
-            Duration.ofHours(2L),
-            Duration.ofHours(3L),
-            Duration.ofHours(4L),
-            Duration.ofHours(5L)
-        };
-    }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -13,8 +13,12 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -26,6 +30,16 @@ import java.util.Set;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class ChannelMessageEvent extends AbstractChannelMessageEvent {
+
+    /**
+     * @see <a href="https://dev.twitch.tv/docs/irc/tags/#privmsg-tags">Documentation</a>
+     */
+    private static final Map<String, Integer> HYPE_CHAT_LEVELS;
+
+    /**
+     * @see <a href="https://help.twitch.tv/s/article/hype-chat-by-twitch">Documentation</a>
+     */
+    private static final Duration[] HYPE_CHAT_DURATION;
 
     /**
      * Information regarding the parent message being replied to, if applicable.
@@ -108,11 +122,11 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
     }
 
     /**
-     * @return the payment amount for the user to elevate their chat message.
-     * @apiNote This method is unofficial since the experiment is not officially documented in the irc guide.
-     * @see <a href ="https://twitter.com/TwitchSupport/status/1575603152908427272">Twitch Announcement</a>
+     * Hype Chat Contribution
+     *
+     * @return the payment information related to this hype chat, if applicable.
+     * @see <a href ="https://blog.twitch.tv/en/2023/06/22/introducing-hype-chat-a-new-way-to-stand-out/">Twitch Announcement</a>
      */
-    @Unofficial
     public Optional<DonationAmount> getElevatedChatPayment() {
         final Map<String, CharSequence> tags = getMessageEvent().getEscapedTags();
 
@@ -142,4 +156,52 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
             });
     }
 
+    /**
+     * @return the level associated with the hype chat contribution (determines how long the paid message is pinned).
+     * @see #getElevatedChatPayment()
+     */
+    public Optional<Integer> getHypeChatLevel() {
+        return getMessageEvent()
+            .getTagValue("pinned-chat-paid-level")
+            .map(HYPE_CHAT_LEVELS::get);
+    }
+
+    /**
+     * @return the amount of time this hype chat message is pinned to the top of chat.
+     * @see #getHypeChatLevel()
+     */
+    @ApiStatus.Experimental // in case twitch allows channels to modify the default durations
+    public Optional<Duration> getHypeChatPinDuration() {
+        return getHypeChatLevel()
+            .filter(i -> i >= 1 && i <= HYPE_CHAT_DURATION.length)
+            .map(i -> HYPE_CHAT_DURATION[i - 1]);
+    }
+
+    static {
+        Map<String, Integer> levels = new HashMap<>();
+        levels.put("ONE", 1);
+        levels.put("TWO", 2);
+        levels.put("THREE", 3);
+        levels.put("FOUR", 4);
+        levels.put("FIVE", 5);
+        levels.put("SIX", 6);
+        levels.put("SEVEN", 7);
+        levels.put("EIGHT", 8);
+        levels.put("NINE", 9);
+        levels.put("TEN", 10);
+        HYPE_CHAT_LEVELS = Collections.unmodifiableMap(levels);
+
+        HYPE_CHAT_DURATION = new Duration[] {
+            Duration.ofSeconds(30L),
+            Duration.ofSeconds(150L),
+            Duration.ofMinutes(5L),
+            Duration.ofMinutes(10L),
+            Duration.ofMinutes(30L),
+            Duration.ofHours(1L),
+            Duration.ofHours(2L),
+            Duration.ofHours(3L),
+            Duration.ofHours(4L),
+            Duration.ofHours(5L)
+        };
+    }
 }

--- a/common/src/main/java/com/github/twitch4j/common/enums/HypeChatLevel.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/HypeChatLevel.java
@@ -1,0 +1,56 @@
+package com.github.twitch4j.common.enums;
+
+import com.github.twitch4j.util.EnumUtil;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * @see <a href="https://help.twitch.tv/s/article/hype-chat-by-twitch">Official Help Article</a>
+ */
+@RequiredArgsConstructor
+public enum HypeChatLevel {
+    ONE(Duration.ofSeconds(30L)),
+    TWO(Duration.ofSeconds(150L)),
+    THREE(Duration.ofMinutes(5L)),
+    FOUR(Duration.ofMinutes(10L)),
+    FIVE(Duration.ofMinutes(30L)),
+    SIX(Duration.ofHours(1L)),
+    SEVEN(Duration.ofHours(2L)),
+    EIGHT(Duration.ofHours(3L)),
+    NINE(Duration.ofHours(4L)),
+    TEN(Duration.ofHours(5L));
+
+    @ApiStatus.Internal
+    public static final Map<String, HypeChatLevel> MAPPINGS = EnumUtil.buildMapping(values());
+
+    /**
+     * The amount of time the message is pinned to the top of chat.
+     */
+    @Getter
+    private final Duration pinDuration;
+
+    /**
+     * @return the level in integer form.
+     */
+    public int getLevel() {
+        return this.ordinal() + 1;
+    }
+
+    /**
+     * @return the maximum number of characters that can be in a hype chat contribution at this level.
+     */
+    public int getCharacterLimit() {
+        return getLevel() * 50;
+    }
+
+    /**
+     * @return whether the Hype Chat contribution has a colored gradient.
+     */
+    public boolean hasGradient() {
+        return this.ordinal() >= SIX.ordinal();
+    }
+}

--- a/common/src/main/java/com/github/twitch4j/common/enums/HypeChatLevel.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/HypeChatLevel.java
@@ -41,14 +41,14 @@ public enum HypeChatLevel {
     }
 
     /**
-     * @return the maximum number of characters that can be in a hype chat contribution at this level.
+     * @return the maximum number of characters that can be in a hype chat message at this level.
      */
     public int getCharacterLimit() {
         return getLevel() * 50;
     }
 
     /**
-     * @return whether the Hype Chat contribution has a colored gradient.
+     * @return whether the Hype Chat contribution has a colored gradient in the official chat interface.
      */
     public boolean hasGradient() {
         return this.ordinal() >= SIX.ordinal();


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Remove `@Unofficial` from `ChannelMessageEvent#getElevatedChatPayment`
* Add `ChannelMessageEvent#getHypeChatLevel`

### Additional Information
2023-07-19 changelog entry https://dev.twitch.tv/docs/change-log/
