### PR TITLE
feat: add get moderated channels beta endpoint

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -64,6 +64,7 @@ public enum TwitchScopes {
     HELIX_USER_FOLLOWS_READ("user:read:follows"),
     HELIX_USER_SUBSCRIPTIONS_READ("user:read:subscriptions"),
     HELIX_USER_EMAIL("user:read:email"),
+    HELIX_USER_MODERATED_READ("user:read:moderated_channels"),
     HELIX_USER_BLOCKS_MANAGE("user:manage:blocked_users"),
     HELIX_USER_WHISPERS_MANAGE("user:manage:whispers"),
     KRAKEN_CHANNEL_CHECK_SUBSCRIPTION("channel_check_subscription"),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1872,6 +1872,26 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets a list of channels that the specified user has moderator privileges in.
+     *
+     * @param authToken User access token (scope: user:read:moderated_channels)
+     * @param userId    The user id associated with the user access token
+     * @param limit     The maximum number of items to return per page in the response. Default: 20. Minimum: 1. Maximum: 100.
+     * @param after     The cursor used to get the next page of results.
+     * @return {@link ModeratedChannelList}
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_MODERATED_READ
+     */
+    @ApiStatus.Experimental // open beta since 2024-01-08
+    @RequestLine("GET /moderation/channels?user_id={user_id}&after={after}&first={first}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ModeratedChannelList> getModeratedChannels(
+        @Param("token") String authToken,
+        @Param("user_id") String userId,
+        @Param("first") Integer limit,
+        @Param("after") String after
+    );
+
+    /**
      * Removes a single chat message or all chat messages from the broadcaster’s chat room.
      * <p>
      * The ID in the moderator_id query parameter must match the user ID in the access token.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratedChannel.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratedChannel.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ModeratedChannel {
+
+    /**
+     * An ID that uniquely identifies the channel this user can moderate.
+     */
+    private String broadcasterId;
+
+    /**
+     * The channel's login name.
+     */
+    private String broadcasterLogin;
+
+    /**
+     * The channel's display name.
+     */
+    private String broadcasterName;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratedChannelList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ModeratedChannelList.java
@@ -1,0 +1,26 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ModeratedChannelList {
+
+    /**
+     * The channels that the user has moderator privileges in.
+     */
+    @JsonProperty("data")
+    private List<ModeratedChannel> channels;
+
+    /**
+     * Contains the information used to page through the list of results.
+     * The object is empty if there are no more pages left to page through.
+     */
+    private HelixPagination pagination;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#getModeratedChannels`

### Additional Information
2024-01-08 changelog entry https://dev.twitch.tv/docs/change-log
