### PR TITLE
fix: avoid eventsocket relocation for module shadow jar

### DIFF
--- a/eventsub-websocket/build.gradle.kts
+++ b/eventsub-websocket/build.gradle.kts
@@ -5,6 +5,13 @@ dependencies {
 	api(project(":twitch4j-client-websocket"))
 }
 
+tasks.withType<Jar> {
+	if (this is com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+		// Avoid com.github.twitch4j.eventsub.socket relocation due to eventsub-common being relocated
+		relocate("com.github.twitch4j.eventsub.socket", "com.github.twitch4j.eventsub.socket")
+	}
+}
+
 tasks.javadoc {
 	options {
 		title = "Twitch4J (v${version}) - EventSub WebSocket Module"

--- a/eventsub-websocket/build.gradle.kts
+++ b/eventsub-websocket/build.gradle.kts
@@ -5,11 +5,9 @@ dependencies {
 	api(project(":twitch4j-client-websocket"))
 }
 
-tasks.withType<Jar> {
-	if (this is com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-		// Avoid com.github.twitch4j.eventsub.socket relocation due to eventsub-common being relocated
-		relocate("com.github.twitch4j.eventsub.socket", "com.github.twitch4j.eventsub.socket")
-	}
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+	// Avoid com.github.twitch4j.eventsub.socket relocation due to eventsub-common being relocated
+	relocate("com.github.twitch4j.eventsub.socket", "com.github.twitch4j.eventsub.socket")
 }
 
 tasks.javadoc {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `:twitch4j-eventsub-websocket:shadowJar` produces a jar where the `com.github.twitch4j.eventsub.socket` package is relocated

### Changes Proposed
* Relocate `com.github.twitch4j.eventsub.socket` to itself, so the package is not moved to the shaded packaged when building the module-specific shadow jar

### Additional Information
`relocate(...) { exclude(...) }` approach did not work, so this trick is used instead
