### PR TITLE
chore: override thumbnail resolution for processing videos

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Video.java
@@ -95,6 +95,12 @@ public class Video {
      * @return String
      */
     public String getThumbnailUrl(int width, int height) {
+        // https://github.com/twitchdev/issues/issues/822
+        if (thumbnailUrl.contains("_404/404_processing_")) {
+            width = 320;
+            height = 180;
+        }
+
         return StringUtils.replaceEach(
             this.getThumbnailUrl(),
             new String[] { "%{width}", "%{height}" },


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/822

### Changes Proposed
* Force 320x180 video thumbnail resolution if video is still processing to avoid users running into error 403
