### PR TITLE
feat(pubsub): add ban sharing settings update event

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -16,6 +16,7 @@ import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.AliasRestrictionUpdateData;
 import com.github.twitch4j.pubsub.domain.AutomodCaughtMessageData;
 import com.github.twitch4j.pubsub.domain.AutomodLevelsModified;
+import com.github.twitch4j.pubsub.domain.BanSharingSettings;
 import com.github.twitch4j.pubsub.domain.BannedTermAdded;
 import com.github.twitch4j.pubsub.domain.BannedTermRemoved;
 import com.github.twitch4j.pubsub.domain.BitsBadgeData;
@@ -74,6 +75,7 @@ import com.github.twitch4j.pubsub.enums.PubSubType;
 import com.github.twitch4j.pubsub.events.AliasRestrictionUpdateEvent;
 import com.github.twitch4j.pubsub.events.AutomodCaughtMessageEvent;
 import com.github.twitch4j.pubsub.events.AutomodLevelsModifiedEvent;
+import com.github.twitch4j.pubsub.events.BanSharingSettingsUpdateEvent;
 import com.github.twitch4j.pubsub.events.BitsLeaderboardEvent;
 import com.github.twitch4j.pubsub.events.ChannelBitsBadgeUnlockEvent;
 import com.github.twitch4j.pubsub.events.ChannelBitsEvent;
@@ -157,7 +159,6 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -792,6 +793,8 @@ public class TwitchPubSub implements ITwitchPubSub {
                         eventManager.publish(new LowTrustUserNewMessageEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserNewMessage.class)));
                     } else if ("low_trust_user_treatment_update".equals(type)) {
                         eventManager.publish(new LowTrustUserTreatmentUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserTreatmentUpdate.class)));
+                    } else if ("bans_sharing_settings_update".equals(type)) {
+                        eventManager.publish(new BanSharingSettingsUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, BanSharingSettings.class)));
                     } else {
                         log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
                     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/BanSharingPermissions.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/BanSharingPermissions.java
@@ -1,0 +1,29 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Determines whether various types of users can request the broadcaster to share their bans.
+ */
+@Data
+@Accessors(fluent = true)
+@Setter(AccessLevel.PRIVATE)
+public class BanSharingPermissions {
+
+    @JsonProperty("ALL")
+    private Boolean canEveryoneRequestAccess;
+
+    @JsonProperty("AFFILIATES")
+    private Boolean canAffiliatesRequestAccess;
+
+    @JsonProperty("PARTNERS")
+    private Boolean canPartnersRequestAccess;
+
+    @JsonProperty("MUTUAL_FOLLOWERS")
+    private Boolean canMutualFollowersRequestAccess;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/BanSharingSettings.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/BanSharingSettings.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.common.annotation.Unofficial;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Unofficial // not present in official pubsub docs
+public class BanSharingSettings {
+
+    /**
+     * Broadcaster User ID.
+     */
+    private String channelId;
+
+    /**
+     * Whether ban sharing is enabled.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_enabled")
+    private Boolean isEnabled;
+
+    /**
+     * The low trust treatment (e.g., restricted, monitored) to be applied
+     * when a user is banned in a channel that shares their bans with this broadcaster.
+     */
+    private LowTrustUserTreatment sharedBansUserTreatment;
+
+    /**
+     * The permissions that dictate what types of channels can request this broadcaster's bans.
+     */
+    private BanSharingPermissions sharingPermissions;
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/BanSharingSettingsUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/BanSharingSettingsUpdateEvent.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.BanSharingSettings;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+/**
+ * Fired when a channel changes their ban sharing settings.
+ * <p>
+ * This includes changing the low trust treatment that is applied to users with shared bans,
+ * or changing which types of users can request the broadcaster to share their bans.
+ * <p>
+ * Requires {@link com.github.twitch4j.pubsub.ITwitchPubSub#listenForLowTrustUsersEvents(OAuth2Credential, String, String)}.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class BanSharingSettingsUpdateEvent extends TwitchEvent {
+    String moderatorId;
+    String channelId;
+    BanSharingSettings data;
+}

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/BanSharingSettingsTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/BanSharingSettingsTest.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BanSharingSettingsTest {
+
+    @Test
+    void deserialize() {
+        String json = "{\"channel_id\":\"1337\",\"is_enabled\":true,\"shared_bans_user_treatment\":\"ACTIVE_MONITORING\"," +
+            "\"sharing_permissions\":{\"AFFILIATES\":false,\"ALL\":false,\"MUTUAL_FOLLOWERS\":true,\"PARTNERS\":true}}";
+
+        BanSharingSettings settings = TypeConvert.jsonToObject(json, BanSharingSettings.class);
+        assertNotNull(settings);
+        assertTrue(settings.isEnabled());
+        assertEquals("1337", settings.getChannelId());
+        assertEquals(LowTrustUserTreatment.ACTIVE_MONITORING, settings.getSharedBansUserTreatment());
+
+        BanSharingPermissions perms = settings.getSharingPermissions();
+        assertNotNull(perms);
+        assertFalse(perms.canEveryoneRequestAccess());
+        assertFalse(perms.canAffiliatesRequestAccess());
+        assertTrue(perms.canPartnersRequestAccess());
+        assertTrue(perms.canMutualFollowersRequestAccess());
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `Unparsable Message: MESSAGE|PubSubResponsePayload(topic=low-trust-users.modId.chanId,message=PubSubResponsePayloadMessage(type=bans_sharing_settings_update,...`

### Changes Proposed
* Fire `BanSharingSettingsUpdateEvent`

### Additional Information
Relevant first-party interfaces

![image](https://github.com/twitch4j/twitch4j/assets/8106344/5c72fc10-f924-4cdd-bbac-210396f2eb3f)

![image](https://github.com/twitch4j/twitch4j/assets/8106344/ba9aaa94-8e4b-4be5-9b6d-9297975b8142)
