### PR TITLE
feat(pubsub): track midroll requests via unofficial ads topic

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -198,7 +198,6 @@ public interface ITwitchPubSub extends AutoCloseable {
      */
 
     @Unofficial
-    @Deprecated
     default PubSubSubscription listenForAdsEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "ads." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -50,6 +50,7 @@ import com.github.twitch4j.pubsub.domain.HypeTrainStart;
 import com.github.twitch4j.pubsub.domain.Leaderboard;
 import com.github.twitch4j.pubsub.domain.LowTrustUserNewMessage;
 import com.github.twitch4j.pubsub.domain.LowTrustUserTreatmentUpdate;
+import com.github.twitch4j.pubsub.domain.MidrollRequest;
 import com.github.twitch4j.pubsub.domain.ModeratorUnbanRequestAction;
 import com.github.twitch4j.pubsub.domain.PinnedChatData;
 import com.github.twitch4j.pubsub.domain.PointsSpent;
@@ -113,6 +114,7 @@ import com.github.twitch4j.pubsub.events.HypeTrainRewardsEvent;
 import com.github.twitch4j.pubsub.events.HypeTrainStartEvent;
 import com.github.twitch4j.pubsub.events.LowTrustUserNewMessageEvent;
 import com.github.twitch4j.pubsub.events.LowTrustUserTreatmentUpdateEvent;
+import com.github.twitch4j.pubsub.events.MidrollRequestEvent;
 import com.github.twitch4j.pubsub.events.ModUnbanRequestActionEvent;
 import com.github.twitch4j.pubsub.events.OnsiteNotificationCreationEvent;
 import com.github.twitch4j.pubsub.events.PinnedChatCreatedEvent;
@@ -471,6 +473,13 @@ public class TwitchPubSub implements ITwitchPubSub {
                     if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(type)) {
                         AutomodCaughtMessageData data = TypeConvert.convertValue(msgData, AutomodCaughtMessageData.class);
                         eventManager.publish(new AutomodCaughtMessageEvent(topicParts[2], data));
+                    } else {
+                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                    }
+                } else if ("ads".equals(topicName)) {
+                    if ("midroll_request".equals(type)) {
+                        MidrollRequest midroll = TypeConvert.convertValue(msgData, MidrollRequest.class);
+                        eventManager.publish(new MidrollRequestEvent(lastTopicIdentifier, midroll));
                     } else {
                         log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
                     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/MidrollRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/MidrollRequest.java
@@ -1,0 +1,17 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class MidrollRequest {
+    private String commercialId;
+    private Integer jitterBuckets;
+    private Long jitterTime;
+    private Long warmupTime;
+    private List<Double> weightedBuckets;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/MidrollRequestEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/MidrollRequestEvent.java
@@ -1,0 +1,13 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.MidrollRequest;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class MidrollRequestEvent extends TwitchEvent {
+    String channelId;
+    MidrollRequest data;
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Fire `MidrollRequestEvent` via unofficial `ads` pubsub topic
