### PR TITLE
docs: update old follow api decommission date

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelFollowType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelFollowType.java
@@ -10,7 +10,8 @@ import com.github.twitch4j.eventsub.events.ChannelFollowEvent;
  *
  * @see <a href="https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322">Deprecation Announcement</a>
  * @deprecated Without prior notice, Twitch has restricted this subscription to client_id's that were using it <i>on</i> 2023-02-17.
- * Furthermore, Twitch will shutdown this topic on 2023-08-03 in favor of {@link ChannelFollowTypeV2} (which has the same event data but more stringent auth).
+ * Furthermore, Twitch will shutdown this topic on <a href="https://discuss.dev.twitch.tv/t/legacy-follows-api-and-eventsub-shutdown-timeline-updated">2023-09-12</a>
+ * in favor of {@link ChannelFollowTypeV2} (which has the same event data but more stringent auth).
  */
 @Deprecated
 @SuppressWarnings("DeprecatedIsStillUsed")

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2683,7 +2683,8 @@ public interface TwitchHelix {
      * @return FollowList
      * @see <a href="https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322">Deprecation Announcement</a>
      * @deprecated Without prior notice, Twitch has restricted this endpoint to client_id's that were using it before 2023-02-18.
-     * Further, Twitch will shutdown this endpoint on 2023-08-03 in favor of {@link #getChannelFollowers(String, String, String, Integer, String)} and {@link #getFollowedChannels(String, String, String, Integer, String)}.
+     * Further, Twitch will shutdown this endpoint on <a href="https://discuss.dev.twitch.tv/t/legacy-follows-api-and-eventsub-shutdown-timeline-updated">2023-09-12</a>
+     * in favor of {@link #getChannelFollowers(String, String, String, Integer, String)} and {@link #getFollowedChannels(String, String, String, Integer, String)}.
      */
     @Deprecated
     @RequestLine("GET /users/follows?from_id={from_id}&to_id={to_id}&after={after}&first={first}")

--- a/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/IClientHelper.java
@@ -47,7 +47,7 @@ public interface IClientHelper extends AutoCloseable {
      * For {@link FollowEvent} to fire, defaultAuthToken must be a user access token from a moderator of the channel
      * with the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
      * Otherwise, the client helper can only fire {@link ChannelFollowCountUpdateEvent}
-     * due to Twitch restrictions implemented on 2023-08-03.
+     * due to Twitch restrictions implemented on 2023-09-12.
      *
      * @param channelId   Channel Id
      * @param channelName Channel Name
@@ -168,7 +168,7 @@ public interface IClientHelper extends AutoCloseable {
      * For {@link FollowEvent} to fire, defaultAuthToken must be a user access token from a moderator of the channel
      * with the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
      * Otherwise, the client helper can only fire {@link ChannelFollowCountUpdateEvent}
-     * due to Twitch restrictions implemented on 2023-08-03.
+     * due to Twitch restrictions implemented on 2023-09-12.
      *
      * @param channelName Channel Name
      */
@@ -193,7 +193,7 @@ public interface IClientHelper extends AutoCloseable {
      * For {@link FollowEvent} to fire, defaultAuthToken must be a user access token from a moderator of the channel
      * with the {@link com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_FOLLOWERS_READ} scope.
      * Otherwise, the client helper can only fire {@link ChannelFollowCountUpdateEvent}
-     * due to Twitch restrictions implemented on 2023-08-03.
+     * due to Twitch restrictions implemented on 2023-09-12.
      *
      * @param channelNames the channel names to be added
      */


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Update docs to reflect that old follows API decommission date was pushed back to 2023-09-12

### Additional Information
https://discuss.dev.twitch.tv/t/legacy-follows-api-and-eventsub-shutdown-timeline-updated
