### PR TITLE
update createStreamScheduleSegment documentation

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2196,7 +2196,7 @@ public interface TwitchHelix {
      *
      * @param authToken     User OAuth Token of the broadcaster (scope: "channel:manage:schedule").
      * @param broadcasterId User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
-     * @param segment       Properties of the scheduled broadcast (required: start_time, timezone, is_recurring).
+     * @param segment       Properties of the scheduled broadcast (required: start_time, timezone, duration).
      * @return StreamScheduleResponse
      */
     @RequestLine("POST /schedule/segment?broadcaster_id={broadcaster_id}")


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

...

### Changes Proposed

* Change `is_recurring` to `duration` in the list of required properties to create a scheduled broadcast

...

### Additional Information

`is_recurring` is not a required value to the [Twitch Helix API](https://dev.twitch.tv/docs/api/reference/#create-channel-stream-schedule-segment), but `duration` is. Attempting to call `createStreamScheduleSegment` without `duration` results with the Helix API error `[3:responseBody={"error":"Bad Request","status":400,"message":"Missing required parameter \"duration\""}]`.