### PR TITLE
refactor: move pubsub topic logic to separate handlers

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -1,160 +1,22 @@
 package com.github.twitch4j.pubsub;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.client.websocket.WebsocketConnection;
 import com.github.twitch4j.client.websocket.domain.WebsocketConnectionState;
 import com.github.twitch4j.common.config.ProxyConfig;
-import com.github.twitch4j.common.enums.CommandPermission;
-import com.github.twitch4j.common.events.domain.EventUser;
-import com.github.twitch4j.common.events.user.PrivateMessageEvent;
 import com.github.twitch4j.common.util.CryptoUtils;
 import com.github.twitch4j.common.util.TimeUtils;
-import com.github.twitch4j.common.util.TwitchUtils;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.domain.AliasRestrictionUpdateData;
-import com.github.twitch4j.pubsub.domain.AutomodCaughtMessageData;
-import com.github.twitch4j.pubsub.domain.AutomodLevelsModified;
-import com.github.twitch4j.pubsub.domain.BanSharingSettings;
-import com.github.twitch4j.pubsub.domain.BannedTermAdded;
-import com.github.twitch4j.pubsub.domain.BannedTermRemoved;
-import com.github.twitch4j.pubsub.domain.BitsBadgeData;
-import com.github.twitch4j.pubsub.domain.ChannelBitsData;
-import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
-import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
-import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
-import com.github.twitch4j.pubsub.domain.ChannelTermsAction;
-import com.github.twitch4j.pubsub.domain.CharityCampaignStatus;
-import com.github.twitch4j.pubsub.domain.CharityDonationData;
-import com.github.twitch4j.pubsub.domain.ChatModerationAction;
-import com.github.twitch4j.pubsub.domain.CheerbombData;
-import com.github.twitch4j.pubsub.domain.ClaimData;
-import com.github.twitch4j.pubsub.domain.CommerceData;
-import com.github.twitch4j.pubsub.domain.CommunityBoostProgression;
-import com.github.twitch4j.pubsub.domain.CommunityGoalContribution;
-import com.github.twitch4j.pubsub.domain.CreateNotificationData;
-import com.github.twitch4j.pubsub.domain.CreateShoutoutData;
-import com.github.twitch4j.pubsub.domain.CreatedUnbanRequest;
-import com.github.twitch4j.pubsub.domain.CreatorGoal;
-import com.github.twitch4j.pubsub.domain.DeletePinnedChatData;
-import com.github.twitch4j.pubsub.domain.FollowingData;
-import com.github.twitch4j.pubsub.domain.FriendshipData;
-import com.github.twitch4j.pubsub.domain.HypeLevelUp;
-import com.github.twitch4j.pubsub.domain.HypeProgression;
-import com.github.twitch4j.pubsub.domain.HypeTrainApproaching;
-import com.github.twitch4j.pubsub.domain.HypeTrainConductor;
-import com.github.twitch4j.pubsub.domain.HypeTrainEnd;
-import com.github.twitch4j.pubsub.domain.HypeTrainRewardsData;
-import com.github.twitch4j.pubsub.domain.HypeTrainStart;
-import com.github.twitch4j.pubsub.domain.Leaderboard;
-import com.github.twitch4j.pubsub.domain.LowTrustUserNewMessage;
-import com.github.twitch4j.pubsub.domain.LowTrustUserTreatmentUpdate;
-import com.github.twitch4j.pubsub.domain.MidrollRequest;
-import com.github.twitch4j.pubsub.domain.ModeratorUnbanRequestAction;
-import com.github.twitch4j.pubsub.domain.PinnedChatData;
-import com.github.twitch4j.pubsub.domain.PointsSpent;
-import com.github.twitch4j.pubsub.domain.PollData;
-import com.github.twitch4j.pubsub.domain.PresenceData;
-import com.github.twitch4j.pubsub.domain.PresenceSettings;
 import com.github.twitch4j.pubsub.domain.PubSubRequest;
 import com.github.twitch4j.pubsub.domain.PubSubResponse;
-import com.github.twitch4j.pubsub.domain.RadioData;
-import com.github.twitch4j.pubsub.domain.RedemptionProgress;
-import com.github.twitch4j.pubsub.domain.ScheduleUpdate;
-import com.github.twitch4j.pubsub.domain.ShieldModeSettings;
-import com.github.twitch4j.pubsub.domain.ShieldModeStatus;
-import com.github.twitch4j.pubsub.domain.SubGiftData;
-import com.github.twitch4j.pubsub.domain.SubscriptionData;
-import com.github.twitch4j.pubsub.domain.SupportActivityFeedData;
-import com.github.twitch4j.pubsub.domain.UpdateSummaryData;
-import com.github.twitch4j.pubsub.domain.UpdatedPinnedChatTiming;
-import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
-import com.github.twitch4j.pubsub.domain.UserAutomodCaughtMessage;
-import com.github.twitch4j.pubsub.domain.UserModerationActionData;
-import com.github.twitch4j.pubsub.domain.VideoPlaybackData;
-import com.github.twitch4j.pubsub.domain.WhisperThread;
+import com.github.twitch4j.pubsub.domain.PubSubResponsePayload;
 import com.github.twitch4j.pubsub.enums.PubSubType;
-import com.github.twitch4j.pubsub.events.AdsScheduleUpdateEvent;
-import com.github.twitch4j.pubsub.events.AliasRestrictionUpdateEvent;
-import com.github.twitch4j.pubsub.events.AutomodCaughtMessageEvent;
-import com.github.twitch4j.pubsub.events.AutomodLevelsModifiedEvent;
-import com.github.twitch4j.pubsub.events.BanSharingSettingsUpdateEvent;
-import com.github.twitch4j.pubsub.events.BitsLeaderboardEvent;
-import com.github.twitch4j.pubsub.events.ChannelBitsBadgeUnlockEvent;
-import com.github.twitch4j.pubsub.events.ChannelBitsEvent;
-import com.github.twitch4j.pubsub.events.ChannelCommerceEvent;
-import com.github.twitch4j.pubsub.events.ChannelSubGiftEvent;
-import com.github.twitch4j.pubsub.events.ChannelSubscribeEvent;
-import com.github.twitch4j.pubsub.events.ChannelTermsEvent;
-import com.github.twitch4j.pubsub.events.ChannelUnbanRequestCreateEvent;
-import com.github.twitch4j.pubsub.events.ChannelUnbanRequestUpdateEvent;
-import com.github.twitch4j.pubsub.events.CharityCampaignDonationEvent;
-import com.github.twitch4j.pubsub.events.CharityCampaignStatusEvent;
-import com.github.twitch4j.pubsub.events.ChatHighlightEvent;
-import com.github.twitch4j.pubsub.events.ChatModerationEvent;
-import com.github.twitch4j.pubsub.events.CheerbombEvent;
-import com.github.twitch4j.pubsub.events.ClaimAvailableEvent;
-import com.github.twitch4j.pubsub.events.ClaimClaimedEvent;
-import com.github.twitch4j.pubsub.events.CommunityBoostProgressionEvent;
-import com.github.twitch4j.pubsub.events.CommunityGoalContributionEvent;
-import com.github.twitch4j.pubsub.events.CreatorGoalEvent;
-import com.github.twitch4j.pubsub.events.CrowdChantCreatedEvent;
-import com.github.twitch4j.pubsub.events.CustomRewardCreatedEvent;
-import com.github.twitch4j.pubsub.events.CustomRewardDeletedEvent;
-import com.github.twitch4j.pubsub.events.CustomRewardUpdatedEvent;
-import com.github.twitch4j.pubsub.events.FollowingEvent;
-import com.github.twitch4j.pubsub.events.FriendshipEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainApproachingEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainConductorUpdateEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainCooldownExpirationEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainEndEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainLevelUpEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainProgressionEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainRewardsEvent;
-import com.github.twitch4j.pubsub.events.HypeTrainStartEvent;
-import com.github.twitch4j.pubsub.events.LowTrustUserNewMessageEvent;
-import com.github.twitch4j.pubsub.events.LowTrustUserTreatmentUpdateEvent;
-import com.github.twitch4j.pubsub.events.MidrollRequestEvent;
-import com.github.twitch4j.pubsub.events.ModUnbanRequestActionEvent;
-import com.github.twitch4j.pubsub.events.OnsiteNotificationCreationEvent;
-import com.github.twitch4j.pubsub.events.PinnedChatCreatedEvent;
-import com.github.twitch4j.pubsub.events.PinnedChatDeletedEvent;
-import com.github.twitch4j.pubsub.events.PinnedChatTimingUpdatedEvent;
-import com.github.twitch4j.pubsub.events.PointsEarnedEvent;
-import com.github.twitch4j.pubsub.events.PointsSpentEvent;
-import com.github.twitch4j.pubsub.events.PollsEvent;
-import com.github.twitch4j.pubsub.events.PredictionCreatedEvent;
-import com.github.twitch4j.pubsub.events.PredictionUpdatedEvent;
-import com.github.twitch4j.pubsub.events.PresenceSettingsEvent;
 import com.github.twitch4j.pubsub.events.PubSubAuthRevokeEvent;
 import com.github.twitch4j.pubsub.events.PubSubConnectionStateEvent;
 import com.github.twitch4j.pubsub.events.PubSubListenResponseEvent;
-import com.github.twitch4j.pubsub.events.RadioEvent;
-import com.github.twitch4j.pubsub.events.RaidCancelEvent;
-import com.github.twitch4j.pubsub.events.RaidGoEvent;
-import com.github.twitch4j.pubsub.events.RaidUpdateEvent;
-import com.github.twitch4j.pubsub.events.RedemptionStatusUpdateEvent;
-import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
-import com.github.twitch4j.pubsub.events.ShieldModeBannedTermAddedEvent;
-import com.github.twitch4j.pubsub.events.ShieldModeBannedTermRemovedEvent;
-import com.github.twitch4j.pubsub.events.ShieldModeSettingsUpdatedEvent;
-import com.github.twitch4j.pubsub.events.ShieldModeStatusUpdatedEvent;
-import com.github.twitch4j.pubsub.events.ShoutoutCreatedEvent;
-import com.github.twitch4j.pubsub.events.SubLeaderboardEvent;
-import com.github.twitch4j.pubsub.events.SupportActivityFeedEvent;
-import com.github.twitch4j.pubsub.events.UpdateOnsiteNotificationSummaryEvent;
-import com.github.twitch4j.pubsub.events.UpdateRedemptionFinishedEvent;
-import com.github.twitch4j.pubsub.events.UpdateRedemptionProgressEvent;
-import com.github.twitch4j.pubsub.events.UserAutomodCaughtMessageEvent;
-import com.github.twitch4j.pubsub.events.UserCommunityGoalContributionEvent;
-import com.github.twitch4j.pubsub.events.UserModerationActionEvent;
-import com.github.twitch4j.pubsub.events.UserPredictionMadeEvent;
-import com.github.twitch4j.pubsub.events.UserPredictionResultEvent;
-import com.github.twitch4j.pubsub.events.UserPresenceEvent;
-import com.github.twitch4j.pubsub.events.UserUnbanRequestUpdateEvent;
-import com.github.twitch4j.pubsub.events.VideoPlaybackEvent;
-import com.github.twitch4j.pubsub.events.WhisperThreadUpdateEvent;
+import com.github.twitch4j.pubsub.handlers.HandlerRegistry;
+import com.github.twitch4j.pubsub.handlers.TopicHandler;
 import com.github.twitch4j.util.IBackoffStrategy;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -162,7 +24,6 @@ import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -176,6 +37,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -267,6 +129,11 @@ public class TwitchPubSub implements ITwitchPubSub {
     private final Collection<String> botOwnerIds;
 
     /**
+     * Fallback Topic Handler
+     */
+    private final Consumer<PubSubResponsePayload> fallbackTopicHandler;
+
+    /**
      * Constructor
      *
      * @param websocketConnection       WebsocketConnection
@@ -277,11 +144,18 @@ public class TwitchPubSub implements ITwitchPubSub {
      * @param wsPingPeriod              WebSocket Ping Period
      * @param connectionBackoffStrategy WebSocket Connection Backoff Strategy
      * @param wsCloseDelay              Websocket Close Delay
+     * @param fallbackTopicHandler      Fallback Topic Handler
      */
-    public TwitchPubSub(WebsocketConnection websocketConnection, EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds, int wsPingPeriod, IBackoffStrategy connectionBackoffStrategy, int wsCloseDelay) {
+    public TwitchPubSub(WebsocketConnection websocketConnection, EventManager eventManager, ScheduledThreadPoolExecutor taskExecutor, ProxyConfig proxyConfig, Collection<String> botOwnerIds, int wsPingPeriod, IBackoffStrategy connectionBackoffStrategy, int wsCloseDelay, Consumer<PubSubResponsePayload> fallbackTopicHandler) {
         this.eventManager = eventManager;
         this.taskExecutor = taskExecutor;
         this.botOwnerIds = botOwnerIds;
+
+        if (fallbackTopicHandler != null) {
+            this.fallbackTopicHandler = fallbackTopicHandler;
+        } else {
+            this.fallbackTopicHandler = message -> log.warn("Unparsable Message: " + message.getTopic() + "|" + message.getMessage());
+        }
 
         // init connection
         if (websocketConnection == null) {
@@ -431,463 +305,21 @@ public class TwitchPubSub implements ITwitchPubSub {
                 String rawMessage = message.getData().getMessage().getRawMessage();
 
                 // Handle Messages
-                if ("channel-bits-events-v2".equals(topicName)) {
-                    eventManager.publish(new ChannelBitsEvent(TypeConvert.convertValue(msgData, ChannelBitsData.class)));
-                } else if ("channel-bits-badge-unlocks".equals(topicName)) {
-                    eventManager.publish(new ChannelBitsBadgeUnlockEvent(TypeConvert.jsonToObject(rawMessage, BitsBadgeData.class)));
-                } else if ("channel-subscribe-events-v1".equals(topicName)) {
-                    eventManager.publish(new ChannelSubscribeEvent(TypeConvert.jsonToObject(rawMessage, SubscriptionData.class)));
-                } else if ("channel-commerce-events-v1".equals(topicName)) {
-                    eventManager.publish(new ChannelCommerceEvent(TypeConvert.jsonToObject(rawMessage, CommerceData.class)));
-                } else if ("whispers".equals(topicName)) {
-                    // Whisper data is escaped Json cast into a String
-                    JsonNode msgDataParsed = TypeConvert.jsonToObject(msgData.asText(), JsonNode.class);
-
-                    if (type.equals("whisper_sent") || type.equals("whisper_received")) {
-                        //TypeReference<T> allows type parameters (unlike Class<T>) and avoids needing @SuppressWarnings("unchecked")
-                        Map<String, Object> tags = TypeConvert.convertValue(msgDataParsed.path("tags"), new TypeReference<Map<String, Object>>() {});
-
-                        String fromId = msgDataParsed.get("from_id").asText();
-                        String displayName = (String) tags.get("display_name");
-                        EventUser eventUser = new EventUser(fromId, displayName);
-
-                        String body = msgDataParsed.get("body").asText();
-
-                        Set<CommandPermission> permissions = TwitchUtils.getPermissionsFromTags(tags, new HashMap<>(), fromId, botOwnerIds);
-
-                        PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(eventUser, body, permissions);
-                        eventManager.publish(privateMessageEvent);
-                    } else if ("thread".equals(type)) {
-                        WhisperThread thread = TypeConvert.convertValue(msgDataParsed, WhisperThread.class);
-                        eventManager.publish(new WhisperThreadUpdateEvent(lastTopicIdentifier, thread));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("automod-levels-modification".equals(topicName) && topicParts.length > 1) {
-                    if ("automod_levels_modified".equals(type)) {
-                        AutomodLevelsModified data = TypeConvert.convertValue(msgData, AutomodLevelsModified.class);
-                        eventManager.publish(new AutomodLevelsModifiedEvent(lastTopicIdentifier, data));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("automod-queue".equals(topicName)) {
-                    if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(type)) {
-                        AutomodCaughtMessageData data = TypeConvert.convertValue(msgData, AutomodCaughtMessageData.class);
-                        eventManager.publish(new AutomodCaughtMessageEvent(topicParts[2], data));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("ads".equals(topicName)) {
-                    if ("midroll_request".equals(type)) {
-                        MidrollRequest midroll = TypeConvert.convertValue(msgData, MidrollRequest.class);
-                        eventManager.publish(new MidrollRequestEvent(lastTopicIdentifier, midroll));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("ads-manager".equals(topicName)) {
-                    if ("ads-schedule-update".equals(type)) {
-                        ScheduleUpdate data = TypeConvert.jsonToObject(rawMessage, ScheduleUpdate.class);
-                        eventManager.publish(new AdsScheduleUpdateEvent(lastTopicIdentifier, data));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("community-boost-events-v1".equals(topicName)) {
-                    if ("community-boost-progression".equals(type)) {
-                        CommunityBoostProgression progression = TypeConvert.convertValue(msgData, CommunityBoostProgression.class);
-                        eventManager.publish(new CommunityBoostProgressionEvent(progression));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("community-points-channel-v1".equals(topicName) || "channel-points-channel-v1".equals(topicName)) {
-                    String timestampText = msgData.path("timestamp").asText();
-                    Instant instant = Instant.parse(timestampText);
-
-                    switch (type) {
-                        case "reward-redeemed":
-                            ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                            eventManager.publish(new RewardRedeemedEvent(instant, redemption));
-                            break;
-                        case "redemption-status-update":
-                            ChannelPointsRedemption updatedRedemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                            eventManager.publish(new RedemptionStatusUpdateEvent(instant, updatedRedemption));
-                            break;
-                        case "custom-reward-created":
-                            ChannelPointsReward newReward = TypeConvert.convertValue(msgData.path("new_reward"), ChannelPointsReward.class);
-                            eventManager.publish(new CustomRewardCreatedEvent(instant, newReward));
-                            break;
-                        case "custom-reward-updated":
-                            ChannelPointsReward updatedReward = TypeConvert.convertValue(msgData.path("updated_reward"), ChannelPointsReward.class);
-                            eventManager.publish(new CustomRewardUpdatedEvent(instant, updatedReward));
-                            break;
-                        case "custom-reward-deleted":
-                            ChannelPointsReward deletedReward = TypeConvert.convertValue(msgData.path("deleted_reward"), ChannelPointsReward.class);
-                            eventManager.publish(new CustomRewardDeletedEvent(instant, deletedReward));
-                            break;
-                        case "update-redemption-statuses-progress":
-                            RedemptionProgress redemptionProgress = TypeConvert.convertValue(msgData.path("progress"), RedemptionProgress.class);
-                            eventManager.publish(new UpdateRedemptionProgressEvent(instant, redemptionProgress));
-                            break;
-                        case "update-redemption-statuses-finished":
-                            RedemptionProgress redemptionFinished = TypeConvert.convertValue(msgData.path("progress"), RedemptionProgress.class);
-                            eventManager.publish(new UpdateRedemptionFinishedEvent(instant, redemptionFinished));
-                            break;
-                        case "community-goal-contribution":
-                            CommunityGoalContribution contribution = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
-                            eventManager.publish(new CommunityGoalContributionEvent(instant, contribution));
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-
-                } else if ("creator-goals-events-v1".equals(topicName)) {
-                    CreatorGoal creatorGoal = TypeConvert.convertValue(msgData.path("goal"), CreatorGoal.class);
-                    eventManager.publish(new CreatorGoalEvent(lastTopicIdentifier, type, creatorGoal));
-                } else if ("crowd-chant-channel-v1".equals(topicName)) {
-                    if ("crowd-chant-created".equals(type)) {
-                        CrowdChantCreatedEvent event = TypeConvert.convertValue(msgData, CrowdChantCreatedEvent.class);
-                        eventManager.publish(event);
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("raid".equals(topicName)) {
-                    switch (type) {
-                        case "raid_go_v2":
-                            eventManager.publish(TypeConvert.jsonToObject(rawMessage, RaidGoEvent.class));
-                            break;
-                        case "raid_update_v2":
-                            eventManager.publish(TypeConvert.jsonToObject(rawMessage, RaidUpdateEvent.class));
-                            break;
-                        case "raid_cancel_v2":
-                            eventManager.publish(TypeConvert.jsonToObject(rawMessage, RaidCancelEvent.class));
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("charity-campaign-donation-events-v1".equals(topicName) && topicParts.length > 1) {
-                    switch (type) {
-                        case "charity_campaign_donation":
-                            CharityDonationData donation = TypeConvert.jsonToObject(rawMessage, CharityDonationData.class);
-                            eventManager.publish(new CharityCampaignDonationEvent(lastTopicIdentifier, donation));
-                            break;
-                        case "charity_campaign_status":
-                            CharityCampaignStatus status = TypeConvert.jsonToObject(rawMessage, CharityCampaignStatus.class);
-                            eventManager.publish(new CharityCampaignStatusEvent(lastTopicIdentifier, status));
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("chat_moderator_actions".equals(topicName) && topicParts.length > 1) {
-                    switch (type) {
-                        case "moderation_action":
-                            ChatModerationAction modAction = TypeConvert.convertValue(msgData, ChatModerationAction.class);
-                            eventManager.publish(new ChatModerationEvent(lastTopicIdentifier, modAction));
-                            break;
-
-                        case "channel_terms_action":
-                            ChannelTermsAction termsAction = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
-                            eventManager.publish(new ChannelTermsEvent(lastTopicIdentifier, termsAction));
-                            break;
-
-                        case "approve_unban_request":
-                        case "deny_unban_request":
-                            ModeratorUnbanRequestAction unbanRequestAction = TypeConvert.convertValue(msgData, ModeratorUnbanRequestAction.class);
-                            eventManager.publish(new ModUnbanRequestActionEvent(lastTopicIdentifier, unbanRequestAction));
-                            break;
-
-                        case "moderator_added":
-                        case "moderator_removed":
-                        case "vip_added":
-                        case "vip_removed":
-                            ChatModerationAction.ModerationAction act = "moderator_added".equals(type) ? ChatModerationAction.ModerationAction.MOD
-                                : "moderator_removed".equals(type) ? ChatModerationAction.ModerationAction.UNMOD
-                                : "vip_added".equals(type) ? ChatModerationAction.ModerationAction.VIP
-                                : ChatModerationAction.ModerationAction.UNVIP;
-
-                            String targetUserId = msgData.path("target_user_id").asText();
-                            String targetUserName = msgData.path("target_user_login").asText();
-                            String createdByUserId = msgData.path("created_by_user_id").asText();
-                            String createdBy = msgData.path("created_by").asText();
-                            ChatModerationAction action = new ChatModerationAction("chat_login_moderation", act, Collections.singletonList(targetUserName), createdBy, createdByUserId, "", targetUserId, targetUserName, false);
-                            eventManager.publish(new ChatModerationEvent(lastTopicIdentifier, action));
-                            break;
-
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("chatrooms-user-v1".equals(topicName) && topicParts.length > 1) {
-                    final String userId = topicParts[1];
-                    switch (type) {
-                        case "channel_banned_alias_restriction_update":
-                            final AliasRestrictionUpdateData aliasData = TypeConvert.convertValue(msgData, AliasRestrictionUpdateData.class);
-                            eventManager.publish(new AliasRestrictionUpdateEvent(userId, aliasData));
-                            break;
-
-                        case "user_moderation_action":
-                            final UserModerationActionData actionData = TypeConvert.convertValue(msgData, UserModerationActionData.class);
-                            eventManager.publish(new UserModerationActionEvent(userId, actionData));
-                            break;
-
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("following".equals(topicName) && topicParts.length > 1) {
-                    final FollowingData data = TypeConvert.jsonToObject(rawMessage, FollowingData.class);
-                    eventManager.publish(new FollowingEvent(lastTopicIdentifier, data));
-                } else if ("hype-train-events-v1".equals(topicName) && topicParts.length > 2 && "rewards".equals(topicParts[1])) {
-                    eventManager.publish(new HypeTrainRewardsEvent(TypeConvert.convertValue(msgData, HypeTrainRewardsData.class)));
-                } else if ("hype-train-events-v1".equals(topicName) && topicParts.length > 1) {
-                    switch (type) {
-                        case "hype-train-approaching":
-                            final HypeTrainApproaching approachData = TypeConvert.convertValue(msgData, HypeTrainApproaching.class);
-                            eventManager.publish(new HypeTrainApproachingEvent(approachData));
-                            break;
-                        case "hype-train-start":
-                            final HypeTrainStart startData = TypeConvert.convertValue(msgData, HypeTrainStart.class);
-                            eventManager.publish(new HypeTrainStartEvent(startData));
-                            break;
-                        case "hype-train-progression":
-                            final HypeProgression progressionData = TypeConvert.convertValue(msgData, HypeProgression.class);
-                            eventManager.publish(new HypeTrainProgressionEvent(lastTopicIdentifier, progressionData));
-                            break;
-                        case "hype-train-level-up":
-                            final HypeLevelUp levelUpData = TypeConvert.convertValue(msgData, HypeLevelUp.class);
-                            eventManager.publish(new HypeTrainLevelUpEvent(lastTopicIdentifier, levelUpData));
-                            break;
-                        case "hype-train-end":
-                            final HypeTrainEnd endData = TypeConvert.convertValue(msgData, HypeTrainEnd.class);
-                            eventManager.publish(new HypeTrainEndEvent(lastTopicIdentifier, endData));
-                            break;
-                        case "hype-train-conductor-update":
-                            final HypeTrainConductor conductorData = TypeConvert.convertValue(msgData, HypeTrainConductor.class);
-                            eventManager.publish(new HypeTrainConductorUpdateEvent(lastTopicIdentifier, conductorData));
-                            break;
-                        case "hype-train-cooldown-expiration":
-                            eventManager.publish(new HypeTrainCooldownExpirationEvent(lastTopicIdentifier));
-                            break;
-                        case "last-x-experiment-event":
-                            // note: this isn't a true hype train event (it can be fired with no train active), but twitch hacked together the feature to use the hype pubsub infrastructure
-                            final SupportActivityFeedData lastData = TypeConvert.convertValue(msgData, SupportActivityFeedData.class);
-                            eventManager.publish(new SupportActivityFeedEvent(lastTopicIdentifier, lastData));
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("community-points-user-v1".equals(topicName)) {
-                    switch (type) {
-                        case "points-earned":
-                            final ChannelPointsEarned pointsEarned = TypeConvert.convertValue(msgData, ChannelPointsEarned.class);
-                            eventManager.publish(new PointsEarnedEvent(pointsEarned));
-                            break;
-                        case "claim-available":
-                            final ClaimData claimAvailable = TypeConvert.convertValue(msgData, ClaimData.class);
-                            eventManager.publish(new ClaimAvailableEvent(claimAvailable));
-                            break;
-                        case "claim-claimed":
-                            final ClaimData claimClaimed = TypeConvert.convertValue(msgData, ClaimData.class);
-                            eventManager.publish(new ClaimClaimedEvent(claimClaimed));
-                            break;
-                        case "points-spent":
-                            final PointsSpent pointsSpent = TypeConvert.convertValue(msgData, PointsSpent.class);
-                            eventManager.publish(new PointsSpentEvent(pointsSpent));
-                            break;
-                        case "reward-redeemed":
-                            final ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                            eventManager.publish(new RewardRedeemedEvent(Instant.parse(msgData.path("timestamp").asText()), redemption));
-                            break;
-                        case "community-goal-contribution":
-                            CommunityGoalContribution goal = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
-                            Instant instant = Instant.parse(msgData.path("timestamp").textValue());
-                            eventManager.publish(new UserCommunityGoalContributionEvent(lastTopicIdentifier, instant, goal));
-                            break;
-                        case "global-last-viewed-content-updated":
-                        case "channel-last-viewed-content-updated":
-                            // unimportant
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("leaderboard-events-v1".equals(topicName)) {
-                    final Leaderboard leaderboard = TypeConvert.jsonToObject(rawMessage, Leaderboard.class);
-                    switch (leaderboard.getIdentifier().getDomain()) {
-                        case "bits-usage-by-channel-v1":
-                            eventManager.publish(new BitsLeaderboardEvent(leaderboard));
-                            break;
-                        case "sub-gifts-sent":
-                            eventManager.publish(new SubLeaderboardEvent(leaderboard));
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("user-moderation-notifications".equals(topicName)) {
-                    if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(type)) {
-                        UserAutomodCaughtMessage data = TypeConvert.convertValue(msgData, UserAutomodCaughtMessage.class);
-                        eventManager.publish(new UserAutomodCaughtMessageEvent(topicParts[1], topicParts[2], data));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("polls".equals(topicName)) {
-                    PollData pollData = TypeConvert.convertValue(msgData.path("poll"), PollData.class);
-                    eventManager.publish(new PollsEvent(type, pollData));
-                } else if ("predictions-channel-v1".equals(topicName)) {
-                    if ("event-created".equals(type)) {
-                        eventManager.publish(TypeConvert.convertValue(msgData, PredictionCreatedEvent.class));
-                    } else if ("event-updated".equals(type)) {
-                        eventManager.publish(TypeConvert.convertValue(msgData, PredictionUpdatedEvent.class));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("predictions-user-v1".equals(topicName)) {
-                    if ("prediction-made".equals(type)) {
-                        eventManager.publish(TypeConvert.convertValue(msgData, UserPredictionMadeEvent.class));
-                    } else if ("prediction-result".equals(type)) {
-                        eventManager.publish(TypeConvert.convertValue(msgData, UserPredictionResultEvent.class));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("friendship".equals(topicName)) {
-                    eventManager.publish(new FriendshipEvent(TypeConvert.jsonToObject(rawMessage, FriendshipData.class)));
-                } else if ("presence".equals(topicName) && topicParts.length > 1) {
-                    if ("presence".equalsIgnoreCase(type)) {
-                        eventManager.publish(new UserPresenceEvent(TypeConvert.convertValue(msgData, PresenceData.class)));
-                    } else if ("settings".equalsIgnoreCase(type)) {
-                        PresenceSettings presenceSettings = TypeConvert.convertValue(msgData, PresenceSettings.class);
-                        eventManager.publish(new PresenceSettingsEvent(lastTopicIdentifier, presenceSettings));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("radio-events-v1".equals(topicName)) {
-                    // noinspection deprecation
-                    eventManager.publish(new RadioEvent(TypeConvert.jsonToObject(rawMessage, RadioData.class)));
-                } else if ("shield-mode".equals(topicName) && topicParts.length == 3) {
-                    String userId = topicParts[1];
-                    String channelId = topicParts[2];
-                    switch (type) {
-                        case "ADD_AUTOBAN_TERM":
-                            BannedTermAdded termAdded = TypeConvert.convertValue(msgData, BannedTermAdded.class);
-                            eventManager.publish(new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded));
-                            break;
-
-                        case "REMOVE_AUTOBAN_TERM":
-                            BannedTermRemoved termRemoved = TypeConvert.convertValue(msgData, BannedTermRemoved.class);
-                            eventManager.publish(new ShieldModeBannedTermRemovedEvent(userId, channelId, termRemoved));
-                            break;
-
-                        case "UPDATE_CHANNEL_MODERATION_MODE":
-                            ShieldModeStatus shieldModeStatus = TypeConvert.convertValue(msgData, ShieldModeStatus.class);
-                            eventManager.publish(new ShieldModeStatusUpdatedEvent(userId, channelId, shieldModeStatus));
-                            break;
-
-                        case "UPDATE_CHANNEL_MODERATION_SETTINGS":
-                            ShieldModeSettings shieldModeSettings = TypeConvert.convertValue(msgData, ShieldModeSettings.class);
-                            eventManager.publish(new ShieldModeSettingsUpdatedEvent(userId, channelId, shieldModeSettings));
-                            break;
-
-                        case "UPDATE_CHANNEL_MODERATION_MODE_SHORTCUT":
-                            // do nothing; is_shortcut_enabled is unimportant
-                            break;
-
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if ("shoutout".equals(topicName)) {
-                    if ("create".equalsIgnoreCase(type)) {
-                        CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(msgData, CreateShoutoutData.class);
-                        eventManager.publish(new ShoutoutCreatedEvent(lastTopicIdentifier, shoutoutInfo));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("channel-sub-gifts-v1".equals(topicName)) {
-                    eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(rawMessage, SubGiftData.class)));
-                } else if ("channel-cheer-events-public-v1".equals(topicName) && topicParts.length > 1) {
-                    if ("cheerbomb".equalsIgnoreCase(type)) {
-                        CheerbombData cheerbomb = TypeConvert.convertValue(msgData, CheerbombData.class);
-                        eventManager.publish(new CheerbombEvent(lastTopicIdentifier, cheerbomb));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("low-trust-users".equals(topicName) && topicParts.length == 3) {
-                    String userId = topicParts[1];
-                    String channelId = topicParts[2];
-                    if ("low_trust_user_new_message".equals(type)) {
-                        eventManager.publish(new LowTrustUserNewMessageEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserNewMessage.class)));
-                    } else if ("low_trust_user_treatment_update".equals(type)) {
-                        eventManager.publish(new LowTrustUserTreatmentUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserTreatmentUpdate.class)));
-                    } else if ("bans_sharing_settings_update".equals(type)) {
-                        eventManager.publish(new BanSharingSettingsUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, BanSharingSettings.class)));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("onsite-notifications".equals(topicName) && topicParts.length > 1) {
-                    if ("create-notification".equalsIgnoreCase(type)) {
-                        eventManager.publish(new OnsiteNotificationCreationEvent(TypeConvert.convertValue(msgData, CreateNotificationData.class)));
-                    } else if ("update-summary".equalsIgnoreCase(type)) {
-                        UpdateSummaryData data = TypeConvert.convertValue(msgData, UpdateSummaryData.class);
-                        eventManager.publish(new UpdateOnsiteNotificationSummaryEvent(lastTopicIdentifier, data));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("pinned-chat-updates-v1".equals(topicName)) {
-                    switch (type) {
-                        case "pin-message":
-                            PinnedChatData createdPin = TypeConvert.convertValue(msgData, PinnedChatData.class);
-                            eventManager.publish(new PinnedChatCreatedEvent(lastTopicIdentifier, createdPin));
-                            break;
-                        case "update-message":
-                            UpdatedPinnedChatTiming updatedPin = TypeConvert.convertValue(msgData, UpdatedPinnedChatTiming.class);
-                            eventManager.publish(new PinnedChatTimingUpdatedEvent(lastTopicIdentifier, updatedPin));
-                            break;
-                        case "unpin-message":
-                            DeletePinnedChatData deletePin = TypeConvert.convertValue(msgData, DeletePinnedChatData.class);
-                            eventManager.publish(new PinnedChatDeletedEvent(lastTopicIdentifier, deletePin));
-                            break;
-                        default:
-                            log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                            break;
-                    }
-                } else if (("video-playback-by-id".equals(topicName) || "video-playback".equals(topicName)) && topicParts.length > 1) {
-                    boolean hasId = topicName.endsWith("d");
-                    VideoPlaybackData data = TypeConvert.jsonToObject(rawMessage, VideoPlaybackData.class);
-                    eventManager.publish(new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
-                } else if ("channel-chat-highlights".equals(topicName)) {
-                    if ("chat-highlight".equals(type)) {
-                        eventManager.publish(TypeConvert.convertValue(msgData, ChatHighlightEvent.class));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("channel-unban-requests".equals(topicName) && topicParts.length == 3) {
-                    String userId = topicParts[1];
-                    String channelId = topicParts[2];
-                    if ("create_unban_request".equals(type)) {
-                        CreatedUnbanRequest request = TypeConvert.convertValue(msgData, CreatedUnbanRequest.class);
-                        eventManager.publish(new ChannelUnbanRequestCreateEvent(userId, channelId, request));
-                    } else if ("update_unban_request".equals(type)) {
-                        UpdatedUnbanRequest request = TypeConvert.convertValue(msgData, UpdatedUnbanRequest.class);
-                        eventManager.publish(new ChannelUnbanRequestUpdateEvent(userId, channelId, request));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
-                    }
-                } else if ("user-unban-requests".equals(topicName) && topicParts.length == 3) {
-                    String userId = topicParts[1];
-                    String channelId = topicParts[2];
-                    if ("update_unban_request".equals(type)) {
-                        UpdatedUnbanRequest request = TypeConvert.convertValue(msgData, UpdatedUnbanRequest.class);
-                        eventManager.publish(new UserUnbanRequestUpdateEvent(userId, channelId, request));
-                    } else {
-                        log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                TopicHandler handler = HandlerRegistry.INSTANCE.getHandlers().get(topicName);
+                boolean fallback = false;
+                if (handler != null) {
+                    try {
+                        fallback = !handler.handle(eventManager, topicParts, message.getData().getMessage(), botOwnerIds);
+                    } catch (Exception e) {
+                        fallback = true;
+                        log.warn("PubSub: Encountered exception when parsing message", e);
                     }
                 } else {
-                    log.warn("Unparsable Message: " + message.getType() + "|" + message.getData());
+                    fallback = true;
                 }
-
+                if (fallback) {
+                    fallbackTopicHandler.accept(message.getData());
+                }
             } else if (message.getType().equals(PubSubType.RESPONSE)) {
                 Supplier<PubSubRequest> findListenRequest = () -> {
                     for (PubSubRequest topic : subscribedTopics) {

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.pubsub;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.client.websocket.WebsocketConnection;
 import com.github.twitch4j.client.websocket.domain.WebsocketConnectionState;
@@ -299,17 +298,13 @@ public class TwitchPubSub implements ITwitchPubSub {
                 String topic = message.getData().getTopic();
                 String[] topicParts = StringUtils.split(topic, '.');
                 String topicName = topicParts[0];
-                String lastTopicIdentifier = topicParts[topicParts.length - 1];
-                String type = message.getData().getMessage().getType();
-                JsonNode msgData = message.getData().getMessage().getMessageData();
-                String rawMessage = message.getData().getMessage().getRawMessage();
 
                 // Handle Messages
                 TopicHandler handler = HandlerRegistry.INSTANCE.getHandlers().get(topicName);
-                boolean fallback = false;
+                boolean fallback;
                 if (handler != null) {
                     try {
-                        fallback = !handler.handle(eventManager, topicParts, message.getData().getMessage(), botOwnerIds);
+                        fallback = !handler.handle(new TopicHandler.Args(eventManager, topicParts, message.getData().getMessage(), botOwnerIds));
                     } catch (Exception e) {
                         fallback = true;
                         log.warn("PubSub: Encountered exception when parsing message", e);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSubBuilder.java
@@ -8,6 +8,7 @@ import com.github.twitch4j.client.websocket.WebsocketConnectionConfig;
 import com.github.twitch4j.common.config.ProxyConfig;
 import com.github.twitch4j.common.util.EventManagerUtils;
 import com.github.twitch4j.common.util.ThreadUtils;
+import com.github.twitch4j.pubsub.domain.PubSubResponsePayload;
 import com.github.twitch4j.util.IBackoffStrategy;
 import lombok.*;
 import lombok.experimental.Accessors;
@@ -17,6 +18,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Consumer;
 
 /**
  * Twitch PubSub Builder
@@ -87,6 +89,15 @@ public class TwitchPubSubBuilder {
     private IBackoffStrategy connectionBackoffStrategy = null;
 
     /**
+     * Consumer of PubSub messages for topics that did not match internal handlers.
+     * <p>
+     * By default, Twitch4J simply logs these payloads, but this consumer can be utilized by users
+     * to implement new logic, such as support for more undocumented topics.
+     */
+    @With
+    private Consumer<PubSubResponsePayload> fallbackTopicHandler = null;
+
+    /**
      * Initialize the builder
      *
      * @return Twitch PubSub Builder
@@ -108,7 +119,7 @@ public class TwitchPubSubBuilder {
         // Initialize/Check EventManager
         eventManager = EventManagerUtils.validateOrInitializeEventManager(eventManager, defaultEventHandler);
 
-        return new TwitchPubSub(this.websocketConnection, this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds, this.wsPingPeriod, this.connectionBackoffStrategy, this.wsCloseDelay);
+        return new TwitchPubSub(this.websocketConnection, this.eventManager, scheduledThreadPoolExecutor, this.proxyConfig, this.botOwnerIds, this.wsPingPeriod, this.connectionBackoffStrategy, this.wsCloseDelay, this.fallbackTopicHandler);
     }
 
     /**

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.MidrollRequest;
 import com.github.twitch4j.pubsub.events.MidrollRequestEvent;
-
-import java.util.Collection;
 
 class AdsHandler implements TopicHandler {
     @Override
@@ -15,10 +11,10 @@ class AdsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("midroll_request".equals(message.getType())) {
-            MidrollRequest midroll = TypeConvert.convertValue(message.getMessageData(), MidrollRequest.class);
-            eventManager.publish(new MidrollRequestEvent(topicParts[topicParts.length - 1], midroll));
+    public boolean handle(Args args) {
+        if ("midroll_request".equals(args.getType())) {
+            MidrollRequest midroll = TypeConvert.convertValue(args.getData(), MidrollRequest.class);
+            args.getEventManager().publish(new MidrollRequestEvent(args.getLastTopicPart(), midroll));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.MidrollRequest;
+import com.github.twitch4j.pubsub.events.MidrollRequestEvent;
+
+import java.util.Collection;
+
+class AdsHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "ads";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("midroll_request".equals(message.getType())) {
+            MidrollRequest midroll = TypeConvert.convertValue(message.getMessageData(), MidrollRequest.class);
+            eventManager.publish(new MidrollRequestEvent(topicParts[topicParts.length - 1], midroll));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.MidrollRequest;
 import com.github.twitch4j.pubsub.events.MidrollRequestEvent;
@@ -11,12 +12,11 @@ class AdsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("midroll_request".equals(args.getType())) {
             MidrollRequest midroll = TypeConvert.convertValue(args.getData(), MidrollRequest.class);
-            args.getEventManager().publish(new MidrollRequestEvent(args.getLastTopicPart(), midroll));
-            return true;
+            return new MidrollRequestEvent(args.getLastTopicPart(), midroll);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsManagerHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsManagerHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.ScheduleUpdate;
+import com.github.twitch4j.pubsub.events.AdsScheduleUpdateEvent;
+
+import java.util.Collection;
+
+class AdsManagerHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "ads-manager";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("ads-schedule-update".equals(message.getType())) {
+            ScheduleUpdate data = TypeConvert.jsonToObject(message.getRawMessage(), ScheduleUpdate.class);
+            eventManager.publish(new AdsScheduleUpdateEvent(topicParts[topicParts.length - 1], data));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsManagerHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsManagerHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.ScheduleUpdate;
 import com.github.twitch4j.pubsub.events.AdsScheduleUpdateEvent;
-
-import java.util.Collection;
 
 class AdsManagerHandler implements TopicHandler {
     @Override
@@ -15,10 +11,10 @@ class AdsManagerHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("ads-schedule-update".equals(message.getType())) {
-            ScheduleUpdate data = TypeConvert.jsonToObject(message.getRawMessage(), ScheduleUpdate.class);
-            eventManager.publish(new AdsScheduleUpdateEvent(topicParts[topicParts.length - 1], data));
+    public boolean handle(Args args) {
+        if ("ads-schedule-update".equals(args.getType())) {
+            ScheduleUpdate data = TypeConvert.jsonToObject(args.getRawMessage(), ScheduleUpdate.class);
+            args.getEventManager().publish(new AdsScheduleUpdateEvent(args.getLastTopicPart(), data));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsManagerHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AdsManagerHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.ScheduleUpdate;
 import com.github.twitch4j.pubsub.events.AdsScheduleUpdateEvent;
@@ -11,12 +12,11 @@ class AdsManagerHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("ads-schedule-update".equals(args.getType())) {
             ScheduleUpdate data = TypeConvert.jsonToObject(args.getRawMessage(), ScheduleUpdate.class);
-            args.getEventManager().publish(new AdsScheduleUpdateEvent(args.getLastTopicPart(), data));
-            return true;
+            return new AdsScheduleUpdateEvent(args.getLastTopicPart(), data);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModLevelHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModLevelHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.AutomodLevelsModified;
 import com.github.twitch4j.pubsub.events.AutomodLevelsModifiedEvent;
@@ -11,12 +12,11 @@ class AutoModLevelHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if (args.getTopicParts().length > 1 && "automod_levels_modified".equals(args.getType())) {
             AutomodLevelsModified data = TypeConvert.convertValue(args.getData(), AutomodLevelsModified.class);
-            args.getEventManager().publish(new AutomodLevelsModifiedEvent(args.getLastTopicPart(), data));
-            return true;
+            return new AutomodLevelsModifiedEvent(args.getLastTopicPart(), data);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModLevelHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModLevelHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.AutomodLevelsModified;
+import com.github.twitch4j.pubsub.events.AutomodLevelsModifiedEvent;
+
+import java.util.Collection;
+
+class AutoModLevelHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "automod-levels-modification";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length > 1 && "automod_levels_modified".equals(message.getType())) {
+            AutomodLevelsModified data = TypeConvert.convertValue(message.getMessageData(), AutomodLevelsModified.class);
+            eventManager.publish(new AutomodLevelsModifiedEvent(topicParts[topicParts.length - 1], data));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModLevelHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModLevelHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.AutomodLevelsModified;
 import com.github.twitch4j.pubsub.events.AutomodLevelsModifiedEvent;
-
-import java.util.Collection;
 
 class AutoModLevelHandler implements TopicHandler {
     @Override
@@ -15,10 +11,10 @@ class AutoModLevelHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if (topicParts.length > 1 && "automod_levels_modified".equals(message.getType())) {
-            AutomodLevelsModified data = TypeConvert.convertValue(message.getMessageData(), AutomodLevelsModified.class);
-            eventManager.publish(new AutomodLevelsModifiedEvent(topicParts[topicParts.length - 1], data));
+    public boolean handle(Args args) {
+        if (args.getTopicParts().length > 1 && "automod_levels_modified".equals(args.getType())) {
+            AutomodLevelsModified data = TypeConvert.convertValue(args.getData(), AutomodLevelsModified.class);
+            args.getEventManager().publish(new AutomodLevelsModifiedEvent(args.getLastTopicPart(), data));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModQueueHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModQueueHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.AutomodCaughtMessageData;
+import com.github.twitch4j.pubsub.events.AutomodCaughtMessageEvent;
+
+import java.util.Collection;
+
+class AutoModQueueHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "automod-queue";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(message.getType())) {
+            AutomodCaughtMessageData data = TypeConvert.convertValue(message.getMessageData(), AutomodCaughtMessageData.class);
+            eventManager.publish(new AutomodCaughtMessageEvent(topicParts[2], data));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModQueueHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModQueueHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.AutomodCaughtMessageData;
 import com.github.twitch4j.pubsub.events.AutomodCaughtMessageEvent;
-
-import java.util.Collection;
 
 class AutoModQueueHandler implements TopicHandler {
     @Override
@@ -15,10 +11,11 @@ class AutoModQueueHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(message.getType())) {
-            AutomodCaughtMessageData data = TypeConvert.convertValue(message.getMessageData(), AutomodCaughtMessageData.class);
-            eventManager.publish(new AutomodCaughtMessageEvent(topicParts[2], data));
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
+        if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(args.getType())) {
+            AutomodCaughtMessageData data = TypeConvert.convertValue(args.getData(), AutomodCaughtMessageData.class);
+            args.getEventManager().publish(new AutomodCaughtMessageEvent(topicParts[2], data));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModQueueHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/AutoModQueueHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.AutomodCaughtMessageData;
 import com.github.twitch4j.pubsub.events.AutomodCaughtMessageEvent;
@@ -11,13 +12,12 @@ class AutoModQueueHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
         if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(args.getType())) {
             AutomodCaughtMessageData data = TypeConvert.convertValue(args.getData(), AutomodCaughtMessageData.class);
-            args.getEventManager().publish(new AutomodCaughtMessageEvent(topicParts[2], data));
-            return true;
+            return new AutomodCaughtMessageEvent(topicParts[2], data);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
@@ -14,6 +14,6 @@ class BitsBadgeHandler implements TopicHandler {
     @Override
     public TwitchEvent apply(Args args) {
         BitsBadgeData data = TypeConvert.jsonToObject(args.getRawMessage(), BitsBadgeData.class);
-        return (new ChannelBitsBadgeUnlockEvent(data));
+        return new ChannelBitsBadgeUnlockEvent(data);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.BitsBadgeData;
 import com.github.twitch4j.pubsub.events.ChannelBitsBadgeUnlockEvent;
@@ -11,9 +12,8 @@ class BitsBadgeHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         BitsBadgeData data = TypeConvert.jsonToObject(args.getRawMessage(), BitsBadgeData.class);
-        args.getEventManager().publish(new ChannelBitsBadgeUnlockEvent(data));
-        return true;
+        return (new ChannelBitsBadgeUnlockEvent(data));
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.BitsBadgeData;
+import com.github.twitch4j.pubsub.events.ChannelBitsBadgeUnlockEvent;
+
+import java.util.Collection;
+
+class BitsBadgeHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-bits-badge-unlocks";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        BitsBadgeData data = TypeConvert.jsonToObject(message.getRawMessage(), BitsBadgeData.class);
+        eventManager.publish(new ChannelBitsBadgeUnlockEvent(data));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsBadgeHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.BitsBadgeData;
 import com.github.twitch4j.pubsub.events.ChannelBitsBadgeUnlockEvent;
-
-import java.util.Collection;
 
 class BitsBadgeHandler implements TopicHandler {
     @Override
@@ -15,9 +11,9 @@ class BitsBadgeHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        BitsBadgeData data = TypeConvert.jsonToObject(message.getRawMessage(), BitsBadgeData.class);
-        eventManager.publish(new ChannelBitsBadgeUnlockEvent(data));
+    public boolean handle(Args args) {
+        BitsBadgeData data = TypeConvert.jsonToObject(args.getRawMessage(), BitsBadgeData.class);
+        args.getEventManager().publish(new ChannelBitsBadgeUnlockEvent(data));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.ChannelBitsData;
 import com.github.twitch4j.pubsub.events.ChannelBitsEvent;
-
-import java.util.Collection;
 
 class BitsHandler implements TopicHandler {
     @Override
@@ -15,9 +11,9 @@ class BitsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        ChannelBitsData data = TypeConvert.convertValue(message.getMessageData(), ChannelBitsData.class);
-        eventManager.publish(new ChannelBitsEvent(data));
+    public boolean handle(Args args) {
+        ChannelBitsData data = TypeConvert.convertValue(args.getData(), ChannelBitsData.class);
+        args.getEventManager().publish(new ChannelBitsEvent(data));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsHandler.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.ChannelBitsData;
+import com.github.twitch4j.pubsub.events.ChannelBitsEvent;
+
+import java.util.Collection;
+
+class BitsHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-bits-events-v2";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        ChannelBitsData data = TypeConvert.convertValue(message.getMessageData(), ChannelBitsData.class);
+        eventManager.publish(new ChannelBitsEvent(data));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BitsHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.ChannelBitsData;
 import com.github.twitch4j.pubsub.events.ChannelBitsEvent;
@@ -11,9 +12,8 @@ class BitsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         ChannelBitsData data = TypeConvert.convertValue(args.getData(), ChannelBitsData.class);
-        args.getEventManager().publish(new ChannelBitsEvent(data));
-        return true;
+        return new ChannelBitsEvent(data);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BoostHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BoostHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CommunityBoostProgression;
 import com.github.twitch4j.pubsub.events.CommunityBoostProgressionEvent;
-
-import java.util.Collection;
 
 class BoostHandler implements TopicHandler {
     @Override
@@ -15,10 +11,10 @@ class BoostHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("community-boost-progression".equals(message.getType())) {
-            CommunityBoostProgression progression = TypeConvert.convertValue(message.getMessageData(), CommunityBoostProgression.class);
-            eventManager.publish(new CommunityBoostProgressionEvent(progression));
+    public boolean handle(Args args) {
+        if ("community-boost-progression".equals(args.getType())) {
+            CommunityBoostProgression progression = TypeConvert.convertValue(args.getData(), CommunityBoostProgression.class);
+            args.getEventManager().publish(new CommunityBoostProgressionEvent(progression));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BoostHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BoostHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CommunityBoostProgression;
 import com.github.twitch4j.pubsub.events.CommunityBoostProgressionEvent;
@@ -11,12 +12,11 @@ class BoostHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("community-boost-progression".equals(args.getType())) {
             CommunityBoostProgression progression = TypeConvert.convertValue(args.getData(), CommunityBoostProgression.class);
-            args.getEventManager().publish(new CommunityBoostProgressionEvent(progression));
-            return true;
+            return new CommunityBoostProgressionEvent(progression);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BoostHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/BoostHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CommunityBoostProgression;
+import com.github.twitch4j.pubsub.events.CommunityBoostProgressionEvent;
+
+import java.util.Collection;
+
+class BoostHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "community-boost-events-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("community-boost-progression".equals(message.getType())) {
+            CommunityBoostProgression progression = TypeConvert.convertValue(message.getMessageData(), CommunityBoostProgression.class);
+            eventManager.publish(new CommunityBoostProgressionEvent(progression));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChannelPointsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChannelPointsHandler.java
@@ -1,0 +1,78 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
+import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
+import com.github.twitch4j.pubsub.domain.CommunityGoalContribution;
+import com.github.twitch4j.pubsub.domain.RedemptionProgress;
+import com.github.twitch4j.pubsub.events.CommunityGoalContributionEvent;
+import com.github.twitch4j.pubsub.events.CustomRewardCreatedEvent;
+import com.github.twitch4j.pubsub.events.CustomRewardDeletedEvent;
+import com.github.twitch4j.pubsub.events.CustomRewardUpdatedEvent;
+import com.github.twitch4j.pubsub.events.RedemptionStatusUpdateEvent;
+import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
+import com.github.twitch4j.pubsub.events.UpdateRedemptionFinishedEvent;
+import com.github.twitch4j.pubsub.events.UpdateRedemptionProgressEvent;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+
+class ChannelPointsHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-points-channel-v1";
+    }
+
+    @Override
+    public Collection<String> topicNames() {
+        return Arrays.asList(topicName(), "community-points-channel-v1");
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        JsonNode msgData = message.getMessageData();
+        String timestampText = msgData.path("timestamp").asText();
+        Instant instant = Instant.parse(timestampText);
+
+        switch (message.getType()) {
+            case "reward-redeemed":
+                ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
+                eventManager.publish(new RewardRedeemedEvent(instant, redemption));
+                return true;
+            case "redemption-status-update":
+                ChannelPointsRedemption updatedRedemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
+                eventManager.publish(new RedemptionStatusUpdateEvent(instant, updatedRedemption));
+                return true;
+            case "custom-reward-created":
+                ChannelPointsReward newReward = TypeConvert.convertValue(msgData.path("new_reward"), ChannelPointsReward.class);
+                eventManager.publish(new CustomRewardCreatedEvent(instant, newReward));
+                return true;
+            case "custom-reward-updated":
+                ChannelPointsReward updatedReward = TypeConvert.convertValue(msgData.path("updated_reward"), ChannelPointsReward.class);
+                eventManager.publish(new CustomRewardUpdatedEvent(instant, updatedReward));
+                return true;
+            case "custom-reward-deleted":
+                ChannelPointsReward deletedReward = TypeConvert.convertValue(msgData.path("deleted_reward"), ChannelPointsReward.class);
+                eventManager.publish(new CustomRewardDeletedEvent(instant, deletedReward));
+                return true;
+            case "update-redemption-statuses-progress":
+                RedemptionProgress redemptionProgress = TypeConvert.convertValue(msgData.path("progress"), RedemptionProgress.class);
+                eventManager.publish(new UpdateRedemptionProgressEvent(instant, redemptionProgress));
+                return true;
+            case "update-redemption-statuses-finished":
+                RedemptionProgress redemptionFinished = TypeConvert.convertValue(msgData.path("progress"), RedemptionProgress.class);
+                eventManager.publish(new UpdateRedemptionFinishedEvent(instant, redemptionFinished));
+                return true;
+            case "community-goal-contribution":
+                CommunityGoalContribution contribution = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
+                eventManager.publish(new CommunityGoalContributionEvent(instant, contribution));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChannelPointsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChannelPointsHandler.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
 import com.github.twitch4j.pubsub.domain.CommunityGoalContribution;
@@ -33,12 +32,13 @@ class ChannelPointsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        JsonNode msgData = message.getMessageData();
+    public boolean handle(Args args) {
+        JsonNode msgData = args.getData();
         String timestampText = msgData.path("timestamp").asText();
         Instant instant = Instant.parse(timestampText);
+        IEventManager eventManager = args.getEventManager();
 
-        switch (message.getType()) {
+        switch (args.getType()) {
             case "reward-redeemed":
                 ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
                 eventManager.publish(new RewardRedeemedEvent(instant, redemption));

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChannelPointsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChannelPointsHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import com.github.twitch4j.pubsub.domain.ChannelPointsReward;
@@ -32,47 +32,38 @@ class ChannelPointsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         JsonNode msgData = args.getData();
         String timestampText = msgData.path("timestamp").asText();
         Instant instant = Instant.parse(timestampText);
-        IEventManager eventManager = args.getEventManager();
 
         switch (args.getType()) {
             case "reward-redeemed":
                 ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                eventManager.publish(new RewardRedeemedEvent(instant, redemption));
-                return true;
+                return new RewardRedeemedEvent(instant, redemption);
             case "redemption-status-update":
                 ChannelPointsRedemption updatedRedemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                eventManager.publish(new RedemptionStatusUpdateEvent(instant, updatedRedemption));
-                return true;
+                return new RedemptionStatusUpdateEvent(instant, updatedRedemption);
             case "custom-reward-created":
                 ChannelPointsReward newReward = TypeConvert.convertValue(msgData.path("new_reward"), ChannelPointsReward.class);
-                eventManager.publish(new CustomRewardCreatedEvent(instant, newReward));
-                return true;
+                return new CustomRewardCreatedEvent(instant, newReward);
             case "custom-reward-updated":
                 ChannelPointsReward updatedReward = TypeConvert.convertValue(msgData.path("updated_reward"), ChannelPointsReward.class);
-                eventManager.publish(new CustomRewardUpdatedEvent(instant, updatedReward));
-                return true;
+                return new CustomRewardUpdatedEvent(instant, updatedReward);
             case "custom-reward-deleted":
                 ChannelPointsReward deletedReward = TypeConvert.convertValue(msgData.path("deleted_reward"), ChannelPointsReward.class);
-                eventManager.publish(new CustomRewardDeletedEvent(instant, deletedReward));
-                return true;
+                return new CustomRewardDeletedEvent(instant, deletedReward);
             case "update-redemption-statuses-progress":
                 RedemptionProgress redemptionProgress = TypeConvert.convertValue(msgData.path("progress"), RedemptionProgress.class);
-                eventManager.publish(new UpdateRedemptionProgressEvent(instant, redemptionProgress));
-                return true;
+                return new UpdateRedemptionProgressEvent(instant, redemptionProgress);
             case "update-redemption-statuses-finished":
                 RedemptionProgress redemptionFinished = TypeConvert.convertValue(msgData.path("progress"), RedemptionProgress.class);
-                eventManager.publish(new UpdateRedemptionFinishedEvent(instant, redemptionFinished));
-                return true;
+                return new UpdateRedemptionFinishedEvent(instant, redemptionFinished);
             case "community-goal-contribution":
                 CommunityGoalContribution contribution = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
-                eventManager.publish(new CommunityGoalContributionEvent(instant, contribution));
-                return true;
+                return new CommunityGoalContributionEvent(instant, contribution);
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CharityHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CharityHandler.java
@@ -1,14 +1,10 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CharityCampaignStatus;
 import com.github.twitch4j.pubsub.domain.CharityDonationData;
 import com.github.twitch4j.pubsub.events.CharityCampaignDonationEvent;
 import com.github.twitch4j.pubsub.events.CharityCampaignStatusEvent;
-
-import java.util.Collection;
 
 class CharityHandler implements TopicHandler {
     @Override
@@ -17,15 +13,15 @@ class CharityHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        switch (message.getType()) {
+    public boolean handle(Args args) {
+        switch (args.getType()) {
             case "charity_campaign_donation":
-                CharityDonationData donation = TypeConvert.jsonToObject(message.getRawMessage(), CharityDonationData.class);
-                eventManager.publish(new CharityCampaignDonationEvent(topicParts[topicParts.length - 1], donation));
+                CharityDonationData donation = TypeConvert.jsonToObject(args.getRawMessage(), CharityDonationData.class);
+                args.getEventManager().publish(new CharityCampaignDonationEvent(args.getLastTopicPart(), donation));
                 return true;
             case "charity_campaign_status":
-                CharityCampaignStatus status = TypeConvert.jsonToObject(message.getRawMessage(), CharityCampaignStatus.class);
-                eventManager.publish(new CharityCampaignStatusEvent(topicParts[topicParts.length - 1], status));
+                CharityCampaignStatus status = TypeConvert.jsonToObject(args.getRawMessage(), CharityCampaignStatus.class);
+                args.getEventManager().publish(new CharityCampaignStatusEvent(args.getLastTopicPart(), status));
                 return true;
             default:
                 return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CharityHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CharityHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CharityCampaignStatus;
 import com.github.twitch4j.pubsub.domain.CharityDonationData;
@@ -13,18 +14,16 @@ class CharityHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         switch (args.getType()) {
             case "charity_campaign_donation":
                 CharityDonationData donation = TypeConvert.jsonToObject(args.getRawMessage(), CharityDonationData.class);
-                args.getEventManager().publish(new CharityCampaignDonationEvent(args.getLastTopicPart(), donation));
-                return true;
+                return new CharityCampaignDonationEvent(args.getLastTopicPart(), donation);
             case "charity_campaign_status":
                 CharityCampaignStatus status = TypeConvert.jsonToObject(args.getRawMessage(), CharityCampaignStatus.class);
-                args.getEventManager().publish(new CharityCampaignStatusEvent(args.getLastTopicPart(), status));
-                return true;
+                return new CharityCampaignStatusEvent(args.getLastTopicPart(), status);
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CharityHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CharityHandler.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CharityCampaignStatus;
+import com.github.twitch4j.pubsub.domain.CharityDonationData;
+import com.github.twitch4j.pubsub.events.CharityCampaignDonationEvent;
+import com.github.twitch4j.pubsub.events.CharityCampaignStatusEvent;
+
+import java.util.Collection;
+
+class CharityHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "charity-campaign-donation-events-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        switch (message.getType()) {
+            case "charity_campaign_donation":
+                CharityDonationData donation = TypeConvert.jsonToObject(message.getRawMessage(), CharityDonationData.class);
+                eventManager.publish(new CharityCampaignDonationEvent(topicParts[topicParts.length - 1], donation));
+                return true;
+            case "charity_campaign_status":
+                CharityCampaignStatus status = TypeConvert.jsonToObject(message.getRawMessage(), CharityCampaignStatus.class);
+                eventManager.publish(new CharityCampaignStatusEvent(topicParts[topicParts.length - 1], status));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChatroomHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChatroomHandler.java
@@ -1,0 +1,40 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.AliasRestrictionUpdateData;
+import com.github.twitch4j.pubsub.domain.UserModerationActionData;
+import com.github.twitch4j.pubsub.events.AliasRestrictionUpdateEvent;
+import com.github.twitch4j.pubsub.events.UserModerationActionEvent;
+
+import java.util.Collection;
+
+class ChatroomHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "chatrooms-user-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length <= 1) return false;
+        String userId = topicParts[1];
+        JsonNode msgData = message.getMessageData();
+        switch (message.getType()) {
+            case "channel_banned_alias_restriction_update":
+                final AliasRestrictionUpdateData aliasData = TypeConvert.convertValue(msgData, AliasRestrictionUpdateData.class);
+                eventManager.publish(new AliasRestrictionUpdateEvent(userId, aliasData));
+                return true;
+
+            case "user_moderation_action":
+                final UserModerationActionData actionData = TypeConvert.convertValue(msgData, UserModerationActionData.class);
+                eventManager.publish(new UserModerationActionEvent(userId, actionData));
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChatroomHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChatroomHandler.java
@@ -1,15 +1,11 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.AliasRestrictionUpdateData;
 import com.github.twitch4j.pubsub.domain.UserModerationActionData;
 import com.github.twitch4j.pubsub.events.AliasRestrictionUpdateEvent;
 import com.github.twitch4j.pubsub.events.UserModerationActionEvent;
-
-import java.util.Collection;
 
 class ChatroomHandler implements TopicHandler {
     @Override
@@ -18,19 +14,20 @@ class ChatroomHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
         if (topicParts.length <= 1) return false;
         String userId = topicParts[1];
-        JsonNode msgData = message.getMessageData();
-        switch (message.getType()) {
+        JsonNode msgData = args.getData();
+        switch (args.getType()) {
             case "channel_banned_alias_restriction_update":
                 final AliasRestrictionUpdateData aliasData = TypeConvert.convertValue(msgData, AliasRestrictionUpdateData.class);
-                eventManager.publish(new AliasRestrictionUpdateEvent(userId, aliasData));
+                args.getEventManager().publish(new AliasRestrictionUpdateEvent(userId, aliasData));
                 return true;
 
             case "user_moderation_action":
                 final UserModerationActionData actionData = TypeConvert.convertValue(msgData, UserModerationActionData.class);
-                eventManager.publish(new UserModerationActionEvent(userId, actionData));
+                args.getEventManager().publish(new UserModerationActionEvent(userId, actionData));
                 return true;
 
             default:

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChatroomHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ChatroomHandler.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.AliasRestrictionUpdateData;
 import com.github.twitch4j.pubsub.domain.UserModerationActionData;
@@ -14,24 +15,22 @@ class ChatroomHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
-        if (topicParts.length <= 1) return false;
+        if (topicParts.length <= 1) return null;
         String userId = topicParts[1];
         JsonNode msgData = args.getData();
         switch (args.getType()) {
             case "channel_banned_alias_restriction_update":
                 final AliasRestrictionUpdateData aliasData = TypeConvert.convertValue(msgData, AliasRestrictionUpdateData.class);
-                args.getEventManager().publish(new AliasRestrictionUpdateEvent(userId, aliasData));
-                return true;
+                return new AliasRestrictionUpdateEvent(userId, aliasData);
 
             case "user_moderation_action":
                 final UserModerationActionData actionData = TypeConvert.convertValue(msgData, UserModerationActionData.class);
-                args.getEventManager().publish(new UserModerationActionEvent(userId, actionData));
-                return true;
+                return new UserModerationActionEvent(userId, actionData);
 
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CheerbombHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CheerbombHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CheerbombData;
 import com.github.twitch4j.pubsub.events.CheerbombEvent;
@@ -11,12 +12,11 @@ class CheerbombHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("cheerbomb".equalsIgnoreCase(args.getType())) {
             CheerbombData cheerbomb = TypeConvert.convertValue(args.getData(), CheerbombData.class);
-            args.getEventManager().publish(new CheerbombEvent(args.getLastTopicPart(), cheerbomb));
-            return true;
+            return new CheerbombEvent(args.getLastTopicPart(), cheerbomb);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CheerbombHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CheerbombHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CheerbombData;
+import com.github.twitch4j.pubsub.events.CheerbombEvent;
+
+import java.util.Collection;
+
+class CheerbombHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-cheer-events-public-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("cheerbomb".equalsIgnoreCase(message.getType())) {
+            CheerbombData cheerbomb = TypeConvert.convertValue(message.getMessageData(), CheerbombData.class);
+            eventManager.publish(new CheerbombEvent(topicParts[topicParts.length - 1], cheerbomb));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CheerbombHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/CheerbombHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CheerbombData;
 import com.github.twitch4j.pubsub.events.CheerbombEvent;
-
-import java.util.Collection;
 
 class CheerbombHandler implements TopicHandler {
     @Override
@@ -15,10 +11,10 @@ class CheerbombHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("cheerbomb".equalsIgnoreCase(message.getType())) {
-            CheerbombData cheerbomb = TypeConvert.convertValue(message.getMessageData(), CheerbombData.class);
-            eventManager.publish(new CheerbombEvent(topicParts[topicParts.length - 1], cheerbomb));
+    public boolean handle(Args args) {
+        if ("cheerbomb".equalsIgnoreCase(args.getType())) {
+            CheerbombData cheerbomb = TypeConvert.convertValue(args.getData(), CheerbombData.class);
+            args.getEventManager().publish(new CheerbombEvent(args.getLastTopicPart(), cheerbomb));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/FollowingHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/FollowingHandler.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.FollowingData;
+import com.github.twitch4j.pubsub.events.FollowingEvent;
+
+import java.util.Collection;
+
+class FollowingHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "following";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        FollowingData data = TypeConvert.jsonToObject(message.getRawMessage(), FollowingData.class);
+        eventManager.publish(new FollowingEvent(topicParts[topicParts.length - 1], data));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/FollowingHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/FollowingHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.FollowingData;
 import com.github.twitch4j.pubsub.events.FollowingEvent;
-
-import java.util.Collection;
 
 class FollowingHandler implements TopicHandler {
     @Override
@@ -15,9 +11,9 @@ class FollowingHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        FollowingData data = TypeConvert.jsonToObject(message.getRawMessage(), FollowingData.class);
-        eventManager.publish(new FollowingEvent(topicParts[topicParts.length - 1], data));
+    public boolean handle(Args args) {
+        FollowingData data = TypeConvert.jsonToObject(args.getRawMessage(), FollowingData.class);
+        args.getEventManager().publish(new FollowingEvent(args.getLastTopicPart(), data));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/FollowingHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/FollowingHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.FollowingData;
 import com.github.twitch4j.pubsub.events.FollowingEvent;
@@ -11,9 +12,8 @@ class FollowingHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         FollowingData data = TypeConvert.jsonToObject(args.getRawMessage(), FollowingData.class);
-        args.getEventManager().publish(new FollowingEvent(args.getLastTopicPart(), data));
-        return true;
+        return new FollowingEvent(args.getLastTopicPart(), data);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GiftHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GiftHandler.java
@@ -1,0 +1,22 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.SubGiftData;
+import com.github.twitch4j.pubsub.events.ChannelSubGiftEvent;
+
+import java.util.Collection;
+
+class GiftHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-sub-gifts-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(message.getRawMessage(), SubGiftData.class)));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GiftHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GiftHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.SubGiftData;
 import com.github.twitch4j.pubsub.events.ChannelSubGiftEvent;
@@ -11,8 +12,7 @@ class GiftHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
-        args.getEventManager().publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(args.getRawMessage(), SubGiftData.class)));
-        return true;
+    public TwitchEvent apply(Args args) {
+        return new ChannelSubGiftEvent(TypeConvert.jsonToObject(args.getRawMessage(), SubGiftData.class));
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GiftHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GiftHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.SubGiftData;
 import com.github.twitch4j.pubsub.events.ChannelSubGiftEvent;
-
-import java.util.Collection;
 
 class GiftHandler implements TopicHandler {
     @Override
@@ -15,8 +11,8 @@ class GiftHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        eventManager.publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(message.getRawMessage(), SubGiftData.class)));
+    public boolean handle(Args args) {
+        args.getEventManager().publish(new ChannelSubGiftEvent(TypeConvert.jsonToObject(args.getRawMessage(), SubGiftData.class)));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GoalsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GoalsHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CreatorGoal;
 import com.github.twitch4j.pubsub.events.CreatorGoalEvent;
@@ -11,9 +12,8 @@ class GoalsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         CreatorGoal creatorGoal = TypeConvert.convertValue(args.getData().path("goal"), CreatorGoal.class);
-        args.getEventManager().publish(new CreatorGoalEvent(args.getLastTopicPart(), args.getType(), creatorGoal));
-        return true;
+        return new CreatorGoalEvent(args.getLastTopicPart(), args.getType(), creatorGoal);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GoalsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GoalsHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CreatorGoal;
 import com.github.twitch4j.pubsub.events.CreatorGoalEvent;
-
-import java.util.Collection;
 
 class GoalsHandler implements TopicHandler {
     @Override
@@ -15,9 +11,9 @@ class GoalsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        CreatorGoal creatorGoal = TypeConvert.convertValue(message.getMessageData().path("goal"), CreatorGoal.class);
-        eventManager.publish(new CreatorGoalEvent(topicParts[topicParts.length - 1], message.getType(), creatorGoal));
+    public boolean handle(Args args) {
+        CreatorGoal creatorGoal = TypeConvert.convertValue(args.getData().path("goal"), CreatorGoal.class);
+        args.getEventManager().publish(new CreatorGoalEvent(args.getLastTopicPart(), args.getType(), creatorGoal));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GoalsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/GoalsHandler.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CreatorGoal;
+import com.github.twitch4j.pubsub.events.CreatorGoalEvent;
+
+import java.util.Collection;
+
+class GoalsHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "creator-goals-events-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        CreatorGoal creatorGoal = TypeConvert.convertValue(message.getMessageData().path("goal"), CreatorGoal.class);
+        eventManager.publish(new CreatorGoalEvent(topicParts[topicParts.length - 1], message.getType(), creatorGoal));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HandlerRegistry.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HandlerRegistry.java
@@ -25,6 +25,8 @@ public enum HandlerRegistry {
             new ChannelPointsHandler(),
             new ModeratorHandler(),
             new SubscriptionHandler(),
+            new SuspiciousHandler(),
+            new UserModeratedHandler(),
             new WhispersHandler(),
 
             // unofficial topics
@@ -47,10 +49,8 @@ public enum HandlerRegistry {
             new RaidHandler(),
             new ShieldHandler(),
             new ShoutoutHandler(),
-            new SuspiciousHandler(),
             new TrainHandler(),
             new UnbanRequestHandler(),
-            new UserModeratedHandler(),
             new UserPointsHandler(),
             new UserPredictionHandler(),
             new UserUnbanRequestHandler()

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HandlerRegistry.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HandlerRegistry.java
@@ -18,7 +18,6 @@ public enum HandlerRegistry {
         Map<String, TopicHandler> map = new HashMap<>();
         Stream.of(
             // official topics
-            new AutoModLevelHandler(),
             new AutoModQueueHandler(),
             new BitsHandler(),
             new BitsBadgeHandler(),
@@ -32,6 +31,7 @@ public enum HandlerRegistry {
             // unofficial topics
             new AdsHandler(),
             new AdsManagerHandler(),
+            new AutoModLevelHandler(),
             new BoostHandler(),
             new CharityHandler(),
             new ChatroomHandler(),

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HandlerRegistry.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HandlerRegistry.java
@@ -1,0 +1,60 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import lombok.Getter;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Getter(onMethod_ = { @ApiStatus.Internal })
+public enum HandlerRegistry {
+    INSTANCE;
+
+    private final Map<String, TopicHandler> handlers;
+
+    HandlerRegistry() {
+        Map<String, TopicHandler> map = new HashMap<>();
+        Stream.of(
+            // official topics
+            new AutoModLevelHandler(),
+            new AutoModQueueHandler(),
+            new BitsHandler(),
+            new BitsBadgeHandler(),
+            new ChannelPointsHandler(),
+            new ModeratorHandler(),
+            new SubscriptionHandler(),
+            new WhispersHandler(),
+
+            // unofficial topics
+            new AdsHandler(),
+            new AdsManagerHandler(),
+            new BoostHandler(),
+            new CharityHandler(),
+            new ChatroomHandler(),
+            new CheerbombHandler(),
+            new FollowingHandler(),
+            new GiftHandler(),
+            new GoalsHandler(),
+            new HighlightHandler(),
+            new LeaderboardHandler(),
+            new NotificationHandler(),
+            new PinHandler(),
+            new PlaybackHandler(),
+            new PollsHandler(),
+            new PredictionHandler(),
+            new RaidHandler(),
+            new ShieldHandler(),
+            new ShoutoutHandler(),
+            new SuspiciousHandler(),
+            new TrainHandler(),
+            new UnbanRequestHandler(),
+            new UserModeratedHandler(),
+            new UserPointsHandler(),
+            new UserPredictionHandler(),
+            new UserUnbanRequestHandler()
+        ).forEach(handler -> handler.topicNames().forEach(topic -> map.put(topic, handler)));
+        this.handlers = Collections.unmodifiableMap(map);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HighlightHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HighlightHandler.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.events.ChatHighlightEvent;
+
+import java.util.Collection;
+
+class HighlightHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-chat-highlights";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("chat-highlight".equals(message.getType())) {
+            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), ChatHighlightEvent.class));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HighlightHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HighlightHandler.java
@@ -1,11 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.events.ChatHighlightEvent;
-
-import java.util.Collection;
 
 class HighlightHandler implements TopicHandler {
     @Override
@@ -14,9 +10,9 @@ class HighlightHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("chat-highlight".equals(message.getType())) {
-            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), ChatHighlightEvent.class));
+    public boolean handle(Args args) {
+        if ("chat-highlight".equals(args.getType())) {
+            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), ChatHighlightEvent.class));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HighlightHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/HighlightHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.events.ChatHighlightEvent;
 
@@ -10,11 +11,10 @@ class HighlightHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("chat-highlight".equals(args.getType())) {
-            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), ChatHighlightEvent.class));
-            return true;
+            return TypeConvert.convertValue(args.getData(), ChatHighlightEvent.class);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.Leaderboard;
+import com.github.twitch4j.pubsub.events.BitsLeaderboardEvent;
+import com.github.twitch4j.pubsub.events.SubLeaderboardEvent;
+
+import java.util.Collection;
+
+class LeaderboardHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "leaderboard-events-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        Leaderboard leaderboard = TypeConvert.jsonToObject(message.getRawMessage(), Leaderboard.class);
+        switch (leaderboard.getIdentifier().getDomain()) {
+            case "bits-usage-by-channel-v1":
+                eventManager.publish(new BitsLeaderboardEvent(leaderboard));
+                return true;
+            case "sub-gifts-sent":
+                eventManager.publish(new SubLeaderboardEvent(leaderboard));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.Leaderboard;
 import com.github.twitch4j.pubsub.events.BitsLeaderboardEvent;
@@ -12,17 +13,15 @@ class LeaderboardHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         Leaderboard leaderboard = TypeConvert.jsonToObject(args.getRawMessage(), Leaderboard.class);
         switch (leaderboard.getIdentifier().getDomain()) {
             case "bits-usage-by-channel-v1":
-                args.getEventManager().publish(new BitsLeaderboardEvent(leaderboard));
-                return true;
+                return new BitsLeaderboardEvent(leaderboard);
             case "sub-gifts-sent":
-                args.getEventManager().publish(new SubLeaderboardEvent(leaderboard));
-                return true;
+                return new SubLeaderboardEvent(leaderboard);
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
@@ -1,13 +1,9 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.Leaderboard;
 import com.github.twitch4j.pubsub.events.BitsLeaderboardEvent;
 import com.github.twitch4j.pubsub.events.SubLeaderboardEvent;
-
-import java.util.Collection;
 
 class LeaderboardHandler implements TopicHandler {
     @Override
@@ -16,14 +12,14 @@ class LeaderboardHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        Leaderboard leaderboard = TypeConvert.jsonToObject(message.getRawMessage(), Leaderboard.class);
+    public boolean handle(Args args) {
+        Leaderboard leaderboard = TypeConvert.jsonToObject(args.getRawMessage(), Leaderboard.class);
         switch (leaderboard.getIdentifier().getDomain()) {
             case "bits-usage-by-channel-v1":
-                eventManager.publish(new BitsLeaderboardEvent(leaderboard));
+                args.getEventManager().publish(new BitsLeaderboardEvent(leaderboard));
                 return true;
             case "sub-gifts-sent":
-                eventManager.publish(new SubLeaderboardEvent(leaderboard));
+                args.getEventManager().publish(new SubLeaderboardEvent(leaderboard));
                 return true;
             default:
                 return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
@@ -1,0 +1,66 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.ChannelTermsAction;
+import com.github.twitch4j.pubsub.domain.ChatModerationAction;
+import com.github.twitch4j.pubsub.domain.ModeratorUnbanRequestAction;
+import com.github.twitch4j.pubsub.events.ChannelTermsEvent;
+import com.github.twitch4j.pubsub.events.ChatModerationEvent;
+import com.github.twitch4j.pubsub.events.ModUnbanRequestActionEvent;
+
+import java.util.Collection;
+import java.util.Collections;
+
+class ModeratorHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "chat_moderator_actions";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        String type = message.getType();
+        JsonNode msgData = message.getMessageData();
+        String channelId = topicParts[topicParts.length - 1];
+        switch (type) {
+            case "moderation_action":
+                ChatModerationAction modAction = TypeConvert.convertValue(msgData, ChatModerationAction.class);
+                eventManager.publish(new ChatModerationEvent(channelId, modAction));
+                return true;
+
+            case "channel_terms_action":
+                ChannelTermsAction termsAction = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
+                eventManager.publish(new ChannelTermsEvent(channelId, termsAction));
+                return true;
+
+            case "approve_unban_request":
+            case "deny_unban_request":
+                ModeratorUnbanRequestAction unbanRequestAction = TypeConvert.convertValue(msgData, ModeratorUnbanRequestAction.class);
+                eventManager.publish(new ModUnbanRequestActionEvent(channelId, unbanRequestAction));
+                return true;
+
+            case "moderator_added":
+            case "moderator_removed":
+            case "vip_added":
+            case "vip_removed":
+                ChatModerationAction.ModerationAction act = "moderator_added".equals(type) ? ChatModerationAction.ModerationAction.MOD
+                    : "moderator_removed".equals(type) ? ChatModerationAction.ModerationAction.UNMOD
+                    : "vip_added".equals(type) ? ChatModerationAction.ModerationAction.VIP
+                    : ChatModerationAction.ModerationAction.UNVIP;
+
+                String targetUserId = msgData.path("target_user_id").asText();
+                String targetUserName = msgData.path("target_user_login").asText();
+                String createdByUserId = msgData.path("created_by_user_id").asText();
+                String createdBy = msgData.path("created_by").asText();
+                ChatModerationAction action = new ChatModerationAction("chat_login_moderation", act, Collections.singletonList(targetUserName), createdBy, createdByUserId, "", targetUserId, targetUserName, false);
+                eventManager.publish(new ChatModerationEvent(channelId, action));
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
@@ -26,16 +26,16 @@ class ModeratorHandler implements TopicHandler {
         switch (type) {
             case "moderation_action":
                 ChatModerationAction modAction = TypeConvert.convertValue(msgData, ChatModerationAction.class);
-                return (new ChatModerationEvent(channelId, modAction));
+                return new ChatModerationEvent(channelId, modAction);
 
             case "channel_terms_action":
                 ChannelTermsAction termsAction = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
-                return (new ChannelTermsEvent(channelId, termsAction));
+                return new ChannelTermsEvent(channelId, termsAction);
 
             case "approve_unban_request":
             case "deny_unban_request":
                 ModeratorUnbanRequestAction unbanRequestAction = TypeConvert.convertValue(msgData, ModeratorUnbanRequestAction.class);
-                return (new ModUnbanRequestActionEvent(channelId, unbanRequestAction));
+                return new ModUnbanRequestActionEvent(channelId, unbanRequestAction);
 
             case "moderator_added":
             case "moderator_removed":
@@ -51,7 +51,7 @@ class ModeratorHandler implements TopicHandler {
                 String createdByUserId = msgData.path("created_by_user_id").asText();
                 String createdBy = msgData.path("created_by").asText();
                 ChatModerationAction action = new ChatModerationAction("chat_login_moderation", act, Collections.singletonList(targetUserName), createdBy, createdByUserId, "", targetUserId, targetUserName, false);
-                return (new ChatModerationEvent(channelId, action));
+                return new ChatModerationEvent(channelId, action);
 
             default:
                 return null;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.ChannelTermsAction;
 import com.github.twitch4j.pubsub.domain.ChatModerationAction;
@@ -19,27 +19,23 @@ class ModeratorHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String type = args.getType();
         JsonNode msgData = args.getData();
         String channelId = args.getLastTopicPart();
-        IEventManager eventManager = args.getEventManager();
         switch (type) {
             case "moderation_action":
                 ChatModerationAction modAction = TypeConvert.convertValue(msgData, ChatModerationAction.class);
-                eventManager.publish(new ChatModerationEvent(channelId, modAction));
-                return true;
+                return (new ChatModerationEvent(channelId, modAction));
 
             case "channel_terms_action":
                 ChannelTermsAction termsAction = TypeConvert.convertValue(msgData, ChannelTermsAction.class);
-                eventManager.publish(new ChannelTermsEvent(channelId, termsAction));
-                return true;
+                return (new ChannelTermsEvent(channelId, termsAction));
 
             case "approve_unban_request":
             case "deny_unban_request":
                 ModeratorUnbanRequestAction unbanRequestAction = TypeConvert.convertValue(msgData, ModeratorUnbanRequestAction.class);
-                eventManager.publish(new ModUnbanRequestActionEvent(channelId, unbanRequestAction));
-                return true;
+                return (new ModUnbanRequestActionEvent(channelId, unbanRequestAction));
 
             case "moderator_added":
             case "moderator_removed":
@@ -55,11 +51,10 @@ class ModeratorHandler implements TopicHandler {
                 String createdByUserId = msgData.path("created_by_user_id").asText();
                 String createdBy = msgData.path("created_by").asText();
                 ChatModerationAction action = new ChatModerationAction("chat_login_moderation", act, Collections.singletonList(targetUserName), createdBy, createdByUserId, "", targetUserId, targetUserName, false);
-                eventManager.publish(new ChatModerationEvent(channelId, action));
-                return true;
+                return (new ChatModerationEvent(channelId, action));
 
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ModeratorHandler.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.ChannelTermsAction;
 import com.github.twitch4j.pubsub.domain.ChatModerationAction;
 import com.github.twitch4j.pubsub.domain.ModeratorUnbanRequestAction;
@@ -11,7 +10,6 @@ import com.github.twitch4j.pubsub.events.ChannelTermsEvent;
 import com.github.twitch4j.pubsub.events.ChatModerationEvent;
 import com.github.twitch4j.pubsub.events.ModUnbanRequestActionEvent;
 
-import java.util.Collection;
 import java.util.Collections;
 
 class ModeratorHandler implements TopicHandler {
@@ -21,10 +19,11 @@ class ModeratorHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        String type = message.getType();
-        JsonNode msgData = message.getMessageData();
-        String channelId = topicParts[topicParts.length - 1];
+    public boolean handle(Args args) {
+        String type = args.getType();
+        JsonNode msgData = args.getData();
+        String channelId = args.getLastTopicPart();
+        IEventManager eventManager = args.getEventManager();
         switch (type) {
             case "moderation_action":
                 ChatModerationAction modAction = TypeConvert.convertValue(msgData, ChatModerationAction.class);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CreateNotificationData;
+import com.github.twitch4j.pubsub.domain.UpdateSummaryData;
+import com.github.twitch4j.pubsub.events.OnsiteNotificationCreationEvent;
+import com.github.twitch4j.pubsub.events.UpdateOnsiteNotificationSummaryEvent;
+
+import java.util.Collection;
+
+class NotificationHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "onsite-notifications";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("create-notification".equalsIgnoreCase(message.getType())) {
+            CreateNotificationData data = TypeConvert.convertValue(message.getMessageData(), CreateNotificationData.class);
+            eventManager.publish(new OnsiteNotificationCreationEvent(data));
+            return true;
+        } else if ("update-summary".equalsIgnoreCase(message.getType())) {
+            UpdateSummaryData data = TypeConvert.convertValue(message.getMessageData(), UpdateSummaryData.class);
+            eventManager.publish(new UpdateOnsiteNotificationSummaryEvent(topicParts[topicParts.length - 1], data));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
@@ -17,10 +17,10 @@ class NotificationHandler implements TopicHandler {
     public TwitchEvent apply(Args args) {
         if ("create-notification".equalsIgnoreCase(args.getType())) {
             CreateNotificationData data = TypeConvert.convertValue(args.getData(), CreateNotificationData.class);
-            return (new OnsiteNotificationCreationEvent(data));
+            return new OnsiteNotificationCreationEvent(data);
         } else if ("update-summary".equalsIgnoreCase(args.getType())) {
             UpdateSummaryData data = TypeConvert.convertValue(args.getData(), UpdateSummaryData.class);
-            return (new UpdateOnsiteNotificationSummaryEvent(args.getLastTopicPart(), data));
+            return new UpdateOnsiteNotificationSummaryEvent(args.getLastTopicPart(), data);
         }
         return null;
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CreateNotificationData;
 import com.github.twitch4j.pubsub.domain.UpdateSummaryData;
@@ -13,16 +14,14 @@ class NotificationHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("create-notification".equalsIgnoreCase(args.getType())) {
             CreateNotificationData data = TypeConvert.convertValue(args.getData(), CreateNotificationData.class);
-            args.getEventManager().publish(new OnsiteNotificationCreationEvent(data));
-            return true;
+            return (new OnsiteNotificationCreationEvent(data));
         } else if ("update-summary".equalsIgnoreCase(args.getType())) {
             UpdateSummaryData data = TypeConvert.convertValue(args.getData(), UpdateSummaryData.class);
-            args.getEventManager().publish(new UpdateOnsiteNotificationSummaryEvent(args.getLastTopicPart(), data));
-            return true;
+            return (new UpdateOnsiteNotificationSummaryEvent(args.getLastTopicPart(), data));
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/NotificationHandler.java
@@ -1,14 +1,10 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CreateNotificationData;
 import com.github.twitch4j.pubsub.domain.UpdateSummaryData;
 import com.github.twitch4j.pubsub.events.OnsiteNotificationCreationEvent;
 import com.github.twitch4j.pubsub.events.UpdateOnsiteNotificationSummaryEvent;
-
-import java.util.Collection;
 
 class NotificationHandler implements TopicHandler {
     @Override
@@ -17,14 +13,14 @@ class NotificationHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("create-notification".equalsIgnoreCase(message.getType())) {
-            CreateNotificationData data = TypeConvert.convertValue(message.getMessageData(), CreateNotificationData.class);
-            eventManager.publish(new OnsiteNotificationCreationEvent(data));
+    public boolean handle(Args args) {
+        if ("create-notification".equalsIgnoreCase(args.getType())) {
+            CreateNotificationData data = TypeConvert.convertValue(args.getData(), CreateNotificationData.class);
+            args.getEventManager().publish(new OnsiteNotificationCreationEvent(data));
             return true;
-        } else if ("update-summary".equalsIgnoreCase(message.getType())) {
-            UpdateSummaryData data = TypeConvert.convertValue(message.getMessageData(), UpdateSummaryData.class);
-            eventManager.publish(new UpdateOnsiteNotificationSummaryEvent(topicParts[topicParts.length - 1], data));
+        } else if ("update-summary".equalsIgnoreCase(args.getType())) {
+            UpdateSummaryData data = TypeConvert.convertValue(args.getData(), UpdateSummaryData.class);
+            args.getEventManager().publish(new UpdateOnsiteNotificationSummaryEvent(args.getLastTopicPart(), data));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
@@ -22,13 +22,13 @@ class PinHandler implements TopicHandler {
         switch (args.getType()) {
             case "pin-message":
                 PinnedChatData createdPin = TypeConvert.convertValue(msgData, PinnedChatData.class);
-                return (new PinnedChatCreatedEvent(args.getLastTopicPart(), createdPin));
+                return new PinnedChatCreatedEvent(args.getLastTopicPart(), createdPin);
             case "update-message":
                 UpdatedPinnedChatTiming updatedPin = TypeConvert.convertValue(msgData, UpdatedPinnedChatTiming.class);
-                return (new PinnedChatTimingUpdatedEvent(args.getLastTopicPart(), updatedPin));
+                return new PinnedChatTimingUpdatedEvent(args.getLastTopicPart(), updatedPin);
             case "unpin-message":
                 DeletePinnedChatData deletePin = TypeConvert.convertValue(msgData, DeletePinnedChatData.class);
-                return (new PinnedChatDeletedEvent(args.getLastTopicPart(), deletePin));
+                return new PinnedChatDeletedEvent(args.getLastTopicPart(), deletePin);
             default:
                 return null;
         }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
@@ -1,0 +1,43 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.DeletePinnedChatData;
+import com.github.twitch4j.pubsub.domain.PinnedChatData;
+import com.github.twitch4j.pubsub.domain.UpdatedPinnedChatTiming;
+import com.github.twitch4j.pubsub.events.PinnedChatCreatedEvent;
+import com.github.twitch4j.pubsub.events.PinnedChatDeletedEvent;
+import com.github.twitch4j.pubsub.events.PinnedChatTimingUpdatedEvent;
+
+import java.util.Collection;
+
+class PinHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "pinned-chat-updates-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        JsonNode msgData = message.getMessageData();
+        String lastTopicIdentifier = topicParts[topicParts.length - 1];
+        switch (message.getType()) {
+            case "pin-message":
+                PinnedChatData createdPin = TypeConvert.convertValue(msgData, PinnedChatData.class);
+                eventManager.publish(new PinnedChatCreatedEvent(lastTopicIdentifier, createdPin));
+                return true;
+            case "update-message":
+                UpdatedPinnedChatTiming updatedPin = TypeConvert.convertValue(msgData, UpdatedPinnedChatTiming.class);
+                eventManager.publish(new PinnedChatTimingUpdatedEvent(lastTopicIdentifier, updatedPin));
+                return true;
+            case "unpin-message":
+                DeletePinnedChatData deletePin = TypeConvert.convertValue(msgData, DeletePinnedChatData.class);
+                eventManager.publish(new PinnedChatDeletedEvent(lastTopicIdentifier, deletePin));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.DeletePinnedChatData;
 import com.github.twitch4j.pubsub.domain.PinnedChatData;
@@ -17,24 +17,20 @@ class PinHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         JsonNode msgData = args.getData();
-        IEventManager eventManager = args.getEventManager();
         switch (args.getType()) {
             case "pin-message":
                 PinnedChatData createdPin = TypeConvert.convertValue(msgData, PinnedChatData.class);
-                eventManager.publish(new PinnedChatCreatedEvent(args.getLastTopicPart(), createdPin));
-                return true;
+                return (new PinnedChatCreatedEvent(args.getLastTopicPart(), createdPin));
             case "update-message":
                 UpdatedPinnedChatTiming updatedPin = TypeConvert.convertValue(msgData, UpdatedPinnedChatTiming.class);
-                eventManager.publish(new PinnedChatTimingUpdatedEvent(args.getLastTopicPart(), updatedPin));
-                return true;
+                return (new PinnedChatTimingUpdatedEvent(args.getLastTopicPart(), updatedPin));
             case "unpin-message":
                 DeletePinnedChatData deletePin = TypeConvert.convertValue(msgData, DeletePinnedChatData.class);
-                eventManager.publish(new PinnedChatDeletedEvent(args.getLastTopicPart(), deletePin));
-                return true;
+                return (new PinnedChatDeletedEvent(args.getLastTopicPart(), deletePin));
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PinHandler.java
@@ -3,15 +3,12 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.DeletePinnedChatData;
 import com.github.twitch4j.pubsub.domain.PinnedChatData;
 import com.github.twitch4j.pubsub.domain.UpdatedPinnedChatTiming;
 import com.github.twitch4j.pubsub.events.PinnedChatCreatedEvent;
 import com.github.twitch4j.pubsub.events.PinnedChatDeletedEvent;
 import com.github.twitch4j.pubsub.events.PinnedChatTimingUpdatedEvent;
-
-import java.util.Collection;
 
 class PinHandler implements TopicHandler {
     @Override
@@ -20,21 +17,21 @@ class PinHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        JsonNode msgData = message.getMessageData();
-        String lastTopicIdentifier = topicParts[topicParts.length - 1];
-        switch (message.getType()) {
+    public boolean handle(Args args) {
+        JsonNode msgData = args.getData();
+        IEventManager eventManager = args.getEventManager();
+        switch (args.getType()) {
             case "pin-message":
                 PinnedChatData createdPin = TypeConvert.convertValue(msgData, PinnedChatData.class);
-                eventManager.publish(new PinnedChatCreatedEvent(lastTopicIdentifier, createdPin));
+                eventManager.publish(new PinnedChatCreatedEvent(args.getLastTopicPart(), createdPin));
                 return true;
             case "update-message":
                 UpdatedPinnedChatTiming updatedPin = TypeConvert.convertValue(msgData, UpdatedPinnedChatTiming.class);
-                eventManager.publish(new PinnedChatTimingUpdatedEvent(lastTopicIdentifier, updatedPin));
+                eventManager.publish(new PinnedChatTimingUpdatedEvent(args.getLastTopicPart(), updatedPin));
                 return true;
             case "unpin-message":
                 DeletePinnedChatData deletePin = TypeConvert.convertValue(msgData, DeletePinnedChatData.class);
-                eventManager.publish(new PinnedChatDeletedEvent(lastTopicIdentifier, deletePin));
+                eventManager.publish(new PinnedChatDeletedEvent(args.getLastTopicPart(), deletePin));
                 return true;
             default:
                 return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.VideoPlaybackData;
 import com.github.twitch4j.pubsub.events.VideoPlaybackEvent;
@@ -19,11 +20,10 @@ class PlaybackHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         boolean hasId = args.getTopicParts()[0].endsWith("d");
         String lastTopicIdentifier = args.getLastTopicPart();
         VideoPlaybackData data = TypeConvert.jsonToObject(args.getRawMessage(), VideoPlaybackData.class);
-        args.getEventManager().publish(new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
-        return true;
+        return (new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
@@ -24,6 +24,6 @@ class PlaybackHandler implements TopicHandler {
         boolean hasId = args.getTopicParts()[0].endsWith("d");
         String lastTopicIdentifier = args.getLastTopicPart();
         VideoPlaybackData data = TypeConvert.jsonToObject(args.getRawMessage(), VideoPlaybackData.class);
-        return (new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
+        return new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.VideoPlaybackData;
+import com.github.twitch4j.pubsub.events.VideoPlaybackEvent;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+class PlaybackHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "video-playback-by-id";
+    }
+
+    @Override
+    public Collection<String> topicNames() {
+        return Arrays.asList(topicName(), "video-playback");
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        boolean hasId = topicParts[0].endsWith("d");
+        String lastTopicIdentifier = topicParts[topicParts.length - 1];
+        VideoPlaybackData data = TypeConvert.jsonToObject(message.getRawMessage(), VideoPlaybackData.class);
+        eventManager.publish(new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PlaybackHandler.java
@@ -1,8 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.VideoPlaybackData;
 import com.github.twitch4j.pubsub.events.VideoPlaybackEvent;
 
@@ -21,11 +19,11 @@ class PlaybackHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        boolean hasId = topicParts[0].endsWith("d");
-        String lastTopicIdentifier = topicParts[topicParts.length - 1];
-        VideoPlaybackData data = TypeConvert.jsonToObject(message.getRawMessage(), VideoPlaybackData.class);
-        eventManager.publish(new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
+    public boolean handle(Args args) {
+        boolean hasId = args.getTopicParts()[0].endsWith("d");
+        String lastTopicIdentifier = args.getLastTopicPart();
+        VideoPlaybackData data = TypeConvert.jsonToObject(args.getRawMessage(), VideoPlaybackData.class);
+        args.getEventManager().publish(new VideoPlaybackEvent(hasId ? lastTopicIdentifier : null, hasId ? null : lastTopicIdentifier, data));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.PollData;
+import com.github.twitch4j.pubsub.events.PollsEvent;
+
+import java.util.Collection;
+
+class PollsHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "polls";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        PollData pollData = TypeConvert.convertValue(message.getMessageData().path("poll"), PollData.class);
+        eventManager.publish(new PollsEvent(message.getType(), pollData));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.PollData;
 import com.github.twitch4j.pubsub.events.PollsEvent;
@@ -11,9 +12,8 @@ class PollsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         PollData pollData = TypeConvert.convertValue(args.getData().path("poll"), PollData.class);
-        args.getEventManager().publish(new PollsEvent(args.getType(), pollData));
-        return true;
+        return (new PollsEvent(args.getType(), pollData));
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
@@ -14,6 +14,6 @@ class PollsHandler implements TopicHandler {
     @Override
     public TwitchEvent apply(Args args) {
         PollData pollData = TypeConvert.convertValue(args.getData().path("poll"), PollData.class);
-        return (new PollsEvent(args.getType(), pollData));
+        return new PollsEvent(args.getType(), pollData);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PollsHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.PollData;
 import com.github.twitch4j.pubsub.events.PollsEvent;
-
-import java.util.Collection;
 
 class PollsHandler implements TopicHandler {
     @Override
@@ -15,9 +11,9 @@ class PollsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        PollData pollData = TypeConvert.convertValue(message.getMessageData().path("poll"), PollData.class);
-        eventManager.publish(new PollsEvent(message.getType(), pollData));
+    public boolean handle(Args args) {
+        PollData pollData = TypeConvert.convertValue(args.getData().path("poll"), PollData.class);
+        args.getEventManager().publish(new PollsEvent(args.getType(), pollData));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
@@ -14,9 +14,9 @@ class PredictionHandler implements TopicHandler {
     @Override
     public TwitchEvent apply(Args args) {
         if ("event-created".equals(args.getType())) {
-            return (TypeConvert.convertValue(args.getData(), PredictionCreatedEvent.class));
+            return TypeConvert.convertValue(args.getData(), PredictionCreatedEvent.class);
         } else if ("event-updated".equals(args.getType())) {
-            return (TypeConvert.convertValue(args.getData(), PredictionUpdatedEvent.class));
+            return TypeConvert.convertValue(args.getData(), PredictionUpdatedEvent.class);
         }
         return null;
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.events.PredictionCreatedEvent;
+import com.github.twitch4j.pubsub.events.PredictionUpdatedEvent;
+
+import java.util.Collection;
+
+class PredictionHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "predictions-channel-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("event-created".equals(message.getType())) {
+            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), PredictionCreatedEvent.class));
+            return true;
+        } else if ("event-updated".equals(message.getType())) {
+            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), PredictionUpdatedEvent.class));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.events.PredictionCreatedEvent;
 import com.github.twitch4j.pubsub.events.PredictionUpdatedEvent;
-
-import java.util.Collection;
 
 class PredictionHandler implements TopicHandler {
     @Override
@@ -15,12 +11,12 @@ class PredictionHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("event-created".equals(message.getType())) {
-            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), PredictionCreatedEvent.class));
+    public boolean handle(Args args) {
+        if ("event-created".equals(args.getType())) {
+            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), PredictionCreatedEvent.class));
             return true;
-        } else if ("event-updated".equals(message.getType())) {
-            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), PredictionUpdatedEvent.class));
+        } else if ("event-updated".equals(args.getType())) {
+            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), PredictionUpdatedEvent.class));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/PredictionHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.events.PredictionCreatedEvent;
 import com.github.twitch4j.pubsub.events.PredictionUpdatedEvent;
@@ -11,14 +12,12 @@ class PredictionHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("event-created".equals(args.getType())) {
-            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), PredictionCreatedEvent.class));
-            return true;
+            return (TypeConvert.convertValue(args.getData(), PredictionCreatedEvent.class));
         } else if ("event-updated".equals(args.getType())) {
-            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), PredictionUpdatedEvent.class));
-            return true;
+            return (TypeConvert.convertValue(args.getData(), PredictionUpdatedEvent.class));
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
@@ -16,11 +16,11 @@ class RaidHandler implements TopicHandler {
     public TwitchEvent apply(Args args) {
         switch (args.getType()) {
             case "raid_go_v2":
-                return (TypeConvert.jsonToObject(args.getRawMessage(), RaidGoEvent.class));
+                return TypeConvert.jsonToObject(args.getRawMessage(), RaidGoEvent.class);
             case "raid_update_v2":
-                return (TypeConvert.jsonToObject(args.getRawMessage(), RaidUpdateEvent.class));
+                return TypeConvert.jsonToObject(args.getRawMessage(), RaidUpdateEvent.class);
             case "raid_cancel_v2":
-                return (TypeConvert.jsonToObject(args.getRawMessage(), RaidCancelEvent.class));
+                return TypeConvert.jsonToObject(args.getRawMessage(), RaidCancelEvent.class);
             default:
                 return null;
         }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
@@ -2,12 +2,9 @@ package com.github.twitch4j.pubsub.handlers;
 
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.events.RaidCancelEvent;
 import com.github.twitch4j.pubsub.events.RaidGoEvent;
 import com.github.twitch4j.pubsub.events.RaidUpdateEvent;
-
-import java.util.Collection;
 
 class RaidHandler implements TopicHandler {
     @Override
@@ -16,16 +13,17 @@ class RaidHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        switch (message.getType()) {
+    public boolean handle(Args args) {
+        IEventManager eventManager = args.getEventManager();
+        switch (args.getType()) {
             case "raid_go_v2":
-                eventManager.publish(TypeConvert.jsonToObject(message.getRawMessage(), RaidGoEvent.class));
+                eventManager.publish(TypeConvert.jsonToObject(args.getRawMessage(), RaidGoEvent.class));
                 return true;
             case "raid_update_v2":
-                eventManager.publish(TypeConvert.jsonToObject(message.getRawMessage(), RaidUpdateEvent.class));
+                eventManager.publish(TypeConvert.jsonToObject(args.getRawMessage(), RaidUpdateEvent.class));
                 return true;
             case "raid_cancel_v2":
-                eventManager.publish(TypeConvert.jsonToObject(message.getRawMessage(), RaidCancelEvent.class));
+                eventManager.publish(TypeConvert.jsonToObject(args.getRawMessage(), RaidCancelEvent.class));
                 return true;
             default:
                 return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
@@ -1,6 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.events.RaidCancelEvent;
 import com.github.twitch4j.pubsub.events.RaidGoEvent;
@@ -13,20 +13,16 @@ class RaidHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
-        IEventManager eventManager = args.getEventManager();
+    public TwitchEvent apply(Args args) {
         switch (args.getType()) {
             case "raid_go_v2":
-                eventManager.publish(TypeConvert.jsonToObject(args.getRawMessage(), RaidGoEvent.class));
-                return true;
+                return (TypeConvert.jsonToObject(args.getRawMessage(), RaidGoEvent.class));
             case "raid_update_v2":
-                eventManager.publish(TypeConvert.jsonToObject(args.getRawMessage(), RaidUpdateEvent.class));
-                return true;
+                return (TypeConvert.jsonToObject(args.getRawMessage(), RaidUpdateEvent.class));
             case "raid_cancel_v2":
-                eventManager.publish(TypeConvert.jsonToObject(args.getRawMessage(), RaidCancelEvent.class));
-                return true;
+                return (TypeConvert.jsonToObject(args.getRawMessage(), RaidCancelEvent.class));
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/RaidHandler.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.events.RaidCancelEvent;
+import com.github.twitch4j.pubsub.events.RaidGoEvent;
+import com.github.twitch4j.pubsub.events.RaidUpdateEvent;
+
+import java.util.Collection;
+
+class RaidHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "raid";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        switch (message.getType()) {
+            case "raid_go_v2":
+                eventManager.publish(TypeConvert.jsonToObject(message.getRawMessage(), RaidGoEvent.class));
+                return true;
+            case "raid_update_v2":
+                eventManager.publish(TypeConvert.jsonToObject(message.getRawMessage(), RaidUpdateEvent.class));
+                return true;
+            case "raid_cancel_v2":
+                eventManager.publish(TypeConvert.jsonToObject(message.getRawMessage(), RaidCancelEvent.class));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.BannedTermAdded;
 import com.github.twitch4j.pubsub.domain.BannedTermRemoved;
@@ -19,40 +19,35 @@ class ShieldHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
-        if (topicParts.length != 3) return false;
+        if (topicParts.length != 3) return null;
         String userId = topicParts[1];
         String channelId = topicParts[2];
         JsonNode msgData = args.getData();
-        IEventManager eventManager = args.getEventManager();
         switch (args.getType()) {
             case "ADD_AUTOBAN_TERM":
                 BannedTermAdded termAdded = TypeConvert.convertValue(msgData, BannedTermAdded.class);
-                eventManager.publish(new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded));
-                return true;
+                return (new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded));
 
             case "REMOVE_AUTOBAN_TERM":
                 BannedTermRemoved termRemoved = TypeConvert.convertValue(msgData, BannedTermRemoved.class);
-                eventManager.publish(new ShieldModeBannedTermRemovedEvent(userId, channelId, termRemoved));
-                return true;
+                return (new ShieldModeBannedTermRemovedEvent(userId, channelId, termRemoved));
 
             case "UPDATE_CHANNEL_MODERATION_MODE":
                 ShieldModeStatus shieldModeStatus = TypeConvert.convertValue(msgData, ShieldModeStatus.class);
-                eventManager.publish(new ShieldModeStatusUpdatedEvent(userId, channelId, shieldModeStatus));
-                return true;
+                return (new ShieldModeStatusUpdatedEvent(userId, channelId, shieldModeStatus));
 
             case "UPDATE_CHANNEL_MODERATION_SETTINGS":
                 ShieldModeSettings shieldModeSettings = TypeConvert.convertValue(msgData, ShieldModeSettings.class);
-                eventManager.publish(new ShieldModeSettingsUpdatedEvent(userId, channelId, shieldModeSettings));
-                return true;
+                return (new ShieldModeSettingsUpdatedEvent(userId, channelId, shieldModeSettings));
 
             case "UPDATE_CHANNEL_MODERATION_MODE_SHORTCUT":
                 // do nothing; is_shortcut_enabled is unimportant
-                return true;
+                return new TwitchEvent() {};
 
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
@@ -28,19 +28,19 @@ class ShieldHandler implements TopicHandler {
         switch (args.getType()) {
             case "ADD_AUTOBAN_TERM":
                 BannedTermAdded termAdded = TypeConvert.convertValue(msgData, BannedTermAdded.class);
-                return (new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded));
+                return new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded);
 
             case "REMOVE_AUTOBAN_TERM":
                 BannedTermRemoved termRemoved = TypeConvert.convertValue(msgData, BannedTermRemoved.class);
-                return (new ShieldModeBannedTermRemovedEvent(userId, channelId, termRemoved));
+                return new ShieldModeBannedTermRemovedEvent(userId, channelId, termRemoved);
 
             case "UPDATE_CHANNEL_MODERATION_MODE":
                 ShieldModeStatus shieldModeStatus = TypeConvert.convertValue(msgData, ShieldModeStatus.class);
-                return (new ShieldModeStatusUpdatedEvent(userId, channelId, shieldModeStatus));
+                return new ShieldModeStatusUpdatedEvent(userId, channelId, shieldModeStatus);
 
             case "UPDATE_CHANNEL_MODERATION_SETTINGS":
                 ShieldModeSettings shieldModeSettings = TypeConvert.convertValue(msgData, ShieldModeSettings.class);
-                return (new ShieldModeSettingsUpdatedEvent(userId, channelId, shieldModeSettings));
+                return new ShieldModeSettingsUpdatedEvent(userId, channelId, shieldModeSettings);
 
             case "UPDATE_CHANNEL_MODERATION_MODE_SHORTCUT":
                 // do nothing; is_shortcut_enabled is unimportant

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
@@ -1,0 +1,59 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.BannedTermAdded;
+import com.github.twitch4j.pubsub.domain.BannedTermRemoved;
+import com.github.twitch4j.pubsub.domain.ShieldModeSettings;
+import com.github.twitch4j.pubsub.domain.ShieldModeStatus;
+import com.github.twitch4j.pubsub.events.ShieldModeBannedTermAddedEvent;
+import com.github.twitch4j.pubsub.events.ShieldModeBannedTermRemovedEvent;
+import com.github.twitch4j.pubsub.events.ShieldModeSettingsUpdatedEvent;
+import com.github.twitch4j.pubsub.events.ShieldModeStatusUpdatedEvent;
+
+import java.util.Collection;
+
+class ShieldHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "shield-mode";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length != 3) return false;
+        String userId = topicParts[1];
+        String channelId = topicParts[2];
+        JsonNode msgData = message.getMessageData();
+        switch (message.getType()) {
+            case "ADD_AUTOBAN_TERM":
+                BannedTermAdded termAdded = TypeConvert.convertValue(msgData, BannedTermAdded.class);
+                eventManager.publish(new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded));
+                return true;
+
+            case "REMOVE_AUTOBAN_TERM":
+                BannedTermRemoved termRemoved = TypeConvert.convertValue(msgData, BannedTermRemoved.class);
+                eventManager.publish(new ShieldModeBannedTermRemovedEvent(userId, channelId, termRemoved));
+                return true;
+
+            case "UPDATE_CHANNEL_MODERATION_MODE":
+                ShieldModeStatus shieldModeStatus = TypeConvert.convertValue(msgData, ShieldModeStatus.class);
+                eventManager.publish(new ShieldModeStatusUpdatedEvent(userId, channelId, shieldModeStatus));
+                return true;
+
+            case "UPDATE_CHANNEL_MODERATION_SETTINGS":
+                ShieldModeSettings shieldModeSettings = TypeConvert.convertValue(msgData, ShieldModeSettings.class);
+                eventManager.publish(new ShieldModeSettingsUpdatedEvent(userId, channelId, shieldModeSettings));
+                return true;
+
+            case "UPDATE_CHANNEL_MODERATION_MODE_SHORTCUT":
+                // do nothing; is_shortcut_enabled is unimportant
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShieldHandler.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.BannedTermAdded;
 import com.github.twitch4j.pubsub.domain.BannedTermRemoved;
 import com.github.twitch4j.pubsub.domain.ShieldModeSettings;
@@ -13,8 +12,6 @@ import com.github.twitch4j.pubsub.events.ShieldModeBannedTermRemovedEvent;
 import com.github.twitch4j.pubsub.events.ShieldModeSettingsUpdatedEvent;
 import com.github.twitch4j.pubsub.events.ShieldModeStatusUpdatedEvent;
 
-import java.util.Collection;
-
 class ShieldHandler implements TopicHandler {
     @Override
     public String topicName() {
@@ -22,12 +19,14 @@ class ShieldHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
         if (topicParts.length != 3) return false;
         String userId = topicParts[1];
         String channelId = topicParts[2];
-        JsonNode msgData = message.getMessageData();
-        switch (message.getType()) {
+        JsonNode msgData = args.getData();
+        IEventManager eventManager = args.getEventManager();
+        switch (args.getType()) {
             case "ADD_AUTOBAN_TERM":
                 BannedTermAdded termAdded = TypeConvert.convertValue(msgData, BannedTermAdded.class);
                 eventManager.publish(new ShieldModeBannedTermAddedEvent(userId, channelId, termAdded));

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShoutoutHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShoutoutHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CreateShoutoutData;
+import com.github.twitch4j.pubsub.events.ShoutoutCreatedEvent;
+
+import java.util.Collection;
+
+class ShoutoutHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "shoutout";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("create".equalsIgnoreCase(message.getType())) {
+            CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(message.getMessageData(), CreateShoutoutData.class);
+            eventManager.publish(new ShoutoutCreatedEvent(topicParts[topicParts.length - 1], shoutoutInfo));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShoutoutHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShoutoutHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CreateShoutoutData;
 import com.github.twitch4j.pubsub.events.ShoutoutCreatedEvent;
@@ -11,12 +12,11 @@ class ShoutoutHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("create".equalsIgnoreCase(args.getType())) {
             CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(args.getData(), CreateShoutoutData.class);
-            args.getEventManager().publish(new ShoutoutCreatedEvent(args.getLastTopicPart(), shoutoutInfo));
-            return true;
+            return new ShoutoutCreatedEvent(args.getLastTopicPart(), shoutoutInfo);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShoutoutHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/ShoutoutHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CreateShoutoutData;
 import com.github.twitch4j.pubsub.events.ShoutoutCreatedEvent;
-
-import java.util.Collection;
 
 class ShoutoutHandler implements TopicHandler {
     @Override
@@ -15,10 +11,10 @@ class ShoutoutHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("create".equalsIgnoreCase(message.getType())) {
-            CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(message.getMessageData(), CreateShoutoutData.class);
-            eventManager.publish(new ShoutoutCreatedEvent(topicParts[topicParts.length - 1], shoutoutInfo));
+    public boolean handle(Args args) {
+        if ("create".equalsIgnoreCase(args.getType())) {
+            CreateShoutoutData shoutoutInfo = TypeConvert.convertValue(args.getData(), CreateShoutoutData.class);
+            args.getEventManager().publish(new ShoutoutCreatedEvent(args.getLastTopicPart(), shoutoutInfo));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SubscriptionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SubscriptionHandler.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.SubscriptionData;
+import com.github.twitch4j.pubsub.events.ChannelSubscribeEvent;
+
+import java.util.Collection;
+
+class SubscriptionHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-subscribe-events-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        SubscriptionData data = TypeConvert.jsonToObject(message.getRawMessage(), SubscriptionData.class);
+        eventManager.publish(new ChannelSubscribeEvent(data));
+        return true;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SubscriptionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SubscriptionHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.SubscriptionData;
 import com.github.twitch4j.pubsub.events.ChannelSubscribeEvent;
-
-import java.util.Collection;
 
 class SubscriptionHandler implements TopicHandler {
     @Override
@@ -15,9 +11,9 @@ class SubscriptionHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        SubscriptionData data = TypeConvert.jsonToObject(message.getRawMessage(), SubscriptionData.class);
-        eventManager.publish(new ChannelSubscribeEvent(data));
+    public boolean handle(Args args) {
+        SubscriptionData data = TypeConvert.jsonToObject(args.getRawMessage(), SubscriptionData.class);
+        args.getEventManager().publish(new ChannelSubscribeEvent(data));
         return true;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SubscriptionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SubscriptionHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.SubscriptionData;
 import com.github.twitch4j.pubsub.events.ChannelSubscribeEvent;
@@ -11,9 +12,8 @@ class SubscriptionHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         SubscriptionData data = TypeConvert.jsonToObject(args.getRawMessage(), SubscriptionData.class);
-        args.getEventManager().publish(new ChannelSubscribeEvent(data));
-        return true;
+        return new ChannelSubscribeEvent(data);
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SuspiciousHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SuspiciousHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.BanSharingSettings;
 import com.github.twitch4j.pubsub.domain.LowTrustUserNewMessage;
@@ -17,24 +17,20 @@ class SuspiciousHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
-        if (topicParts.length != 3) return false;
+        if (topicParts.length != 3) return null;
         String userId = topicParts[1];
         String channelId = topicParts[2];
         String type = args.getType();
         JsonNode msgData = args.getData();
-        IEventManager eventManager = args.getEventManager();
         if ("low_trust_user_new_message".equals(type)) {
-            eventManager.publish(new LowTrustUserNewMessageEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserNewMessage.class)));
-            return true;
+            return new LowTrustUserNewMessageEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserNewMessage.class));
         } else if ("low_trust_user_treatment_update".equals(type)) {
-            eventManager.publish(new LowTrustUserTreatmentUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserTreatmentUpdate.class)));
-            return true;
+            return new LowTrustUserTreatmentUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserTreatmentUpdate.class));
         } else if ("bans_sharing_settings_update".equals(type)) {
-            eventManager.publish(new BanSharingSettingsUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, BanSharingSettings.class)));
-            return true;
+            return new BanSharingSettingsUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, BanSharingSettings.class));
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SuspiciousHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SuspiciousHandler.java
@@ -3,15 +3,12 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.BanSharingSettings;
 import com.github.twitch4j.pubsub.domain.LowTrustUserNewMessage;
 import com.github.twitch4j.pubsub.domain.LowTrustUserTreatmentUpdate;
 import com.github.twitch4j.pubsub.events.BanSharingSettingsUpdateEvent;
 import com.github.twitch4j.pubsub.events.LowTrustUserNewMessageEvent;
 import com.github.twitch4j.pubsub.events.LowTrustUserTreatmentUpdateEvent;
-
-import java.util.Collection;
 
 class SuspiciousHandler implements TopicHandler {
     @Override
@@ -20,12 +17,14 @@ class SuspiciousHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
         if (topicParts.length != 3) return false;
         String userId = topicParts[1];
         String channelId = topicParts[2];
-        String type = message.getType();
-        JsonNode msgData = message.getMessageData();
+        String type = args.getType();
+        JsonNode msgData = args.getData();
+        IEventManager eventManager = args.getEventManager();
         if ("low_trust_user_new_message".equals(type)) {
             eventManager.publish(new LowTrustUserNewMessageEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserNewMessage.class)));
             return true;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SuspiciousHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/SuspiciousHandler.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.BanSharingSettings;
+import com.github.twitch4j.pubsub.domain.LowTrustUserNewMessage;
+import com.github.twitch4j.pubsub.domain.LowTrustUserTreatmentUpdate;
+import com.github.twitch4j.pubsub.events.BanSharingSettingsUpdateEvent;
+import com.github.twitch4j.pubsub.events.LowTrustUserNewMessageEvent;
+import com.github.twitch4j.pubsub.events.LowTrustUserTreatmentUpdateEvent;
+
+import java.util.Collection;
+
+class SuspiciousHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "low-trust-users";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length != 3) return false;
+        String userId = topicParts[1];
+        String channelId = topicParts[2];
+        String type = message.getType();
+        JsonNode msgData = message.getMessageData();
+        if ("low_trust_user_new_message".equals(type)) {
+            eventManager.publish(new LowTrustUserNewMessageEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserNewMessage.class)));
+            return true;
+        } else if ("low_trust_user_treatment_update".equals(type)) {
+            eventManager.publish(new LowTrustUserTreatmentUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, LowTrustUserTreatmentUpdate.class)));
+            return true;
+        } else if ("bans_sharing_settings_update".equals(type)) {
+            eventManager.publish(new BanSharingSettingsUpdateEvent(userId, channelId, TypeConvert.convertValue(msgData, BanSharingSettings.class)));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TopicHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TopicHandler.java
@@ -1,18 +1,17 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import lombok.Value;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 
-public interface TopicHandler {
+public interface TopicHandler extends Function<TopicHandler.Args, TwitchEvent> {
 
     String topicName();
-
-    boolean handle(Args args);
 
     default Collection<String> topicNames() {
         return Collections.singletonList(topicName());
@@ -20,7 +19,6 @@ public interface TopicHandler {
 
     @Value
     class Args {
-        IEventManager eventManager;
         String[] topicParts;
         PubSubResponsePayloadMessage message;
         Collection<String> botOwnerIds;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TopicHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TopicHandler.java
@@ -1,0 +1,19 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public interface TopicHandler {
+
+    String topicName();
+
+    boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds);
+
+    default Collection<String> topicNames() {
+        return Collections.singletonList(topicName());
+    }
+
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TopicHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TopicHandler.java
@@ -1,7 +1,9 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import lombok.Value;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -10,10 +12,33 @@ public interface TopicHandler {
 
     String topicName();
 
-    boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds);
+    boolean handle(Args args);
 
     default Collection<String> topicNames() {
         return Collections.singletonList(topicName());
     }
 
+    @Value
+    class Args {
+        IEventManager eventManager;
+        String[] topicParts;
+        PubSubResponsePayloadMessage message;
+        Collection<String> botOwnerIds;
+
+        public String getType() {
+            return message.getType();
+        }
+
+        public JsonNode getData() {
+            return message.getMessageData();
+        }
+
+        public String getRawMessage() {
+            return message.getRawMessage();
+        }
+
+        public String getLastTopicPart() {
+            return topicParts[topicParts.length - 1];
+        }
+    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.HypeLevelUp;
 import com.github.twitch4j.pubsub.domain.HypeProgression;
 import com.github.twitch4j.pubsub.domain.HypeTrainApproaching;
@@ -22,8 +21,6 @@ import com.github.twitch4j.pubsub.events.HypeTrainRewardsEvent;
 import com.github.twitch4j.pubsub.events.HypeTrainStartEvent;
 import com.github.twitch4j.pubsub.events.SupportActivityFeedEvent;
 
-import java.util.Collection;
-
 class TrainHandler implements TopicHandler {
     @Override
     public String topicName() {
@@ -31,14 +28,16 @@ class TrainHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
+        IEventManager eventManager = args.getEventManager();
         if (topicParts.length > 2 && "rewards".equals(topicParts[1])) {
-            eventManager.publish(new HypeTrainRewardsEvent(TypeConvert.convertValue(message.getMessageData(), HypeTrainRewardsData.class)));
+            eventManager.publish(new HypeTrainRewardsEvent(TypeConvert.convertValue(args.getData(), HypeTrainRewardsData.class)));
             return true;
         }
-        JsonNode msgData = message.getMessageData();
-        String lastTopicIdentifier = topicParts[topicParts.length - 1];
-        switch (message.getType()) {
+        JsonNode msgData = args.getData();
+        String lastTopicIdentifier = args.getLastTopicPart();
+        switch (args.getType()) {
             case "hype-train-approaching":
                 final HypeTrainApproaching approachData = TypeConvert.convertValue(msgData, HypeTrainApproaching.class);
                 eventManager.publish(new HypeTrainApproachingEvent(approachData));

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
@@ -1,0 +1,78 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.HypeLevelUp;
+import com.github.twitch4j.pubsub.domain.HypeProgression;
+import com.github.twitch4j.pubsub.domain.HypeTrainApproaching;
+import com.github.twitch4j.pubsub.domain.HypeTrainConductor;
+import com.github.twitch4j.pubsub.domain.HypeTrainEnd;
+import com.github.twitch4j.pubsub.domain.HypeTrainRewardsData;
+import com.github.twitch4j.pubsub.domain.HypeTrainStart;
+import com.github.twitch4j.pubsub.domain.SupportActivityFeedData;
+import com.github.twitch4j.pubsub.events.HypeTrainApproachingEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainConductorUpdateEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainCooldownExpirationEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainEndEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainLevelUpEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainProgressionEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainRewardsEvent;
+import com.github.twitch4j.pubsub.events.HypeTrainStartEvent;
+import com.github.twitch4j.pubsub.events.SupportActivityFeedEvent;
+
+import java.util.Collection;
+
+class TrainHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "hype-train-events-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length > 2 && "rewards".equals(topicParts[1])) {
+            eventManager.publish(new HypeTrainRewardsEvent(TypeConvert.convertValue(message.getMessageData(), HypeTrainRewardsData.class)));
+            return true;
+        }
+        JsonNode msgData = message.getMessageData();
+        String lastTopicIdentifier = topicParts[topicParts.length - 1];
+        switch (message.getType()) {
+            case "hype-train-approaching":
+                final HypeTrainApproaching approachData = TypeConvert.convertValue(msgData, HypeTrainApproaching.class);
+                eventManager.publish(new HypeTrainApproachingEvent(approachData));
+                return true;
+            case "hype-train-start":
+                final HypeTrainStart startData = TypeConvert.convertValue(msgData, HypeTrainStart.class);
+                eventManager.publish(new HypeTrainStartEvent(startData));
+                return true;
+            case "hype-train-progression":
+                final HypeProgression progressionData = TypeConvert.convertValue(msgData, HypeProgression.class);
+                eventManager.publish(new HypeTrainProgressionEvent(lastTopicIdentifier, progressionData));
+                return true;
+            case "hype-train-level-up":
+                final HypeLevelUp levelUpData = TypeConvert.convertValue(msgData, HypeLevelUp.class);
+                eventManager.publish(new HypeTrainLevelUpEvent(lastTopicIdentifier, levelUpData));
+                return true;
+            case "hype-train-end":
+                final HypeTrainEnd endData = TypeConvert.convertValue(msgData, HypeTrainEnd.class);
+                eventManager.publish(new HypeTrainEndEvent(lastTopicIdentifier, endData));
+                return true;
+            case "hype-train-conductor-update":
+                final HypeTrainConductor conductorData = TypeConvert.convertValue(msgData, HypeTrainConductor.class);
+                eventManager.publish(new HypeTrainConductorUpdateEvent(lastTopicIdentifier, conductorData));
+                return true;
+            case "hype-train-cooldown-expiration":
+                eventManager.publish(new HypeTrainCooldownExpirationEvent(lastTopicIdentifier));
+                return true;
+            case "last-x-experiment-event":
+                // note: this isn't a true hype train event (it can be fired with no train active), but twitch hacked together the feature to use the hype pubsub infrastructure
+                final SupportActivityFeedData lastData = TypeConvert.convertValue(msgData, SupportActivityFeedData.class);
+                eventManager.publish(new SupportActivityFeedEvent(lastTopicIdentifier, lastData));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.HypeLevelUp;
 import com.github.twitch4j.pubsub.domain.HypeProgression;
@@ -28,50 +28,40 @@ class TrainHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
-        IEventManager eventManager = args.getEventManager();
         if (topicParts.length > 2 && "rewards".equals(topicParts[1])) {
-            eventManager.publish(new HypeTrainRewardsEvent(TypeConvert.convertValue(args.getData(), HypeTrainRewardsData.class)));
-            return true;
+            return new HypeTrainRewardsEvent(TypeConvert.convertValue(args.getData(), HypeTrainRewardsData.class));
         }
         JsonNode msgData = args.getData();
         String lastTopicIdentifier = args.getLastTopicPart();
         switch (args.getType()) {
             case "hype-train-approaching":
                 final HypeTrainApproaching approachData = TypeConvert.convertValue(msgData, HypeTrainApproaching.class);
-                eventManager.publish(new HypeTrainApproachingEvent(approachData));
-                return true;
+                return new HypeTrainApproachingEvent(approachData);
             case "hype-train-start":
                 final HypeTrainStart startData = TypeConvert.convertValue(msgData, HypeTrainStart.class);
-                eventManager.publish(new HypeTrainStartEvent(startData));
-                return true;
+                return new HypeTrainStartEvent(startData);
             case "hype-train-progression":
                 final HypeProgression progressionData = TypeConvert.convertValue(msgData, HypeProgression.class);
-                eventManager.publish(new HypeTrainProgressionEvent(lastTopicIdentifier, progressionData));
-                return true;
+                return new HypeTrainProgressionEvent(lastTopicIdentifier, progressionData);
             case "hype-train-level-up":
                 final HypeLevelUp levelUpData = TypeConvert.convertValue(msgData, HypeLevelUp.class);
-                eventManager.publish(new HypeTrainLevelUpEvent(lastTopicIdentifier, levelUpData));
-                return true;
+                return new HypeTrainLevelUpEvent(lastTopicIdentifier, levelUpData);
             case "hype-train-end":
                 final HypeTrainEnd endData = TypeConvert.convertValue(msgData, HypeTrainEnd.class);
-                eventManager.publish(new HypeTrainEndEvent(lastTopicIdentifier, endData));
-                return true;
+                return new HypeTrainEndEvent(lastTopicIdentifier, endData);
             case "hype-train-conductor-update":
                 final HypeTrainConductor conductorData = TypeConvert.convertValue(msgData, HypeTrainConductor.class);
-                eventManager.publish(new HypeTrainConductorUpdateEvent(lastTopicIdentifier, conductorData));
-                return true;
+                return new HypeTrainConductorUpdateEvent(lastTopicIdentifier, conductorData);
             case "hype-train-cooldown-expiration":
-                eventManager.publish(new HypeTrainCooldownExpirationEvent(lastTopicIdentifier));
-                return true;
+                return new HypeTrainCooldownExpirationEvent(lastTopicIdentifier);
             case "last-x-experiment-event":
                 // note: this isn't a true hype train event (it can be fired with no train active), but twitch hacked together the feature to use the hype pubsub infrastructure
                 final SupportActivityFeedData lastData = TypeConvert.convertValue(msgData, SupportActivityFeedData.class);
-                eventManager.publish(new SupportActivityFeedEvent(lastTopicIdentifier, lastData));
-                return true;
+                return new SupportActivityFeedEvent(lastTopicIdentifier, lastData);
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UnbanRequestHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UnbanRequestHandler.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.CreatedUnbanRequest;
+import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
+import com.github.twitch4j.pubsub.events.ChannelUnbanRequestCreateEvent;
+import com.github.twitch4j.pubsub.events.ChannelUnbanRequestUpdateEvent;
+
+import java.util.Collection;
+
+class UnbanRequestHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "channel-unban-requests";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length != 3) return false;
+        String userId = topicParts[1];
+        String channelId = topicParts[2];
+        if ("create_unban_request".equals(message.getType())) {
+            CreatedUnbanRequest request = TypeConvert.convertValue(message.getMessageData(), CreatedUnbanRequest.class);
+            eventManager.publish(new ChannelUnbanRequestCreateEvent(userId, channelId, request));
+            return true;
+        } else if ("update_unban_request".equals(message.getType())) {
+            UpdatedUnbanRequest request = TypeConvert.convertValue(message.getMessageData(), UpdatedUnbanRequest.class);
+            eventManager.publish(new ChannelUnbanRequestUpdateEvent(userId, channelId, request));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UnbanRequestHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UnbanRequestHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.CreatedUnbanRequest;
 import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
@@ -13,20 +14,18 @@ class UnbanRequestHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
-        if (topicParts.length != 3) return false;
+        if (topicParts.length != 3) return null;
         String userId = topicParts[1];
         String channelId = topicParts[2];
         if ("create_unban_request".equals(args.getType())) {
             CreatedUnbanRequest request = TypeConvert.convertValue(args.getData(), CreatedUnbanRequest.class);
-            args.getEventManager().publish(new ChannelUnbanRequestCreateEvent(userId, channelId, request));
-            return true;
+            return new ChannelUnbanRequestCreateEvent(userId, channelId, request);
         } else if ("update_unban_request".equals(args.getType())) {
             UpdatedUnbanRequest request = TypeConvert.convertValue(args.getData(), UpdatedUnbanRequest.class);
-            args.getEventManager().publish(new ChannelUnbanRequestUpdateEvent(userId, channelId, request));
-            return true;
+            return new ChannelUnbanRequestUpdateEvent(userId, channelId, request);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UnbanRequestHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UnbanRequestHandler.java
@@ -1,14 +1,10 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.CreatedUnbanRequest;
 import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
 import com.github.twitch4j.pubsub.events.ChannelUnbanRequestCreateEvent;
 import com.github.twitch4j.pubsub.events.ChannelUnbanRequestUpdateEvent;
-
-import java.util.Collection;
 
 class UnbanRequestHandler implements TopicHandler {
     @Override
@@ -17,17 +13,18 @@ class UnbanRequestHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
         if (topicParts.length != 3) return false;
         String userId = topicParts[1];
         String channelId = topicParts[2];
-        if ("create_unban_request".equals(message.getType())) {
-            CreatedUnbanRequest request = TypeConvert.convertValue(message.getMessageData(), CreatedUnbanRequest.class);
-            eventManager.publish(new ChannelUnbanRequestCreateEvent(userId, channelId, request));
+        if ("create_unban_request".equals(args.getType())) {
+            CreatedUnbanRequest request = TypeConvert.convertValue(args.getData(), CreatedUnbanRequest.class);
+            args.getEventManager().publish(new ChannelUnbanRequestCreateEvent(userId, channelId, request));
             return true;
-        } else if ("update_unban_request".equals(message.getType())) {
-            UpdatedUnbanRequest request = TypeConvert.convertValue(message.getMessageData(), UpdatedUnbanRequest.class);
-            eventManager.publish(new ChannelUnbanRequestUpdateEvent(userId, channelId, request));
+        } else if ("update_unban_request".equals(args.getType())) {
+            UpdatedUnbanRequest request = TypeConvert.convertValue(args.getData(), UpdatedUnbanRequest.class);
+            args.getEventManager().publish(new ChannelUnbanRequestUpdateEvent(userId, channelId, request));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserModeratedHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserModeratedHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.UserAutomodCaughtMessage;
 import com.github.twitch4j.pubsub.events.UserAutomodCaughtMessageEvent;
@@ -11,13 +12,12 @@ class UserModeratedHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
         if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(args.getType())) {
             UserAutomodCaughtMessage data = TypeConvert.convertValue(args.getData(), UserAutomodCaughtMessage.class);
-            args.getEventManager().publish(new UserAutomodCaughtMessageEvent(topicParts[1], topicParts[2], data));
-            return true;
+            return new UserAutomodCaughtMessageEvent(topicParts[1], topicParts[2], data);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserModeratedHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserModeratedHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.UserAutomodCaughtMessage;
 import com.github.twitch4j.pubsub.events.UserAutomodCaughtMessageEvent;
-
-import java.util.Collection;
 
 class UserModeratedHandler implements TopicHandler {
     @Override
@@ -15,10 +11,11 @@ class UserModeratedHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(message.getType())) {
-            UserAutomodCaughtMessage data = TypeConvert.convertValue(message.getMessageData(), UserAutomodCaughtMessage.class);
-            eventManager.publish(new UserAutomodCaughtMessageEvent(topicParts[1], topicParts[2], data));
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
+        if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(args.getType())) {
+            UserAutomodCaughtMessage data = TypeConvert.convertValue(args.getData(), UserAutomodCaughtMessage.class);
+            args.getEventManager().publish(new UserAutomodCaughtMessageEvent(topicParts[1], topicParts[2], data));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserModeratedHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserModeratedHandler.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.UserAutomodCaughtMessage;
+import com.github.twitch4j.pubsub.events.UserAutomodCaughtMessageEvent;
+
+import java.util.Collection;
+
+class UserModeratedHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "user-moderation-notifications";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length == 3 && "automod_caught_message".equalsIgnoreCase(message.getType())) {
+            UserAutomodCaughtMessage data = TypeConvert.convertValue(message.getMessageData(), UserAutomodCaughtMessage.class);
+            eventManager.publish(new UserAutomodCaughtMessageEvent(topicParts[1], topicParts[2], data));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPointsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPointsHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
@@ -24,41 +24,34 @@ class UserPointsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         JsonNode msgData = args.getData();
-        IEventManager eventManager = args.getEventManager();
         switch (args.getType()) {
             case "points-earned":
                 final ChannelPointsEarned pointsEarned = TypeConvert.convertValue(msgData, ChannelPointsEarned.class);
-                eventManager.publish(new PointsEarnedEvent(pointsEarned));
-                return true;
+                return new PointsEarnedEvent(pointsEarned);
             case "claim-available":
                 final ClaimData claimAvailable = TypeConvert.convertValue(msgData, ClaimData.class);
-                eventManager.publish(new ClaimAvailableEvent(claimAvailable));
-                return true;
+                return new ClaimAvailableEvent(claimAvailable);
             case "claim-claimed":
                 final ClaimData claimClaimed = TypeConvert.convertValue(msgData, ClaimData.class);
-                eventManager.publish(new ClaimClaimedEvent(claimClaimed));
-                return true;
+                return new ClaimClaimedEvent(claimClaimed);
             case "points-spent":
                 final PointsSpent pointsSpent = TypeConvert.convertValue(msgData, PointsSpent.class);
-                eventManager.publish(new PointsSpentEvent(pointsSpent));
-                return true;
+                return new PointsSpentEvent(pointsSpent);
             case "reward-redeemed":
                 final ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
-                eventManager.publish(new RewardRedeemedEvent(Instant.parse(msgData.path("timestamp").asText()), redemption));
-                return true;
+                return new RewardRedeemedEvent(Instant.parse(msgData.path("timestamp").asText()), redemption);
             case "community-goal-contribution":
                 CommunityGoalContribution goal = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
                 Instant instant = Instant.parse(msgData.path("timestamp").textValue());
-                eventManager.publish(new UserCommunityGoalContributionEvent(args.getLastTopicPart(), instant, goal));
-                return true;
+                return new UserCommunityGoalContributionEvent(args.getLastTopicPart(), instant, goal);
             case "global-last-viewed-content-updated":
             case "channel-last-viewed-content-updated":
                 // unimportant
-                return true;
+                return new TwitchEvent() {};
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPointsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPointsHandler.java
@@ -1,0 +1,65 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
+import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
+import com.github.twitch4j.pubsub.domain.ClaimData;
+import com.github.twitch4j.pubsub.domain.CommunityGoalContribution;
+import com.github.twitch4j.pubsub.domain.PointsSpent;
+import com.github.twitch4j.pubsub.events.ClaimAvailableEvent;
+import com.github.twitch4j.pubsub.events.ClaimClaimedEvent;
+import com.github.twitch4j.pubsub.events.PointsEarnedEvent;
+import com.github.twitch4j.pubsub.events.PointsSpentEvent;
+import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
+import com.github.twitch4j.pubsub.events.UserCommunityGoalContributionEvent;
+
+import java.time.Instant;
+import java.util.Collection;
+
+class UserPointsHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "community-points-user-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        JsonNode msgData = message.getMessageData();
+        switch (message.getType()) {
+            case "points-earned":
+                final ChannelPointsEarned pointsEarned = TypeConvert.convertValue(msgData, ChannelPointsEarned.class);
+                eventManager.publish(new PointsEarnedEvent(pointsEarned));
+                return true;
+            case "claim-available":
+                final ClaimData claimAvailable = TypeConvert.convertValue(msgData, ClaimData.class);
+                eventManager.publish(new ClaimAvailableEvent(claimAvailable));
+                return true;
+            case "claim-claimed":
+                final ClaimData claimClaimed = TypeConvert.convertValue(msgData, ClaimData.class);
+                eventManager.publish(new ClaimClaimedEvent(claimClaimed));
+                return true;
+            case "points-spent":
+                final PointsSpent pointsSpent = TypeConvert.convertValue(msgData, PointsSpent.class);
+                eventManager.publish(new PointsSpentEvent(pointsSpent));
+                return true;
+            case "reward-redeemed":
+                final ChannelPointsRedemption redemption = TypeConvert.convertValue(msgData.path("redemption"), ChannelPointsRedemption.class);
+                eventManager.publish(new RewardRedeemedEvent(Instant.parse(msgData.path("timestamp").asText()), redemption));
+                return true;
+            case "community-goal-contribution":
+                CommunityGoalContribution goal = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
+                Instant instant = Instant.parse(msgData.path("timestamp").textValue());
+                eventManager.publish(new UserCommunityGoalContributionEvent(topicParts[topicParts.length - 1], instant, goal));
+                return true;
+            case "global-last-viewed-content-updated":
+            case "channel-last-viewed-content-updated":
+                // unimportant
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPointsHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPointsHandler.java
@@ -3,7 +3,6 @@ package com.github.twitch4j.pubsub.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.ChannelPointsEarned;
 import com.github.twitch4j.pubsub.domain.ChannelPointsRedemption;
 import com.github.twitch4j.pubsub.domain.ClaimData;
@@ -17,7 +16,6 @@ import com.github.twitch4j.pubsub.events.RewardRedeemedEvent;
 import com.github.twitch4j.pubsub.events.UserCommunityGoalContributionEvent;
 
 import java.time.Instant;
-import java.util.Collection;
 
 class UserPointsHandler implements TopicHandler {
     @Override
@@ -26,9 +24,10 @@ class UserPointsHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        JsonNode msgData = message.getMessageData();
-        switch (message.getType()) {
+    public boolean handle(Args args) {
+        JsonNode msgData = args.getData();
+        IEventManager eventManager = args.getEventManager();
+        switch (args.getType()) {
             case "points-earned":
                 final ChannelPointsEarned pointsEarned = TypeConvert.convertValue(msgData, ChannelPointsEarned.class);
                 eventManager.publish(new PointsEarnedEvent(pointsEarned));
@@ -52,7 +51,7 @@ class UserPointsHandler implements TopicHandler {
             case "community-goal-contribution":
                 CommunityGoalContribution goal = TypeConvert.convertValue(msgData.path("contribution"), CommunityGoalContribution.class);
                 Instant instant = Instant.parse(msgData.path("timestamp").textValue());
-                eventManager.publish(new UserCommunityGoalContributionEvent(topicParts[topicParts.length - 1], instant, goal));
+                eventManager.publish(new UserCommunityGoalContributionEvent(args.getLastTopicPart(), instant, goal));
                 return true;
             case "global-last-viewed-content-updated":
             case "channel-last-viewed-content-updated":

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPredictionHandler.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.events.UserPredictionMadeEvent;
+import com.github.twitch4j.pubsub.events.UserPredictionResultEvent;
+
+import java.util.Collection;
+
+class UserPredictionHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "predictions-user-v1";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if ("prediction-made".equals(message.getType())) {
+            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), UserPredictionMadeEvent.class));
+            return true;
+        } else if ("prediction-result".equals(message.getType())) {
+            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), UserPredictionResultEvent.class));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPredictionHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.events.UserPredictionMadeEvent;
 import com.github.twitch4j.pubsub.events.UserPredictionResultEvent;
-
-import java.util.Collection;
 
 class UserPredictionHandler implements TopicHandler {
     @Override
@@ -15,12 +11,12 @@ class UserPredictionHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if ("prediction-made".equals(message.getType())) {
-            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), UserPredictionMadeEvent.class));
+    public boolean handle(Args args) {
+        if ("prediction-made".equals(args.getType())) {
+            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), UserPredictionMadeEvent.class));
             return true;
-        } else if ("prediction-result".equals(message.getType())) {
-            eventManager.publish(TypeConvert.convertValue(message.getMessageData(), UserPredictionResultEvent.class));
+        } else if ("prediction-result".equals(args.getType())) {
+            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), UserPredictionResultEvent.class));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPredictionHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserPredictionHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.events.UserPredictionMadeEvent;
 import com.github.twitch4j.pubsub.events.UserPredictionResultEvent;
@@ -11,14 +12,12 @@ class UserPredictionHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         if ("prediction-made".equals(args.getType())) {
-            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), UserPredictionMadeEvent.class));
-            return true;
+            return TypeConvert.convertValue(args.getData(), UserPredictionMadeEvent.class);
         } else if ("prediction-result".equals(args.getType())) {
-            args.getEventManager().publish(TypeConvert.convertValue(args.getData(), UserPredictionResultEvent.class));
-            return true;
+            return TypeConvert.convertValue(args.getData(), UserPredictionResultEvent.class);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserUnbanRequestHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserUnbanRequestHandler.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub.handlers;
 
+import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
 import com.github.twitch4j.pubsub.events.UserUnbanRequestUpdateEvent;
@@ -11,15 +12,14 @@ class UserUnbanRequestHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(Args args) {
+    public TwitchEvent apply(Args args) {
         String[] topicParts = args.getTopicParts();
         if (topicParts.length == 3 && "update_unban_request".equals(args.getType())) {
             String userId = topicParts[1];
             String channelId = topicParts[2];
             UpdatedUnbanRequest request = TypeConvert.convertValue(args.getData(), UpdatedUnbanRequest.class);
-            args.getEventManager().publish(new UserUnbanRequestUpdateEvent(userId, channelId, request));
-            return true;
+            return new UserUnbanRequestUpdateEvent(userId, channelId, request);
         }
-        return false;
+        return null;
     }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserUnbanRequestHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserUnbanRequestHandler.java
@@ -1,12 +1,8 @@
 package com.github.twitch4j.pubsub.handlers;
 
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
 import com.github.twitch4j.pubsub.events.UserUnbanRequestUpdateEvent;
-
-import java.util.Collection;
 
 class UserUnbanRequestHandler implements TopicHandler {
     @Override
@@ -15,12 +11,13 @@ class UserUnbanRequestHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
-        if (topicParts.length == 3 && "update_unban_request".equals(message.getType())) {
+    public boolean handle(Args args) {
+        String[] topicParts = args.getTopicParts();
+        if (topicParts.length == 3 && "update_unban_request".equals(args.getType())) {
             String userId = topicParts[1];
             String channelId = topicParts[2];
-            UpdatedUnbanRequest request = TypeConvert.convertValue(message.getMessageData(), UpdatedUnbanRequest.class);
-            eventManager.publish(new UserUnbanRequestUpdateEvent(userId, channelId, request));
+            UpdatedUnbanRequest request = TypeConvert.convertValue(args.getData(), UpdatedUnbanRequest.class);
+            args.getEventManager().publish(new UserUnbanRequestUpdateEvent(userId, channelId, request));
             return true;
         }
         return false;

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserUnbanRequestHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/UserUnbanRequestHandler.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.UpdatedUnbanRequest;
+import com.github.twitch4j.pubsub.events.UserUnbanRequestUpdateEvent;
+
+import java.util.Collection;
+
+class UserUnbanRequestHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "user-unban-requests";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        if (topicParts.length == 3 && "update_unban_request".equals(message.getType())) {
+            String userId = topicParts[1];
+            String channelId = topicParts[2];
+            UpdatedUnbanRequest request = TypeConvert.convertValue(message.getMessageData(), UpdatedUnbanRequest.class);
+            eventManager.publish(new UserUnbanRequestUpdateEvent(userId, channelId, request));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/WhispersHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/WhispersHandler.java
@@ -1,0 +1,54 @@
+package com.github.twitch4j.pubsub.handlers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.philippheuer.events4j.api.IEventManager;
+import com.github.twitch4j.common.enums.CommandPermission;
+import com.github.twitch4j.common.events.domain.EventUser;
+import com.github.twitch4j.common.events.user.PrivateMessageEvent;
+import com.github.twitch4j.common.util.TwitchUtils;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
+import com.github.twitch4j.pubsub.domain.WhisperThread;
+import com.github.twitch4j.pubsub.events.WhisperThreadUpdateEvent;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+class WhispersHandler implements TopicHandler {
+    @Override
+    public String topicName() {
+        return "whispers";
+    }
+
+    @Override
+    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+        // Whisper data is escaped Json cast into a String
+        JsonNode msgDataParsed = TypeConvert.jsonToObject(message.getMessageData().asText(), JsonNode.class);
+        String type = message.getType();
+        if ("whisper_sent".equals(type) || "whisper_received".equals(type)) {
+            //TypeReference<T> allows type parameters (unlike Class<T>) and avoids needing @SuppressWarnings("unchecked")
+            Map<String, Object> tags = TypeConvert.convertValue(msgDataParsed.path("tags"), new TypeReference<Map<String, Object>>() {});
+
+            String fromId = msgDataParsed.get("from_id").asText();
+            String displayName = (String) tags.get("display_name");
+            EventUser eventUser = new EventUser(fromId, displayName);
+
+            String body = msgDataParsed.get("body").asText();
+
+            Set<CommandPermission> permissions = TwitchUtils.getPermissionsFromTags(tags, new HashMap<>(), fromId, botOwnerIds);
+
+            PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(eventUser, body, permissions);
+            eventManager.publish(privateMessageEvent);
+            return true;
+        }
+        if ("thread".equals(type)) {
+            WhisperThread thread = TypeConvert.convertValue(msgDataParsed, WhisperThread.class);
+            eventManager.publish(new WhisperThreadUpdateEvent(topicParts[topicParts.length - 1], thread));
+            return true;
+        }
+        return false;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/WhispersHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/WhispersHandler.java
@@ -2,17 +2,14 @@ package com.github.twitch4j.pubsub.handlers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventUser;
 import com.github.twitch4j.common.events.user.PrivateMessageEvent;
 import com.github.twitch4j.common.util.TwitchUtils;
 import com.github.twitch4j.common.util.TypeConvert;
-import com.github.twitch4j.pubsub.PubSubResponsePayloadMessage;
 import com.github.twitch4j.pubsub.domain.WhisperThread;
 import com.github.twitch4j.pubsub.events.WhisperThreadUpdateEvent;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -24,10 +21,10 @@ class WhispersHandler implements TopicHandler {
     }
 
     @Override
-    public boolean handle(IEventManager eventManager, String[] topicParts, PubSubResponsePayloadMessage message, Collection<String> botOwnerIds) {
+    public boolean handle(Args args) {
         // Whisper data is escaped Json cast into a String
-        JsonNode msgDataParsed = TypeConvert.jsonToObject(message.getMessageData().asText(), JsonNode.class);
-        String type = message.getType();
+        JsonNode msgDataParsed = TypeConvert.jsonToObject(args.getData().asText(), JsonNode.class);
+        String type = args.getType();
         if ("whisper_sent".equals(type) || "whisper_received".equals(type)) {
             //TypeReference<T> allows type parameters (unlike Class<T>) and avoids needing @SuppressWarnings("unchecked")
             Map<String, Object> tags = TypeConvert.convertValue(msgDataParsed.path("tags"), new TypeReference<Map<String, Object>>() {});
@@ -38,15 +35,15 @@ class WhispersHandler implements TopicHandler {
 
             String body = msgDataParsed.get("body").asText();
 
-            Set<CommandPermission> permissions = TwitchUtils.getPermissionsFromTags(tags, new HashMap<>(), fromId, botOwnerIds);
+            Set<CommandPermission> permissions = TwitchUtils.getPermissionsFromTags(tags, new HashMap<>(), fromId, args.getBotOwnerIds());
 
             PrivateMessageEvent privateMessageEvent = new PrivateMessageEvent(eventUser, body, permissions);
-            eventManager.publish(privateMessageEvent);
+            args.getEventManager().publish(privateMessageEvent);
             return true;
         }
         if ("thread".equals(type)) {
             WhisperThread thread = TypeConvert.convertValue(msgDataParsed, WhisperThread.class);
-            eventManager.publish(new WhisperThreadUpdateEvent(topicParts[topicParts.length - 1], thread));
+            args.getEventManager().publish(new WhisperThreadUpdateEvent(args.getLastTopicPart(), thread));
             return true;
         }
         return false;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Closes #172

### Changes Proposed
* Create `TopicHandler` for each pubsub topic
* Delegate pubsub message handling to `HandlerRegistry`, rather than having logic directly in `TwitchPubSub`
* Allow customization of `fallbackTopicHandler` (e.g., to allow users to implement their own logic for topics we don't yet support)

### Additional Information
Did not migrate handlers for decommissioned pubsub topics: chant, commerce, friendship, presence, soundtrack (radio)
