### PR TITLE
chore: promote ads scheduler api out of beta

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelAdBreakBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelAdBreakBeginEvent.java
@@ -20,9 +20,9 @@ import java.time.Instant;
 public class ChannelAdBreakBeginEvent extends EventSubChannelEvent {
 
     /**
-     * Length in seconds of the mid-roll ad break requested
+     * Length in seconds of the mid-roll ad break requested.
      */
-    @JsonAlias("duration") // https://github.com/twitchdev/issues/issues/850
+    @JsonAlias({"duration", "duration_seconds"}) // https://github.com/twitchdev/issues/issues/850
     private Integer lengthSeconds;
 
     /**
@@ -35,7 +35,7 @@ public class ChannelAdBreakBeginEvent extends EventSubChannelEvent {
     private Instant startedAt;
 
     /**
-     * Indicates if the ad was automatically scheduled via Ads Manager
+     * Indicates if the ad was automatically scheduled via Ads Manager.
      */
     @Accessors(fluent = true)
     @JsonProperty("is_automatic")
@@ -46,5 +46,15 @@ public class ChannelAdBreakBeginEvent extends EventSubChannelEvent {
      * For automatic ads, this will be the ID of the broadcaster.
      */
     private String requesterUserId;
+
+    /**
+     * The login of the user that requested the ad.
+     */
+    private String requesterUserLogin;
+
+    /**
+     * The display name of the user that requested the ad.
+     */
+    private String requesterUserName;
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelAdBreakBeginType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelAdBreakBeginType.java
@@ -2,7 +2,6 @@ package com.github.twitch4j.eventsub.subscriptions;
 
 import com.github.twitch4j.eventsub.condition.ChannelAdBreakCondition;
 import com.github.twitch4j.eventsub.events.ChannelAdBreakBeginEvent;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * The channel.ad_break.begin subscription type sends a notification when a user runs a midroll commercial break,
@@ -12,8 +11,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_ADS_READ
  */
-@ApiStatus.Experimental
-public class BetaChannelAdBreakBeginType implements SubscriptionType<ChannelAdBreakCondition, ChannelAdBreakCondition.ChannelAdBreakConditionBuilder<?, ?>, ChannelAdBreakBeginEvent> {
+public class ChannelAdBreakBeginType implements SubscriptionType<ChannelAdBreakCondition, ChannelAdBreakCondition.ChannelAdBreakConditionBuilder<?, ?>, ChannelAdBreakBeginEvent> {
     @Override
     public String getName() {
         return "channel.ad_break.begin";
@@ -21,7 +19,7 @@ public class BetaChannelAdBreakBeginType implements SubscriptionType<ChannelAdBr
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
-    public final @ApiStatus.Experimental BetaChannelAdBreakBeginType BETA_CHANNEL_AD_BREAK_BEGIN;
+    public final ChannelAdBreakBeginType CHANNEL_AD_BREAK_BEGIN;
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelChatClearType CHANNEL_CHAT_CLEAR;
     public final ChannelClearUserMessagesType CHANNEL_CLEAR_USER_MESSAGES;
@@ -74,7 +74,7 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
-                BETA_CHANNEL_AD_BREAK_BEGIN = new BetaChannelAdBreakBeginType(),
+                CHANNEL_AD_BREAK_BEGIN = new ChannelAdBreakBeginType(),
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHAT_CLEAR = new ChannelChatClearType(),
                 CHANNEL_CLEAR_USER_MESSAGES = new ChannelClearUserMessagesType(),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1210,7 +1210,6 @@ public interface TwitchHelix {
      * @return {@link AdScheduleWrapper}
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_ADS_READ
      */
-    @ApiStatus.Experimental // in open beta
     @RequestLine("GET /channels/ads?broadcaster_id={broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<AdScheduleWrapper> getAdSchedule(
@@ -1232,7 +1231,6 @@ public interface TwitchHelix {
      * @return {@link SnoozedAdWrapper}
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_ADS_MANAGE
      */
-    @ApiStatus.Experimental // in open beta
     @RequestLine("POST /channels/ads/schedule/snooze?broadcaster_id={broadcaster_id}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<SnoozedAdWrapper> snoozeNextAd(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdSchedule.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -28,12 +29,14 @@ public class AdSchedule {
     /**
      * The length in seconds of the scheduled upcoming ad break.
      */
+    @JsonAlias({"duration", "duration_seconds"})
     private Integer lengthSeconds;
 
     /**
      * The amount of pre-roll free time remaining for the channel in seconds.
      * Returns 0 if they are currently not pre-roll free.
      */
+    @JsonAlias("preroll_free_time")
     private Integer prerollFreeTimeSeconds;
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* EventSub docs still have a `timestamp` vs. `started_at` discrepancy: https://github.com/twitchdev/issues/issues/850
* `length_seconds` was renamed to `duration` in helix and `duration_seconds` in eventsub - I don't trust this inconsistency (particularly since eventsub docs used to say `duration` in some places as another inconsistency), so will accept all three of these property names to be safe


### Changes Proposed
* Promote `channel.ad_break.begin` eventsub to v1 from open beta
* Add `requester_user_login`/`requester_user_name` to `ChannelAdBreakBeginEvent`
* Promote helix ads scheduler endpoints out of open beta
* Update aliases for fields that were renamed by Twitch

### Additional Information
2023-12-11 changelog entry https://dev.twitch.tv/docs/change-log/
