### PR TITLE
feat: add open beta ad schedule helix and eventsub

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -14,6 +14,8 @@ public enum TwitchScopes {
     HELIX_ANALYTICS_READ_GAMES("analytics:read:games"),
     HELIX_BITS_READ("bits:read"),
     HELIX_CLIPS_EDIT("clips:edit"),
+    HELIX_CHANNEL_ADS_MANAGE("channel:manage:ads"),
+    HELIX_CHANNEL_ADS_READ("channel:read:ads"),
     HELIX_CHANNEL_BROADCAST_MANAGE("channel:manage:broadcast"),
     HELIX_CHANNEL_CHARITY_READ("channel:read:charity"),
     HELIX_CHANNEL_COMMERCIALS_EDIT("channel:edit:commercial"),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelAdBreakCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ChannelAdBreakCondition.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@SuperBuilder
+@Jacksonized
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ChannelAdBreakCondition extends ChannelEventSubCondition {}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelAdBreakBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelAdBreakBeginEvent.java
@@ -1,0 +1,50 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelAdBreakBeginEvent extends EventSubChannelEvent {
+
+    /**
+     * Length in seconds of the mid-roll ad break requested
+     */
+    @JsonAlias("duration") // https://github.com/twitchdev/issues/issues/850
+    private Integer lengthSeconds;
+
+    /**
+     * The UTC timestamp of when the ad break began, in RFC3339 format.
+     * <p>
+     * Note that there is potential delay between this event,
+     * when the streamer requested the ad break, and when the viewers will see ads.
+     */
+    @JsonAlias("timestamp") // https://github.com/twitchdev/issues/issues/850
+    private Instant startedAt;
+
+    /**
+     * Indicates if the ad was automatically scheduled via Ads Manager
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_automatic")
+    private Boolean isAutomatic;
+
+    /**
+     * The ID of the user that requested the ad.
+     * For automatic ads, this will be the ID of the broadcaster.
+     */
+    private String requesterUserId;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelAdBreakBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/BetaChannelAdBreakBeginType.java
@@ -1,0 +1,36 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelAdBreakCondition;
+import com.github.twitch4j.eventsub.events.ChannelAdBreakBeginEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * The channel.ad_break.begin subscription type sends a notification when a user runs a midroll commercial break,
+ * either manually or automatically via ads manager.
+ * <p>
+ * Must have channel:read:ads scope.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_ADS_READ
+ */
+@ApiStatus.Experimental
+public class BetaChannelAdBreakBeginType implements SubscriptionType<ChannelAdBreakCondition, ChannelAdBreakCondition.ChannelAdBreakConditionBuilder<?, ?>, ChannelAdBreakBeginEvent> {
+    @Override
+    public String getName() {
+        return "channel.ad_break.begin";
+    }
+
+    @Override
+    public String getVersion() {
+        return "beta";
+    }
+
+    @Override
+    public ChannelAdBreakCondition.ChannelAdBreakConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelAdBreakCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelAdBreakBeginEvent> getEventClass() {
+        return ChannelAdBreakBeginEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
 import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
 import java.util.Map;
@@ -13,6 +14,7 @@ import java.util.stream.Stream;
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
+    public final @ApiStatus.Experimental BetaChannelAdBreakBeginType BETA_CHANNEL_AD_BREAK_BEGIN;
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelCharityDonateType CHANNEL_CHARITY_DONATE;
     public final CharityCampaignStartType CHANNEL_CHARITY_START;
@@ -68,6 +70,7 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
+                BETA_CHANNEL_AD_BREAK_BEGIN = new BetaChannelAdBreakBeginType(),
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHARITY_DONATE = new ChannelCharityDonateType(),
                 CHANNEL_CHARITY_START = new CharityCampaignStartType(),

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -30,6 +30,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class EventSubEventTest {
 
     @Test
+    @DisplayName("Deserialize ChannelAdBreakBeginEvent")
+    public void deserializeAdBreakEvent() {
+        ChannelAdBreakBeginEvent event = jsonToObject(
+            "{\"length_seconds\":\"60\",\"started_at\":\"2019-11-16T10:11:12.634234626Z\",\"is_automatic\":\"false\",\"broadcaster_user_id\":\"1337\",\"requester_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\"}",
+            ChannelAdBreakBeginEvent.class
+        );
+        assertFalse(event.isAutomatic());
+        assertEquals(60, event.getLengthSeconds());
+        assertEquals("1337", event.getBroadcasterUserId());
+        assertEquals("1337", event.getRequesterUserId());
+        assertEquals(Instant.parse("2019-11-16T10:11:12.634234626Z"), event.getStartedAt());
+    }
+
+    @Test
     @DisplayName("Deserialize ChannelBanEvent: Timeout")
     public void deserializeModerationEvent() {
         ChannelBanEvent event = jsonToObject(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1185,6 +1185,45 @@ public interface TwitchHelix {
     );
 
     /**
+     * Obtains ad schedule related information, including snooze, when the last ad was run,
+     * when the next ad is scheduled, and if the channel is currently in pre-roll free time.
+     *
+     * @param authToken     User access token with the channel:read:ads scope from the broadcaster.
+     * @param broadcasterId The user id that corresponds with the user access token.
+     * @return {@link AdScheduleWrapper}
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_ADS_READ
+     */
+    @ApiStatus.Experimental // in open beta
+    @RequestLine("GET /channels/ads?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<AdScheduleWrapper> getAdSchedule(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
+     * If available, pushes back the timestamp of the upcoming automatic mid-roll ad by 5 minutes.
+     * This endpoint duplicates the snooze functionality in the creator dashboard’s Ads Manager.
+     * <p>
+     * If the channel is not currently live or the channel does not have an upcoming scheduled ad break,
+     * this endpoint will return Error 400: Bad Request.
+     * <p>
+     * If the channel has no snoozes left, this endpoint will return Error 429: Too Many Requests.
+     *
+     * @param authToken     User access token with the channel:manage:ads scope from the broadcaster.
+     * @param broadcasterId The user id that corresponds with the user access token.
+     * @return {@link SnoozedAdWrapper}
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_ADS_MANAGE
+     */
+    @ApiStatus.Experimental // in open beta
+    @RequestLine("POST /channels/ads/schedule/snooze?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<SnoozedAdWrapper> snoozeNextAd(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
+    /**
      * Starts a commercial on a specified channel
      *
      * @param authToken Auth Token (scope: channel:edit:commercial)

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -28,6 +29,7 @@ public class AdSchedule {
     /**
      * The length in seconds of the scheduled upcoming ad break.
      */
+    @JsonAlias("lengths_seconds") // docs are incorrect
     private Integer lengthSeconds;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
@@ -1,0 +1,49 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class AdSchedule {
+
+    /**
+     * The UTC timestamp of the broadcaster’s next scheduled ad, in RFC3339 format.
+     * Empty if the channel has no ad scheduled or is not live.
+     */
+    @Nullable
+    private Instant nextAdAt;
+
+    /**
+     * The UTC timestamp of the broadcaster’s last ad-break, in RFC3339 format.
+     * Empty if the channel has not run an ad or is not live.
+     */
+    @Nullable
+    private Instant lastAdAt;
+
+    /**
+     * The length in seconds of the scheduled upcoming ad break.
+     */
+    private Integer lengthSeconds;
+
+    /**
+     * The amount of pre-roll free time remaining for the channel in seconds.
+     * Returns 0 if they are currently not pre-roll free.
+     */
+    private Integer prerollFreeTimeSeconds;
+
+    /**
+     * The number of snoozes available for the broadcaster.
+     */
+    private Integer snoozeCount;
+
+    /**
+     * The UTC timestamp when the broadcaster will gain an additional snooze.
+     */
+    private Instant snoozeRefreshAt;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
@@ -1,6 +1,5 @@
 package com.github.twitch4j.helix.domain;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -29,7 +28,6 @@ public class AdSchedule {
     /**
      * The length in seconds of the scheduled upcoming ad break.
      */
-    @JsonAlias("lengths_seconds") // docs are incorrect
     private Integer lengthSeconds;
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdScheduleWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdScheduleWrapper.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class AdScheduleWrapper {
+
+    /**
+     * A list that contains information related to the channel’s ad schedule.
+     */
+    private List<AdSchedule> data;
+
+    /**
+     * @return information related to the channel’s ad schedule
+     */
+    public AdSchedule get() {
+        if (data == null || data.isEmpty()) return null;
+        return data.get(0);
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SnoozedAd.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SnoozedAd.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SnoozedAd {
+
+    /**
+     * The number of snoozes available for the broadcaster.
+     */
+    private Integer snoozeCount;
+
+    /**
+     * The UTC timestamp when the broadcaster will gain an additional snooze, in RFC3339 format.
+     */
+    private Instant snoozeRefreshAt;
+
+    /**
+     * The UTC timestamp of the broadcaster’s next scheduled ad, in RFC3339 format.
+     */
+    private Instant nextAdAt;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SnoozedAdWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SnoozedAdWrapper.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SnoozedAdWrapper {
+
+    /**
+     * A list that contains information about the channel’s snoozes and next upcoming ad after successfully snoozing.
+     */
+    private List<SnoozedAd> data;
+
+    /**
+     * @return information about the channel’s snoozes and next upcoming ad after successfully snoozing
+     */
+    public SnoozedAd get() {
+        if (data == null || data.isEmpty()) return null;
+        return data.get(0);
+    }
+
+}

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
@@ -1,0 +1,78 @@
+package com.github.twitch4j.helix.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AdScheduleTest {
+
+    @Test
+    void deserializeActual() {
+        // actual example from 2023-11-03 for a non-affiliate
+        AdSchedule ads = TypeConvert.jsonToObject(
+            "{\"snooze_count\":3,\"snooze_refresh_at\":0,\"next_ad_at\":0,\"length_seconds\":0,\"last_ad_at\":0,\"preroll_free_time_seconds\":0}",
+            AdSchedule.class
+        );
+        assertNotNull(ads);
+        assertEquals(3, ads.getSnoozeCount());
+        assertEquals(0, ads.getLengthSeconds());
+        assertEquals(0, ads.getPrerollFreeTimeSeconds());
+        assertEquals(Instant.EPOCH, ads.getSnoozeRefreshAt());
+        assertEquals(Instant.EPOCH, ads.getNextAdAt());
+        assertEquals(Instant.EPOCH, ads.getLastAdAt());
+    }
+
+    @Test
+    void deserializeSpec() {
+        // what the example should look like if they adhered to the spec (i.e., 0 instants should be empty strings)
+        AdSchedule ads = TypeConvert.jsonToObject(
+            "{\"snooze_count\":3,\"snooze_refresh_at\":\"\",\"next_ad_at\":\"\",\"length_seconds\":0,\"last_ad_at\":\"\",\"preroll_free_time_seconds\":0}",
+            AdSchedule.class
+        );
+        assertNotNull(ads);
+        assertEquals(3, ads.getSnoozeCount());
+        assertEquals(0, ads.getLengthSeconds());
+        assertEquals(0, ads.getPrerollFreeTimeSeconds());
+        assertNull(ads.getSnoozeRefreshAt());
+        assertNull(ads.getNextAdAt());
+        assertNull(ads.getLastAdAt());
+    }
+
+    @Test
+    void deserializeSample() {
+        // the example response from the official docs
+        AdSchedule ads = TypeConvert.jsonToObject(
+            "{\"next_ad_at\":\"2023-08-01T23:08:18+00:00\",\"last_ad_at\":\"2023-08-01T23:08:18+00:00\",\"length_seconds\":\"60\",\"preroll_free_time_seconds\":\"90\",\"snooze_count\":\"1\",\"snooze_refresh_at\":\"2023-08-01T23:08:18+00:00\"}",
+            AdSchedule.class
+        );
+        assertNotNull(ads);
+        assertEquals(1, ads.getSnoozeCount());
+        assertEquals(60, ads.getLengthSeconds());
+        assertEquals(90, ads.getPrerollFreeTimeSeconds());
+        assertEquals(Instant.parse("2023-08-01T23:08:18Z"), ads.getNextAdAt());
+        assertEquals(Instant.parse("2023-08-01T23:08:18Z"), ads.getLastAdAt());
+        assertEquals(Instant.parse("2023-08-01T23:08:18Z"), ads.getSnoozeRefreshAt());
+    }
+
+    @Test
+    void deserializeSampleSpec() {
+        // the example response from the official docs, if it followed the spec (i.e., integers are not strings)
+        AdSchedule ads = TypeConvert.jsonToObject(
+            "{\"next_ad_at\":\"2023-08-01T23:08:18+00:00\",\"last_ad_at\":\"2023-08-01T23:08:18+00:00\",\"length_seconds\":60,\"preroll_free_time_seconds\":90,\"snooze_count\":1,\"snooze_refresh_at\":\"2023-08-01T23:08:18+00:00\"}",
+            AdSchedule.class
+        );
+        assertNotNull(ads);
+        assertEquals(1, ads.getSnoozeCount());
+        assertEquals(60, ads.getLengthSeconds());
+        assertEquals(90, ads.getPrerollFreeTimeSeconds());
+        assertEquals(Instant.parse("2023-08-01T23:08:18Z"), ads.getNextAdAt());
+        assertEquals(Instant.parse("2023-08-01T23:08:18Z"), ads.getLastAdAt());
+        assertEquals(Instant.parse("2023-08-01T23:08:18Z"), ads.getSnoozeRefreshAt());
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* ~~Endpoints are broken at launch; they require `channel:edit:commercial` when they're supposed to require `channel:read:ads`/`channel:manage:ads`~~
* ~~Endpoints are broken at launch; even with additional scopes, the endpoint just returns 404 with an empty message~~
* EventSub event field names are inconsistent across the documentation: https://github.com/twitchdev/issues/issues/850
* ~~Official scope documentation claims `channel:read:ads` is only relevant for Chat/PubSub, when in reality it's only relevant for API/EventSub~~

### Changes Proposed
* Add `BetaChannelAdBreakBeginType` eventsub subscription type
* Add `TwitchHelix#getAdSchedule`
* Add `TwitchHelix#snoozeNextAd`

### Additional Information
2023-10-19 changelog entry https://dev.twitch.tv/docs/change-log/
