### PR TITLE
chore: project version build constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,13 +41,6 @@ local.properties
 !gradle/wrapper/*.jar
 gradle.properties
 
-# Logs / Save Files
-config/*
-client.log
-
-# Example Code
-src/*/java/twitch4j/example/*
-
 # Modules
 /modules/
 
@@ -58,5 +51,5 @@ src/*/java/twitch4j/example/*
 docs/
 
 # Pipeline
-dist/*
-tmp/*
+.dist/*
+.tmp/*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import io.freefair.gradle.plugins.lombok.LombokExtension
 import io.freefair.gradle.plugins.lombok.tasks.Delombok
 import me.champeau.jmh.JmhParameters
 
-// Plugins
 plugins {
 	signing
 	`java-library`
@@ -13,12 +12,12 @@ plugins {
 	id("com.coditory.manifest").version("0.2.6").apply(false)
 	id("me.champeau.jmh").version("0.7.1").apply(false)
 	id("com.github.johnrengelman.shadow").version("8.1.1").apply(false)
+	id("com.github.gmazzo.buildconfig").version("4.1.2").apply(false)
 }
 
 group = group
 version = version
 
-// Allprojects
 allprojects {
 	repositories {
 		mavenCentral()

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -39,12 +39,6 @@ project.extensions.getByType(BuildConfigExtension::class.java).apply {
 	}
 }
 
-sourceSets {
-	main {
-		java.srcDir("build/generated/sources/buildConfig/main")
-	}
-}
-
 tasks.javadoc {
 	options {
 		title = "Twitch4J (v${version}) - Common Module API"

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,4 +1,9 @@
-// In this section you declare the dependencies for your production and test code
+import com.github.gmazzo.gradle.plugins.BuildConfigExtension
+
+plugins {
+	id("com.github.gmazzo.buildconfig")
+}
+
 dependencies {
 	// Event Manager
 	api(group = "com.github.philippheuer.events4j", name = "events4j-core")
@@ -19,6 +24,25 @@ dependencies {
 	// Twitch4J Modules
 	api(project(":twitch4j-auth"))
 	api(project(":twitch4j-util"))
+}
+
+project.extensions.getByType(BuildConfigExtension::class.java).apply {
+	packageName("com.github.twitch4j.common.config")
+	className("Twitch4JBuildConstants")
+
+	useJavaOutput {
+		defaultVisibility = true // this removes the public modifier from the generated class
+	}
+
+	forClass(packageName = "com.github.twitch4j.common.config", className = "Twitch4JBuildConstants") {
+		buildConfigField("String", "VERSION", provider { "\"${project.version}\"" })
+	}
+}
+
+sourceSets {
+	main {
+		java.srcDir("build/generated/sources/buildConfig/main")
+	}
 }
 
 tasks.javadoc {

--- a/common/build/generated/sources/buildConfig/main/com/github/twitch4j/common/config/Twitch4JBuildConstants.java
+++ b/common/build/generated/sources/buildConfig/main/com/github/twitch4j/common/config/Twitch4JBuildConstants.java
@@ -1,0 +1,10 @@
+package com.github.twitch4j.common.config;
+
+import java.lang.String;
+
+final class Twitch4JBuildConstants {
+  public static final String VERSION = "0.0.0";
+
+  private Twitch4JBuildConstants() {
+  }
+}

--- a/common/src/main/java/com/github/twitch4j/common/config/Twitch4JGlobal.java
+++ b/common/src/main/java/com/github/twitch4j/common/config/Twitch4JGlobal.java
@@ -14,7 +14,9 @@ public class Twitch4JGlobal {
 
     /**
      * Default UserAgent
+     * <p>
+     * NOTE: The Twitch4JBuildConstants class is generated / updated during the build process.
      */
-    public static String userAgent = "Twitch4J/1.2.0";
+    public static String userAgent = "Twitch4J/" + Twitch4JBuildConstants.VERSION;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

Uses a gradle plugin to generate a class with build constants (project-version). This will ensure that the userAgent header will always report the proper version in the future.

### Additional Information

i added the generated class with `0.0.0` as placeholder to ensure no errors show up when checking the project out pre-build.
