### PR TITLE
feat(pubsub): add unofficial chat highlights topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -422,6 +422,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForChatHighlightEvents(OAuth2Credential credential, String userId, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "channel-chat-highlights." + userId + '.' + channelId);
+    }
+
+    @Unofficial
     default PubSubSubscription listenForPublicCheerEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-cheer-events-public-v1." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -90,6 +90,7 @@ import com.github.twitch4j.pubsub.events.ChannelUnbanRequestCreateEvent;
 import com.github.twitch4j.pubsub.events.ChannelUnbanRequestUpdateEvent;
 import com.github.twitch4j.pubsub.events.CharityCampaignDonationEvent;
 import com.github.twitch4j.pubsub.events.CharityCampaignStatusEvent;
+import com.github.twitch4j.pubsub.events.ChatHighlightEvent;
 import com.github.twitch4j.pubsub.events.ChatModerationEvent;
 import com.github.twitch4j.pubsub.events.CheerbombEvent;
 import com.github.twitch4j.pubsub.events.ClaimAvailableEvent;
@@ -847,6 +848,12 @@ public class TwitchPubSub implements ITwitchPubSub {
                     boolean hasId = topicName.endsWith("d");
                     VideoPlaybackData data = TypeConvert.jsonToObject(rawMessage, VideoPlaybackData.class);
                     eventManager.publish(new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
+                } else if ("channel-chat-highlights".equals(topicName)) {
+                    if ("chat-highlight".equals(type)) {
+                        eventManager.publish(TypeConvert.convertValue(msgData, ChatHighlightEvent.class));
+                    } else {
+                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                    }
                 } else if ("channel-unban-requests".equals(topicName) && topicParts.length == 3) {
                     String userId = topicParts[1];
                     String channelId = topicParts[2];

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatHighlight.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatHighlight.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ChatHighlight {
+    private String type;
+    private String sourceChannelId;
+    private Long secondsSinceEvent;
+
+    public boolean isRaider() {
+        return "raider".equalsIgnoreCase(type);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChatHighlightEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ChatHighlightEvent.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ChatHighlight;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Unofficial
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = false)
+public class ChatHighlightEvent extends TwitchEvent {
+    private String channelId;
+    private String userId;
+    private String msgId;
+    private Instant chatSentAt;
+    private Instant highlightsSentAt;
+    private List<ChatHighlight> highlights;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Support `channel-chat-highlights` unofficial pubsub topic

### Additional Information
Useful to distinguish which chatters came from a raid (or other highlights twitch may add)
