### PR TITLE
feat(pubsub): parse whisper thread details

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/WhisperThread.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/WhisperThread.java
@@ -1,0 +1,36 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class WhisperThread {
+    @JsonProperty("id")
+    private String threadId;
+    private Long lastRead;
+    private Boolean archived;
+    private Boolean muted;
+    private SpamClassification spamInfo;
+    @JsonAlias("allowlisted_until")
+    @JsonProperty("whitelisted_until")
+    private Instant allowlistedUntil;
+
+    public String getOtherUserId() {
+        int delimIndex = threadId.indexOf('_');
+        if (delimIndex < 0) return null;
+        return threadId.substring(delimIndex + 1);
+    }
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class SpamClassification {
+        private String likelihood; // e.g., "low"
+        private Long lastMarkedNotSpam;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/WhisperThreadUpdateEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/WhisperThreadUpdateEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.WhisperThread;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class WhisperThreadUpdateEvent extends TwitchEvent {
+    String userId;
+    WhisperThread data;
+}

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/WhisperThreadTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/WhisperThreadTest.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class WhisperThreadTest {
+
+    @Test
+    void deserialize() {
+        String json = "{\"id\":\"53888434_268669435\",\"last_read\":13006,\"archived\":false,\"muted\":false," +
+            "\"spam_info\":{\"likelihood\":\"low\",\"last_marked_not_spam\":0}," +
+            "\"whitelisted_until\":\"2023-06-09T06:51:19Z\"}";
+        WhisperThread data = TypeConvert.jsonToObject(json, WhisperThread.class);
+        assertNotNull(data);
+        assertEquals(13006, data.getLastRead());
+        assertFalse(data.getArchived());
+        assertFalse(data.getMuted());
+        assertNotNull(data.getSpamInfo());
+        assertEquals("low", data.getSpamInfo().getLikelihood());
+        assertEquals(Instant.parse("2023-06-09T06:51:19Z"), data.getAllowlistedUntil());
+        assertEquals("268669435", data.getOtherUserId());
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
```
[com.github.twitch4j.pubsub.TwitchPubSub] Unparsable Message: MESSAGE|PubSubResponsePayload(topic=whispers.938512436, message=PubSubResponsePayloadMessage(type=thread, messageData=...
```

### Changes Proposed
* Fire `WhisperThreadUpdateEvent`
