### PR TITLE
fix: npe when parsing global user state in channelName lookup

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -134,7 +134,7 @@ public class IRCMessageEvent extends TwitchEvent {
         // set channel id and name from tags or cache
         if (channelName == null) {
             this.channelId = getRawTagString("room-id");
-            this.channelName = channelIdToChannelName.get(channelId);
+            this.channelName = channelId == null ? null : channelIdToChannelName.get(channelId);
         } else {
             this.channelId = channelNameToChannelId.get(channelName);
             if (channelId == null) {

--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @UtilityClass
 public class MessageParser {
@@ -20,7 +21,7 @@ public class MessageParser {
     @Nullable
     @VisibleForTesting
     public IRCMessageEvent parse(@NotNull String rawMessage) {
-        return parse(rawMessage, Collections.emptyMap(), Collections.emptyMap(), null);
+        return parse(rawMessage, new ConcurrentHashMap<>(0), new ConcurrentHashMap<>(0), null);
     }
 
     @Nullable


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* null-check on channelId before channel name lookup
* use `ConcurrentHashMap` in parse test-cases to ensure identical behavior

### Additional Information

Our test case didn't catch this because `Collections.emptyMap` allows null-key lookups while the `ConcurrentHashMap` used in the real code doesn't / throws a NPE.
