### PR TITLE
feat: use helix default token for eventsocket pool

### DIFF
--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocketPool.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocketPool.java
@@ -58,6 +58,12 @@ public final class TwitchEventSocketPool implements IEventSubSocket {
     private final TwitchIdentityProvider identityProvider = new TwitchIdentityProvider(null, null, null);
 
     /**
+     * The default {@link OAuth2Credential} to use when initially creating an EventSub subscription.
+     */
+    @Nullable
+    private final OAuth2Credential fallbackToken;
+
+    /**
      * The base url for websocket connections.
      *
      * @see TwitchEventSocket#WEB_SOCKET_SERVER
@@ -200,7 +206,7 @@ public final class TwitchEventSocketPool implements IEventSubSocket {
             .filter(pool -> pool.getDefaultToken() != null)
             .min(Comparator.comparingInt(SubscriptionConnectionPool::numSubscriptions))
             .map(IEventSubSocket::getDefaultToken)
-            .orElse(null);
+            .orElse(fallbackToken);
     }
 
     @Override

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -517,6 +517,7 @@ public class TwitchClientBuilder {
             eventSocket = TwitchEventSocketPool.builder()
                 .eventManager(eventManager)
                 .executor(scheduledThreadPoolExecutor)
+                .fallbackToken(defaultAuthToken)
                 .helix(helix)
                 .advancedConfiguration(builder ->
                     builder.proxyConfig(() -> proxyConfig)

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -566,6 +566,7 @@ public class TwitchClientPoolBuilder {
             eventSocket = TwitchEventSocketPool.builder()
                 .eventManager(eventManager)
                 .executor(scheduledThreadPoolExecutor)
+                .fallbackToken(defaultAuthToken)
                 .helix(helix)
                 .advancedConfiguration(builder ->
                     builder.proxyConfig(() -> proxyConfig)


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* `defaultAuthToken` in `TwitchClient(Pool)Builder` is now used by `TwitchEventSocketPool` if `register` is called without a credential

### Additional Information
Improves consistency with `TwitchSingleUserEventSocketPool` & `TwitchEventSocket`
