### PR TITLE
perf: split irc messages more efficiently

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -541,8 +541,8 @@ public class TwitchChat implements ITwitchChat {
     }
 
     protected void onTextMessage(String text) {
-        Arrays.asList(StringUtils.split(text.replace("\r\n", "\n"), '\n'))
-            .forEach(message -> {
+        MessageParser.consumeLines(text,
+            message -> {
                 if (!message.equals("")) {
                     // Handle messages
                     log.trace("Received WebSocketMessage: " + message);

--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -132,21 +132,18 @@ public class MessageParser {
 
     @ApiStatus.Internal
     public void consumeLines(@NotNull String source, @NotNull Consumer<String> consumer) {
+        int len = source.length();
         int start = 0;
         int i;
-        while (true) {
-            i = source.indexOf('\n', start);
-            if (i < 0) {
-                if (start < source.length()) {
-                    consumer.accept(source.substring(start));
-                }
-                break;
-            } else {
-                boolean carriage = i > 0 && source.charAt(i - 1) == '\r';
-                consumer.accept(source.substring(start, carriage ? i - 1 : i));
-                start = i + 1;
-            }
+
+        while ((i = source.indexOf('\n', start)) >= 0) {
+            boolean carriage = i > 0 && source.charAt(i - 1) == '\r';
+            consumer.accept(source.substring(start, carriage ? i - 1 : i));
+            start = i + 1;
+        }
+
+        if (start < len) {
+            consumer.accept(source.substring(start));
         }
     }
-
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 @UtilityClass
 public class MessageParser {
@@ -127,6 +128,25 @@ public class MessageParser {
             value = tag.subSequence(delim + 1, tag.length());
         }
         tags.put(key.toString(), value);
+    }
+
+    @ApiStatus.Internal
+    public void consumeLines(@NotNull String source, @NotNull Consumer<String> consumer) {
+        int start = 0;
+        int i;
+        while (true) {
+            i = source.indexOf('\n', start);
+            if (i < 0) {
+                if (start < source.length()) {
+                    consumer.accept(source.substring(start));
+                }
+                break;
+            } else {
+                boolean carriage = i > 0 && source.charAt(i - 1) == '\r';
+                consumer.accept(source.substring(start, carriage ? i - 1 : i));
+                start = i + 1;
+            }
+        }
     }
 
 }

--- a/chat/src/test/java/com/github/twitch4j/chat/util/MessageParserTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/util/MessageParserTest.java
@@ -1,0 +1,45 @@
+package com.github.twitch4j.chat.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MessageParserTest {
+
+    @Test
+    void consumeLines() {
+        assertEquals(singletonList("hello"), split("hello"));
+        assertEquals(singletonList("hello "), split("hello "));
+        assertEquals(singletonList("hello"), split("hello\n"));
+        assertEquals(asList("hello", ""), split("hello\n\n"));
+        assertEquals(singletonList("hello "), split("hello \n"));
+        assertEquals(asList("hello ", " "), split("hello \n "));
+        assertEquals(singletonList("hello"), split("hello\r\n"));
+        assertEquals(asList("hello", ""), split("hello\r\n\r\n"));
+        assertEquals(singletonList("hello "), split("hello \r\n"));
+        assertEquals(asList("hello ", " "), split("hello \r\n "));
+
+        assertEquals(singletonList("hello world"), split("hello world"));
+        assertEquals(asList("hello", "world"), split("hello\nworld"));
+        assertEquals(asList("hello", "world"), split("hello\r\nworld"));
+        assertEquals(asList("hello", "world"), split("hello\r\nworld\n"));
+        assertEquals(asList("hello", "world"), split("hello\r\nworld\r\n"));
+        assertEquals(asList("hello", "world", "foo"), split("hello\r\nworld\r\nfoo"));
+        assertEquals(asList("hello", "world", "foo"), split("hello\r\nworld\r\nfoo\n"));
+        assertEquals(asList("hello", "world", "foo", "bar"), split("hello\r\nworld\r\nfoo\nbar"));
+        assertEquals(asList("hello", "world", "foo", "bar"), split("hello\r\nworld\r\nfoo\nbar\r\n"));
+        assertEquals(asList("hello", "world", "foo", "bar", "baz\r"), split("hello\r\nworld\r\nfoo\nbar\r\nbaz\r"));
+    }
+
+    private static List<String> split(String input) {
+        List<String> lines = new ArrayList<>();
+        MessageParser.consumeLines(input, lines::add);
+        return lines;
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Reduce string/array allocations in `TwitchChat#onTextMessage(String)` via `MessageParser.consumeLines`
