### PR TITLE
refactor(eventsub): use subTier over subPlan, add isPrime field

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/CommunitySubGift.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/CommunitySubGift.java
@@ -24,8 +24,10 @@ public class CommunitySubGift {
 
     /**
      * The type of subscription plan being used.
+     * <p>
+     * Cannot be {@link SubscriptionPlan#TWITCH_PRIME}.
      */
-    private SubscriptionPlan subPlan;
+    private SubscriptionPlan subTier;
 
     /**
      * The amount of gifts the gifter has given in this channel.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/PrimePaidUpgrade.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/PrimePaidUpgrade.java
@@ -11,7 +11,9 @@ public class PrimePaidUpgrade {
 
     /**
      * The type of subscription plan being used.
+     * <p>
+     * Cannot be {@link SubscriptionPlan#TWITCH_PRIME}.
      */
-    private SubscriptionPlan subPlan;
+    private SubscriptionPlan subTier;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Resubscription.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Resubscription.java
@@ -32,8 +32,17 @@ public class Resubscription {
 
     /**
      * The type of subscription plan being used.
+     * <p>
+     * Does not contain {@link SubscriptionPlan#TWITCH_PRIME}; use {@link #isPrime()} instead.
      */
-    private SubscriptionPlan subPlan;
+    private SubscriptionPlan subTier;
+
+    /**
+     * Indicates if the subscription was obtained through Amazon Prime.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_prime")
+    private Boolean isPrime;
 
     /**
      * Whether or not the resub was a result of a gift.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/SubGift.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/SubGift.java
@@ -39,8 +39,10 @@ public class SubGift {
 
     /**
      * The type of subscription plan being used.
+     * <p>
+     * Cannot be {@link SubscriptionPlan#TWITCH_PRIME}.
      */
-    private SubscriptionPlan subPlan;
+    private SubscriptionPlan subTier;
 
     /**
      * The ID of the associated community gift.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Subscription.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Subscription.java
@@ -1,9 +1,11 @@
 package com.github.twitch4j.eventsub.domain.chat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -21,7 +23,16 @@ public class Subscription {
 
     /**
      * The type of subscription plan being used.
+     * <p>
+     * Does not contain {@link SubscriptionPlan#TWITCH_PRIME}; use {@link #isPrime()} instead.
      */
-    private SubscriptionPlan subPlan;
+    private SubscriptionPlan subTier;
+
+    /**
+     * Indicates if the subscription was obtained through Amazon Prime.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_prime")
+    private Boolean isPrime;
 
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -442,7 +442,7 @@ public class EventSubEventTest {
     @DisplayName("Deserialize ChannelChatNotificationEvent where notice_type is resub")
     public void deserializeChatPrimeResub() {
         ChannelChatNotificationEvent event = jsonToObject(
-            "{\"broadcaster_user_id\":\"207813352\",\"broadcaster_user_login\":\"hasanabi\",\"broadcaster_user_name\":\"HasanAbi\",\"chatter_user_id\":\"47525664\",\"chatter_user_login\":\"deetmonster\",\"chatter_user_name\":\"deetmonster\",\"chatter_is_anonymous\":false,\"color\":\"#0000FF\",\"system_message\":\"deetmonster subscribed with Prime. They've subscribed for 50 months, currently on a 12 month streak!\",\"message_id\":\"2e96f15c-db41-45f6-8e76-1d773ef3c47f\",\"message\":{\"text\":\"\",\"fragments\":[]},\"notice_type\":\"resub\",\"sub\":null,\"resub\":{\"cumulative_months\":50,\"duration_months\":0,\"streak_months\":12,\"sub_plan\":\"Prime\",\"is_gift\":false,\"gifter_is_anonymous\":null,\"gifter_user_id\":null,\"gifter_user_name\":null,\"gifter_user_login\":null},\"sub_gift\":null,\"community_sub_gift\":null,\"gift_paid_upgrade\":null,\"prime_paid_upgrade\":null,\"pay_it_forward\":null,\"raid\":null,\"unraid\":null,\"announcement\":null,\"bits_badge_tier\":null,\"charity_donation\":null}",
+            "{\"broadcaster_user_id\":\"207813352\",\"broadcaster_user_login\":\"hasanabi\",\"broadcaster_user_name\":\"HasanAbi\",\"chatter_user_id\":\"47525664\",\"chatter_user_login\":\"deetmonster\",\"chatter_user_name\":\"deetmonster\",\"chatter_is_anonymous\":false,\"color\":\"#0000FF\",\"system_message\":\"deetmonster subscribed with Prime. They've subscribed for 50 months, currently on a 12 month streak!\",\"message_id\":\"2e96f15c-db41-45f6-8e76-1d773ef3c47f\",\"message\":{\"text\":\"\",\"fragments\":[]},\"notice_type\":\"resub\",\"sub\":null,\"resub\":{\"cumulative_months\":50,\"duration_months\":0,\"streak_months\":12,\"sub_tier\":\"1000\",\"is_prime\":true,\"is_gift\":false,\"gifter_is_anonymous\":null,\"gifter_user_id\":null,\"gifter_user_name\":null,\"gifter_user_login\":null},\"sub_gift\":null,\"community_sub_gift\":null,\"gift_paid_upgrade\":null,\"prime_paid_upgrade\":null,\"pay_it_forward\":null,\"raid\":null,\"unraid\":null,\"announcement\":null,\"bits_badge_tier\":null,\"charity_donation\":null}",
             ChannelChatNotificationEvent.class
         );
 
@@ -456,7 +456,8 @@ public class EventSubEventTest {
         assertEquals(50, resub.getCumulativeMonths());
         assertEquals(1, resub.getDurationMonths()); // we convert 0 to 1 intentionally
         assertEquals(12, resub.getStreakMonths());
-        assertEquals(SubscriptionPlan.TWITCH_PRIME, resub.getSubPlan());
+        assertEquals(SubscriptionPlan.TIER1, resub.getSubTier());
+        assertTrue(resub.isPrime());
         assertFalse(resub.isGift());
     }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Context
https://discord.com/channels/504015559252377601/523675755503157248/1166536899918307410

### Changes Proposed
For usernotice over eventsub:
* Rename `subPlan` to `subTier`
* Add `isPrime` to sub/resub objects

### Additional Information
2023‑11‑07 changelog entry https://dev.twitch.tv/docs/change-log/

