### PR TITLE
chore(chat): queue reconnect from another thread to avoid benign exception

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -563,7 +563,7 @@ public class TwitchChat implements ITwitchChat {
                     // - Reconnect
                     else if (message.equalsIgnoreCase(":tmi.twitch.tv RECONNECT")) {
                         log.debug("Received RECONNECT request");
-                        this.reconnect();
+                        taskExecutor.execute(this::reconnect);
                     }
                     // - Login failed.
                     else if (message.equalsIgnoreCase(":tmi.twitch.tv NOTICE * :Login authentication failed")) {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed
Avoids this exception from being logged (which has no impact on the chat bot's stability) when we are told by twitch to `RECONNECT`:
```
ERROR  connection to webSocket server wss://irc-ws.chat.twitch.tv:443 failed: retrying ...
com.neovisionaries.ws.client.WebSocketException: Failed to connect to 'irc-ws.chat.twitch.tv:443': null
        at com.neovisionaries.ws.client.SocketConnector.connectSocket(SocketConnector.java:126)
        at com.neovisionaries.ws.client.SocketConnector.doConnect(SocketConnector.java:238)
        at com.neovisionaries.ws.client.SocketConnector.connect(SocketConnector.java:189)
        at com.neovisionaries.ws.client.WebSocket.connect(WebSocket.java:2351)
        at com.github.twitch4j.client.websocket.WebsocketConnection.connect(WebsocketConnection.java:225)
        at com.github.twitch4j.client.websocket.WebsocketConnection.reconnect(WebsocketConnection.java:295)
        at com.github.twitch4j.chat.TwitchChat.reconnect(TwitchChat.java:619)
        at com.github.twitch4j.chat.TwitchChat.lambda$onTextMessage$16(TwitchChat.java:566)
        at com.github.twitch4j.chat.util.MessageParser.consumeLines(MessageParser.java:143)
        at com.github.twitch4j.chat.TwitchChat.onTextMessage(TwitchChat.java:544)
        at com.github.twitch4j.client.websocket.WebsocketConnection$1.onTextMessage(WebsocketConnection.java:123)
        at com.neovisionaries.ws.client.ListenerManager.callOnTextMessage(ListenerManager.java:353)
        at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:266)
        at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:244)
        at com.neovisionaries.ws.client.ReadingThread.handleTextFrame(ReadingThread.java:969)
        at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:752)
        at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108)
        at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64)
        at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45)
Caused by: java.lang.InterruptedException: null
        at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1048)
        at java.base/java.util.concurrent.CountDownLatch.await(CountDownLatch.java:230)
        at com.neovisionaries.ws.client.SocketInitiator$SocketFuture.await(SocketInitiator.java:293)
        at com.neovisionaries.ws.client.SocketInitiator.establish(SocketInitiator.java:370)
        at com.neovisionaries.ws.client.SocketConnector.connectSocket(SocketConnector.java:114)
        ... 18 common frames omitted
```

### Changes Proposed
* Queue chat socket reconnection from a separate thread when requested to reconnect by twitch
