### PR TITLE
chore: bump minimum jackson version to 2.15.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,7 @@ subprojects {
 			listOf("com.fasterxml.jackson.core:jackson-annotations", "com.fasterxml.jackson.core:jackson-core", "com.fasterxml.jackson.core:jackson-databind", "com.fasterxml.jackson.datatype:jackson-datatype-jsr310").forEach { dep ->
 				add("api", dep) {
 					version {
-						strictly("[2.12,3-alpha[")
+						strictly("[2.15,3-alpha[")
 						// renovate: depName=com.fasterxml.jackson:jackson-bom
 						prefer("2.15.3")
 					}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
While we do not yet depend on any v2.15 features, many maven users end up with mismatched jackson versions, which can break (de)serialization. For example, v2.15 `InstantDeserializer` references `JsonFormat.Feature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS`, which requires annotations v2.15, but versions could be mismatched, leading to: `java.lang.NoSuchFieldError: READ_DATE_TIMESTAMPS_AS_NANOSECONDS` for many helix endpoints

### Changes Proposed
* Bump minimum jackson version to 2.15

### Additional Information
Jackson usually only patches the 2 latest minor versions. Currently, that is v2.15 and v2.14, but v2.16 is about to be released, so we don't need to care about v2.14. Also v2.13 and below have CVEs, so we shouldn't worry about dropping 2.12/2.13 support
