### PR TITLE
fix: populate ChannelStateEvent when single room setting changed

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -694,48 +694,46 @@ public class IRCEventHandler {
             // getting Status on channel
             EventChannel channel = event.getChannel();
             Map<ChannelStateEvent.ChannelState, Object> states = new HashMap<>();
-            if (event.getEscapedTags().size() > 2) {
-                event.getEscapedTags().forEach((k, v) -> {
-                    switch (k) {
-                        case "broadcaster-lang":
-                            Locale locale = v != null ? Locale.forLanguageTag(v.toString()) : null;
-                            states.put(ChannelStateEvent.ChannelState.BROADCAST_LANG, locale);
-                            eventManager.publish(new BroadcasterLanguageEvent(channel, locale));
-                            break;
-                        case "emote-only":
-                            boolean eoActive = StringUtils.equals("1", v);
-                            states.put(ChannelStateEvent.ChannelState.EMOTE, eoActive);
-                            eventManager.publish(new EmoteOnlyEvent(channel, eoActive));
-                            break;
-                        case "followers-only":
-                            long followDelay = Long.parseLong(v.toString());
-                            states.put(ChannelStateEvent.ChannelState.FOLLOWERS, followDelay);
-                            eventManager.publish(new FollowersOnlyEvent(channel, followDelay));
-                            break;
-                        case "r9k":
-                            boolean uniqActive = StringUtils.equals("1", v);
-                            states.put(ChannelStateEvent.ChannelState.R9K, uniqActive);
-                            eventManager.publish(new Robot9000Event(channel, uniqActive));
-                            break;
-                        case "rituals":
-                            boolean ritualsActive = StringUtils.equals("1", v);
-                            states.put(ChannelStateEvent.ChannelState.RITUALS, ritualsActive);
-                            break;
-                        case "slow":
-                            long slowDelay = Long.parseLong(v.toString());
-                            states.put(ChannelStateEvent.ChannelState.SLOW, slowDelay);
-                            eventManager.publish(new SlowModeEvent(channel, slowDelay));
-                            break;
-                        case "subs-only":
-                            boolean subActive = StringUtils.equals("1", v);
-                            states.put(ChannelStateEvent.ChannelState.SUBSCRIBERS, subActive);
-                            eventManager.publish(new SubscribersOnlyEvent(channel, subActive));
-                            break;
-                        default:
-                            break;
-                    }
-                });
-            }
+            event.getEscapedTags().forEach((k, v) -> {
+                switch (k) {
+                    case "broadcaster-lang":
+                        Locale locale = v != null ? Locale.forLanguageTag(v.toString()) : null;
+                        states.put(ChannelStateEvent.ChannelState.BROADCAST_LANG, locale);
+                        eventManager.publish(new BroadcasterLanguageEvent(channel, locale));
+                        break;
+                    case "emote-only":
+                        boolean eoActive = StringUtils.equals("1", v);
+                        states.put(ChannelStateEvent.ChannelState.EMOTE, eoActive);
+                        eventManager.publish(new EmoteOnlyEvent(channel, eoActive));
+                        break;
+                    case "followers-only":
+                        long followDelay = Long.parseLong(v.toString());
+                        states.put(ChannelStateEvent.ChannelState.FOLLOWERS, followDelay);
+                        eventManager.publish(new FollowersOnlyEvent(channel, followDelay));
+                        break;
+                    case "r9k":
+                        boolean uniqActive = StringUtils.equals("1", v);
+                        states.put(ChannelStateEvent.ChannelState.R9K, uniqActive);
+                        eventManager.publish(new Robot9000Event(channel, uniqActive));
+                        break;
+                    case "rituals":
+                        boolean ritualsActive = StringUtils.equals("1", v);
+                        states.put(ChannelStateEvent.ChannelState.RITUALS, ritualsActive);
+                        break;
+                    case "slow":
+                        long slowDelay = Long.parseLong(v.toString());
+                        states.put(ChannelStateEvent.ChannelState.SLOW, slowDelay);
+                        eventManager.publish(new SlowModeEvent(channel, slowDelay));
+                        break;
+                    case "subs-only":
+                        boolean subActive = StringUtils.equals("1", v);
+                        states.put(ChannelStateEvent.ChannelState.SUBSCRIBERS, subActive);
+                        eventManager.publish(new SubscribersOnlyEvent(channel, subActive));
+                        break;
+                    default:
+                        break;
+                }
+            });
             eventManager.publish(new ChannelStateEvent(channel, states));
             return true;
         }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelStateEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ChannelStateEvent.java
@@ -4,31 +4,80 @@ import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Called upon successfully joining a channel, or when a moderator updates a public chat room setting.
+ * <p>
+ * This event corresponds to {@code ROOMSTATE} over IRC.
+ * <p>
+ * When inspecting the updated setting values, it is easier to utilize these individual events:
+ * {@link com.github.twitch4j.chat.events.roomstate.EmoteOnlyEvent},
+ * {@link com.github.twitch4j.chat.events.roomstate.FollowersOnlyEvent},
+ * {@link com.github.twitch4j.chat.events.roomstate.Robot9000Event},
+ * {@link com.github.twitch4j.chat.events.roomstate.SlowModeEvent},
+ * {@link com.github.twitch4j.chat.events.roomstate.SubscribersOnlyEvent}.
+ */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 public class ChannelStateEvent extends AbstractChannelEvent {
+    /**
+     * The possible chat room settings that can be configured.
+     */
     public enum ChannelState {
+        /**
+         * The language of the stream.
+         *
+         * @deprecated has not been sent since 2019-03-08.
+         */
         @Deprecated
         BROADCAST_LANG,
+        /**
+         * Emote only chat configuration;
+         * determines whether users can only send Twitch emotes in chat.
+         */
         EMOTE,
+        /**
+         * Followers only chat configuration;
+         * In minutes corresponding to how long a user must be following in order to chat.
+         * Negative values indicate this setting is disabled.
+         */
         FOLLOWERS,
+        /**
+         * Unique chat configuration (formerly Robot9000);
+         * determines whether a user can repeat a previous message of theirs.
+         */
         R9K,
+        /**
+         * Determines whether rituals are enabled on the channel.
+         *
+         * @see ChannelMessageEvent#isUserIntroduction()
+         * @deprecated Twitch replaced this feature with the "user introduction" feature
+         */
         @Unofficial
         @Deprecated
         RITUALS,
+        /**
+         * Slow mode chat configuration;
+         * In seconds corresponding to minimum delay between an individual user's messages.
+         */
         SLOW,
+        /**
+         * Subscribers-only chat configuration.
+         */
         SUBSCRIBERS
     }
 
-    private final Map<ChannelState, Object> states;
+    /**
+     * Contains the singular chat room setting that was updated
+     * (or all chat room settings upon joining the channel).
+     */
+    Map<ChannelState, Object> states;
 
     /**
      * Event Constructor
@@ -36,21 +85,30 @@ public class ChannelStateEvent extends AbstractChannelEvent {
      * @param channel The channel that this event originates from.
      * @param state   The changed state triggering the event
      * @param value   The value representing the state
+     * @deprecated unused by Twitch4J
      */
+    @Deprecated
     public ChannelStateEvent(EventChannel channel, ChannelState state, Object value) {
+        this(channel, Collections.singletonMap(state, value));
+    }
+
+    /**
+     * Event Constructor
+     *
+     * @param channel The channel that this event originates from.
+     * @param states  The chat room settings.
+     */
+    public ChannelStateEvent(EventChannel channel, Map<ChannelState, Object> states) {
         super(channel);
-        Map<ChannelState, Object> states = new HashMap<>();
-        states.put(state, value);
         this.states = Collections.unmodifiableMap(states);
     }
 
-    public ChannelStateEvent(EventChannel channel, Map<ChannelState, Object> state) {
-        super(channel);
-        Map<ChannelState, Object> states = new HashMap<>(state);
-        this.states = Collections.unmodifiableMap(states);
-    }
-
-    public Object getState(ChannelState state) {
+    /**
+     * @param state a chat room setting to query
+     * @return the latest value for the setting if it was just adjusted
+     */
+    @Nullable
+    public Object getState(@NotNull ChannelState state) {
         return states.getOrDefault(state, null);
     }
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `ChannelStateEvent` (and corresponding individual events) were only being fired upon channel JOIN - reported by MineTrain

### Changes Proposed
* Ensure `ChannelStateEvent#getStates` is not empty when a single chat room setting was updated
* Ensure individual chat setting events are fired when the single setting is updated post JOIN
* Update documentation of `ChannelStateEvent` (and minor refactoring)

### Additional Information
https://dev.twitch.tv/docs/irc/tags/#roomstate-tags
