### PR TITLE
feat: include top level parent information in ChatReply

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ReplyableEvent.java
@@ -2,7 +2,6 @@ package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.ITwitchChat;
 import com.github.twitch4j.common.events.domain.EventChannel;
-import com.github.twitch4j.common.util.ChatReply;
 import com.github.twitch4j.common.util.CryptoUtils;
 
 @FunctionalInterface
@@ -21,9 +20,7 @@ public interface ReplyableEvent {
      * @param message the message to be sent.
      */
     default void reply(ITwitchChat chat, String message) {
-        String replyId = getMessageEvent().getTagValue(ChatReply.REPLY_MSG_ID_TAG_NAME)
-            .orElseGet(() -> getMessageEvent().getMessageId().orElse(null));
-        chat.sendMessage(getChannel().getName(), message, CryptoUtils.generateNonce(32), replyId);
+        chat.sendMessage(getChannel().getName(), message, CryptoUtils.generateNonce(32), getMessageEvent().getMessageId().orElse(null));
     }
 
 }

--- a/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/ChatReply.java
@@ -18,30 +18,40 @@ public class ChatReply {
     public static final String REPLY_MSG_ID_TAG_NAME = "reply-parent-msg-id";
 
     /**
-     * The msgId of the original message being replied to.
+     * An ID that uniquely identifies the direct parent message that this message is replying to.
      */
     @NonNull
     String messageId;
 
     /**
-     * The text of the original message being replied to.
+     * The text of the direct parent message.
      */
     String messageBody;
 
     /**
-     * The id of the user who originally sent the message being replied to.
+     * An ID that identifies the sender of the direct parent message.
      */
     String userId;
 
     /**
-     * The login name of the user who originally sent the message being replied to.
+     * The login name of the sender of the direct parent message.
      */
     String userLogin;
 
     /**
-     * The display name of the user who originally sent the message being replied to.
+     * The display name of the sender of the direct parent message.
      */
     String displayName;
+
+    /**
+     * An ID that uniquely identifies the top-level parent message of the reply thread that this message is replying to.
+     */
+    String threadMessageId;
+
+    /**
+     * The login name of the sender of the top-level parent message.
+     */
+    String threadUserLogin;
 
     /**
      * Attempts to parse a {@link ChatReply} instance from chat tags.
@@ -60,7 +70,9 @@ public class ChatReply {
             unescapeTagValue(tags.get("reply-parent-msg-body")),
             Objects.toString(tags.get("reply-parent-user-id"), null),
             Objects.toString(tags.get("reply-parent-user-login"), null),
-            unescapeTagValue(tags.get("reply-parent-display-name"))
+            unescapeTagValue(tags.get("reply-parent-display-name")),
+            Objects.toString(tags.get("reply-thread-parent-msg-id"), null),
+            Objects.toString(tags.get("reply-thread-parent-user-login"), null)
         );
     }
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Include `reply-thread-parent-msg-id` & `reply-thread-parent-user-login` in `ChatReply` (now officially documented)
* Revert #785

### Additional Information
Twitch updated their chat reply logic, so replying directly to a message doesn't break threads anymore: https://twitter.com/TwitchSupport/status/1687193841240059905 
