### PR TITLE
fix(clienthelper): reflect name changes in live events

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientHelper.java
@@ -201,9 +201,10 @@ public class TwitchClientHelper implements IClientHelper {
                         return;
 
                     ChannelCache currentChannelCache = channelInformation.computeIfAbsent(userId, s -> new ChannelCache());
-                    // Disabled name updates while Helix returns display name https://github.com/twitchdev/issues/issues/3
-                    if (stream != null && currentChannelCache.getUserName() == null)
-                        currentChannelCache.setUserName(stream.getUserName());
+                    if (stream != null) {
+                        // gracefully support name changes
+                        currentChannelCache.setUserName(stream.getUserLogin());
+                    }
                     final EventChannel channel = new EventChannel(userId, currentChannelCache.getUserName());
 
                     boolean dispatchGoLiveEvent = false;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Use the latest broadcaster login name in `ChannelGoLiveEvent`, `ChannelGoOfflineEvent`, `ChannelChangeTitleEvent`, `ChannelChangeGameEvent`, `ChannelViewerCountUpdateEvent` (in case the broadcaster changes their username while the application is running)

### Additional Information
* `Stream#getUserLogin` did not exist when this conditional branch was originally written
* Same exact change cannot be made for clips / follow events since broadcaster login name is not exposed by Twitch in these endpoints
* If user has client helper running stream listener for a channel alongside follow/clips listener, updated username *will* also apply to follow/clip events
