### PR TITLE
chore: limit shadowJar publication to twitch4j, chat, helix, pubsub, eventsub-websocket

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,6 @@ subprojects {
 	apply(plugin = "maven-publish")
 	apply(plugin = "io.freefair.lombok")
 	apply(plugin = "me.champeau.jmh")
-	apply(plugin = "com.github.johnrengelman.shadow")
 
 	if (enableManifest) {
 		apply(plugin = "com.coditory.manifest")

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -1,4 +1,7 @@
-// In this section you declare the dependencies for your production and test code
+plugins {
+	id("com.github.johnrengelman.shadow")
+}
+
 dependencies {
 	// Rate Limiting
 	api(group = "com.bucket4j", name = "bucket4j_jdk8-core")

--- a/client-websocket/build.gradle.kts
+++ b/client-websocket/build.gradle.kts
@@ -1,4 +1,3 @@
-// In this section you declare the dependencies for your production and test code
 dependencies {
 	// Common
 	api(project(":twitch4j-util"))

--- a/eventsub-common/build.gradle.kts
+++ b/eventsub-common/build.gradle.kts
@@ -1,4 +1,3 @@
-// In this section you declare the dependencies for your production and test code
 dependencies {
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")

--- a/eventsub-websocket/build.gradle.kts
+++ b/eventsub-websocket/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+	id("com.github.johnrengelman.shadow")
+}
+
 dependencies {
 	// Twitch4J Modules
 	api(project(":twitch4j-eventsub-common"))

--- a/pubsub/build.gradle.kts
+++ b/pubsub/build.gradle.kts
@@ -1,4 +1,7 @@
-// In this section you declare the dependencies for your production and test code
+plugins {
+	id("com.github.johnrengelman.shadow")
+}
+
 dependencies {
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")

--- a/rest-extensions/build.gradle.kts
+++ b/rest-extensions/build.gradle.kts
@@ -1,4 +1,3 @@
-// In this section you declare the dependencies for your production and test code
 dependencies {
 	// HTTP Client
 	api(group = "io.github.openfeign", name = "feign-okhttp")

--- a/rest-helix/build.gradle.kts
+++ b/rest-helix/build.gradle.kts
@@ -1,4 +1,7 @@
-// In this section you declare the dependencies for your production and test code
+plugins {
+	id("com.github.johnrengelman.shadow")
+}
+
 dependencies {
 	// HTTP Client
 	api(group = "io.github.openfeign", name = "feign-okhttp")

--- a/rest-kraken/build.gradle.kts
+++ b/rest-kraken/build.gradle.kts
@@ -1,4 +1,3 @@
-// In this section you declare the dependencies for your production and test code
 dependencies {
 	// HTTP Client
 	api(group = "io.github.openfeign", name = "feign-okhttp")

--- a/rest-tmi/build.gradle.kts
+++ b/rest-tmi/build.gradle.kts
@@ -1,4 +1,3 @@
-// In this section you declare the dependencies for your production and test code
 dependencies {
 	// HTTP Client
 	api(group = "io.github.openfeign", name = "feign-okhttp")

--- a/twitch4j/build.gradle.kts
+++ b/twitch4j/build.gradle.kts
@@ -1,4 +1,7 @@
-// In this section you declare the dependencies for your production and test code
+plugins {
+	id("com.github.johnrengelman.shadow")
+}
+
 dependencies {
 	// Twitch4J Modules
 	val thatProject = project


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

Publishing shaded jars for `common`, `auth`, ... or some of the deprecated modules is not needed.
This limits the publication of shaded jars to the following modules:

- twitch4j
- chat
- helix
- pubsub
- eventsub-websocket
