### PR TITLE
perf(chat): lazily evaluate permissions in channel message event

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
@@ -37,11 +37,6 @@ public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent i
     private String message;
 
     /**
-     * Permissions of the user
-     */
-    private Set<CommandPermission> permissions;
-
-    /**
      * The exact number of months the user has been a subscriber, or zero if not subscribed
      */
     private int subscriberMonths;
@@ -58,14 +53,20 @@ public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent i
     @Getter(lazy = true)
     private final String nonce = getMessageEvent().getNonce().orElse(null);
 
-    public AbstractChannelMessageEvent(EventChannel channel, IRCMessageEvent messageEvent, EventUser user, String message, Set<CommandPermission> permissions) {
+    public AbstractChannelMessageEvent(EventChannel channel, IRCMessageEvent messageEvent, EventUser user, String message) {
         super(channel);
         this.messageEvent = messageEvent;
         this.user = user;
         this.message = message;
-        this.permissions = permissions;
         this.subscriberMonths = messageEvent.getSubscriberMonths().orElse(0);
         this.subscriptionTier = messageEvent.getSubscriptionTier().orElse(0);
+    }
+
+    /**
+     * Permissions of the user
+     */
+    public Set<CommandPermission> getPermissions() {
+        return messageEvent.getClientPermissions();
     }
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -121,11 +121,11 @@ public class IRCEventHandler {
                 // Dispatch Event
                 if (message.startsWith("\u0001ACTION ") && message.endsWith("\u0001")) {
                     // Action
-                    eventManager.publish(new ChannelMessageActionEvent(channel, event, user, message.substring(8, message.length() - 1), event.getClientPermissions()));
+                    eventManager.publish(new ChannelMessageActionEvent(channel, event, user, message.substring(8, message.length() - 1)));
                     return true;
                 } else {
                     // Regular Message
-                    eventManager.publish(new ChannelMessageEvent(channel, event, user, message, event.getClientPermissions()));
+                    eventManager.publish(new ChannelMessageEvent(channel, event, user, message));
                     return true;
                 }
             }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageActionEvent.java
@@ -1,11 +1,8 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelMessageEvent;
-import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
-
-import java.util.Set;
 
 /**
  * This event gets called when an action message (/me text) is received in a channel.
@@ -19,15 +16,14 @@ public class ChannelMessageActionEvent extends AbstractChannelMessageEvent {
      * @param messageEvent The raw message event
      * @param user         The user who triggered the event.
      * @param message      The plain text of the message.
-     * @param permissions  The permissions of the triggering user.
      */
     public ChannelMessageActionEvent(
         EventChannel channel,
         IRCMessageEvent messageEvent,
-        EventUser user, String message,
-        Set<CommandPermission> permissions
+        EventUser user,
+        String message
     ) {
-        super(channel, messageEvent, user, message, permissions);
+        super(channel, messageEvent, user, message);
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelMessageEvent.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.chat.events.channel;
 import com.github.twitch4j.chat.events.AbstractChannelMessageEvent;
 import com.github.twitch4j.chat.util.ChatCrowdChant;
 import com.github.twitch4j.common.annotation.Unofficial;
-import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.enums.HypeChatLevel;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -18,7 +17,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * This event gets called when a message is received in a channel.
@@ -53,15 +51,14 @@ public class ChannelMessageEvent extends AbstractChannelMessageEvent {
      * @param messageEvent The raw message event
      * @param user         The user who triggered the event.
      * @param message      The plain text of the message.
-     * @param permissions  The permissions of the triggering user.
      */
     public ChannelMessageEvent(
         EventChannel channel,
         IRCMessageEvent messageEvent,
-        EventUser user, String message,
-        Set<CommandPermission> permissions
+        EventUser user,
+        String message
     ) {
-        super(channel, messageEvent, user, message, permissions);
+        super(channel, messageEvent, user, message);
     }
 
     /**

--- a/kotlin/src/test/kotlin/com/github/twitch4j/kotlin/chat/ChatExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/com/github/twitch4j/kotlin/chat/ChatExtensionsTest.kt
@@ -176,7 +176,7 @@ class ChatExtensionsTest {
     private val testChannelJoinEvent1 = ChannelJoinEvent(testChannel1, testUser)
     private val testChannelJoinEvent2 = ChannelJoinEvent(testChannel2, testUser)
     private val testChannelMessageEvent1 =
-        ChannelMessageEvent(testChannel1, testIrcMessageEvent, testUser, "TestMessage", emptySet())
+        ChannelMessageEvent(testChannel1, testIrcMessageEvent, testUser, "TestMessage")
     private val testChannelMessageEvent2 =
-        ChannelMessageEvent(testChannel2, testIrcMessageEvent, testUser, "TestMessage", emptySet())
+        ChannelMessageEvent(testChannel2, testIrcMessageEvent, testUser, "TestMessage")
 }


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Avoid eagerly calling `IRCMessageEvent#getClientPermissions` for `ChannelMessageEvent`/`ChannelMessageActionEvent`

### Additional Information

`IRCMessageEvent#getClientPermissions` became lazily evaluated in #801
