### PR TITLE
perf: utilize char array over string in irc parser

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/MessageParser.java
@@ -28,7 +28,7 @@ public class MessageParser {
 
     @Nullable
     @ApiStatus.Internal
-    public IRCMessageEvent parse(String raw, @NotNull Map<String, String> channelIdToChannelName, @NotNull Map<String, String> channelNameToChannelId, @Nullable Collection<String> botOwnerIds) {
+    public IRCMessageEvent parse(@NotNull String raw, @NotNull Map<String, String> channelIdToChannelName, @NotNull Map<String, String> channelNameToChannelId, @Nullable Collection<String> botOwnerIds) {
         final int len = raw.length();
         if (len == 0) return null;
         final char[] chars = raw.toCharArray();


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* `String#toCharArray` on the full irc message was already being done in `MessageParser.parseTags` - we move this call into `MessageParser.parse` so the array can be used for more efficient character lookups instead of using `String#charAt` (which has greater overhead from range checks and utf byte conversion)
* Remove benchmark for deprecated tag parsing method

### Additional Information

Achieves 12% speed-up on my machine:

#### Before

```
Benchmark                               Mode  Cnt  Score   Error  Units
MessageParserBenchmark.parse1kMessages  avgt    4  1.708 ± 0.085  us/op
MessageParserBenchmark.parse1kTags      avgt    4  0.987 ± 0.061  us/op
```

#### After

```
Benchmark                               Mode  Cnt  Score   Error  Units
MessageParserBenchmark.parse1kMessages  avgt    4  1.501 ± 0.015  us/op
MessageParserBenchmark.parse1kTags      avgt    4  1.149 ± 0.018  us/op
```
