### PR TITLE
chore: add another test case to AdScheduleTest

### DIFF
--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
@@ -12,6 +12,21 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class AdScheduleTest {
 
     @Test
+    void deserializePartner() {
+        // actual example from a partner in early November 2023 (epoch seconds are sent instead of rfc3339 strings)
+        AdSchedule ads = TypeConvert.jsonToObject(
+            "{\"snooze_count\":3,\"snooze_refresh_at\":0,\"next_ad_at\":1698437870,\"length_seconds\":90,\"last_ad_at\":1698429628,\"preroll_free_time_seconds\":0}",
+            AdSchedule.class
+        );
+        assertNotNull(ads);
+        assertEquals(3, ads.getSnoozeCount());
+        assertEquals(Instant.ofEpochSecond(1698437870L), ads.getNextAdAt());
+        assertEquals(Instant.ofEpochSecond(1698429628L), ads.getLastAdAt());
+        assertEquals(90, ads.getLengthSeconds());
+        assertEquals(0, ads.getPrerollFreeTimeSeconds());
+    }
+
+    @Test
     void deserializeActual() {
         // actual example from 2023-11-03 for a non-affiliate
         AdSchedule ads = TypeConvert.jsonToObject(


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues 
* https://github.com/twitchdev/issues/issues/857#issuecomment-1800822567

### Changes Proposed
* Add `AdSchedule` deserialization test case using actual response for a partnered account, which exhibits spec nonconformity (see below)

### Additional Information
Currently, Twitch actually sends `snooze_refresh_at`, `next_ad_at`, `last_ad_at` as epoch seconds while documentation claims it should be RFC3339 strings. Jackson handles either format well
