### PR TITLE
feat(eventsub): add chat message subscription type

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Cheer.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Cheer.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.eventsub.domain.chat;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class Cheer {
+
+    /**
+     * The amount of Bits the user cheered.
+     */
+    private int bits;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Message.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Message.java
@@ -10,6 +10,8 @@ import java.util.List;
 @Setter(AccessLevel.PRIVATE)
 public class Message {
 
+    private static final String ACTION_PREFIX = "\u0001ACTION ";
+
     /**
      * The chat message in plain text.
      */
@@ -19,5 +21,19 @@ public class Message {
      * Ordered list of chat message fragments.
      */
     private List<Fragment> fragments;
+
+    /**
+     * @return whether the user sent an action (i.e., "/me ") message
+     */
+    public boolean isAction() {
+        return text.startsWith(ACTION_PREFIX) && text.endsWith("\u0001");
+    }
+
+    /**
+     * @return the full message text without any ACTION prefix/suffix
+     */
+    public String getCleanedText() {
+        return isAction() ? text.substring(ACTION_PREFIX.length(), text.length() - 1) : text;
+    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/MessageType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/MessageType.java
@@ -1,0 +1,38 @@
+package com.github.twitch4j.eventsub.domain.chat;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+/**
+ * EventSub equivalent of the {@code msg-id} IRC tag.
+ */
+public enum MessageType {
+
+    /**
+     * A normal chat message.
+     */
+    TEXT,
+
+    /**
+     * Channel points were used to highlight the chat message.
+     */
+    CHANNEL_POINTS_HIGHLIGHTED,
+
+    /**
+     * Channel points were used to send this message in sub-only mode.
+     */
+    CHANNEL_POINTS_SUB_ONLY,
+
+    /**
+     * The user designated this message as their introduction to the community.
+     *
+     * @see <a href="https://twitter.com/TwitchSupport/status/1481008097749573641">Twitch Announcement</a>
+     */
+    USER_INTRO,
+
+    /**
+     * An unrecognized message type; please report to our issue tracker.
+     */
+    @JsonEnumDefaultValue
+    OTHER
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Reply.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Reply.java
@@ -1,0 +1,56 @@
+package com.github.twitch4j.eventsub.domain.chat;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class Reply {
+
+    /**
+     * An ID that uniquely identifies the parent message that this message is replying to.
+     */
+    private String parentMessageId;
+
+    /**
+     * The message body of the parent message.
+     */
+    private String parentMessageBody;
+
+    /**
+     * User ID of the sender of the parent message.
+     */
+    private String parentUserId;
+
+    /**
+     * User display name of the sender of the parent message.
+     */
+    private String parentUserName;
+
+    /**
+     * User login name of the sender of the parent message.
+     */
+    private String parentUserLogin;
+
+    /**
+     * An ID that identifies the parent message of the reply thread.
+     */
+    private String threadMessageId;
+
+    /**
+     * User ID of the sender of the thread’s parent message.
+     */
+    private String threadUserId;
+
+    /**
+     * User display name of the sender of the thread’s parent message.
+     */
+    private String threadUserName;
+
+    /**
+     * User login name of the sender of the thread’s parent message.
+     */
+    private String threadUserLogin;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatMessageEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatMessageEvent.java
@@ -1,0 +1,72 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.chat.Badge;
+import com.github.twitch4j.eventsub.domain.chat.Cheer;
+import com.github.twitch4j.eventsub.domain.chat.Message;
+import com.github.twitch4j.eventsub.domain.chat.MessageType;
+import com.github.twitch4j.eventsub.domain.chat.Reply;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelChatMessageEvent extends ChannelChatUserEvent {
+
+    /**
+     * A UUID that identifies the message.
+     */
+    private String messageId;
+
+    /**
+     * The structured chat message.
+     */
+    private Message message;
+
+    /**
+     * The color of the user’s name in the chat room.
+     * This is a hexadecimal RGB color code with a "#" prefix.
+     * This tag may be empty if it is never set.
+     */
+    private String color;
+
+    /**
+     * The chatting user's visible badges.
+     */
+    private List<Badge> badges;
+
+    /**
+     * The type of message.
+     */
+    @NotNull
+    private MessageType messageType;
+
+    /**
+     * Metadata if this message is a cheer.
+     */
+    @Nullable
+    private Cheer cheer;
+
+    /**
+     * Metadata if this message is a reply.
+     */
+    @Nullable
+    private Reply reply;
+
+    /**
+     * The ID of a channel points custom reward that was redeemed.
+     */
+    @Nullable
+    private String channelPointsCustomRewardId;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelChatMessageType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelChatMessageType.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelChatCondition;
+import com.github.twitch4j.eventsub.events.ChannelChatMessageEvent;
+
+/**
+ * Sends a notification when any user sends a message to a specific chat room, effectively replicating IRC PRIVMSG.
+ * <p>
+ * Requires user:read:chat scope from chatting user.
+ * If app access token used, then additionally requires user:bot scope from chatting user,
+ * and either channel:bot scope from broadcaster or moderator status.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_USER_READ
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_USER_BOT
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_CHANNEL_BOT
+ */
+public class ChannelChatMessageType implements SubscriptionType<ChannelChatCondition, ChannelChatCondition.ChannelChatConditionBuilder<?, ?>, ChannelChatMessageEvent> {
+    @Override
+    public String getName() {
+        return "channel.chat.message";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ChannelChatCondition.ChannelChatConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelChatCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelChatMessageEvent> getEventClass() {
+        return ChannelChatMessageEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -18,6 +18,7 @@ public class SubscriptionTypes {
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelChatClearType CHANNEL_CHAT_CLEAR;
     public final ChannelClearUserMessagesType CHANNEL_CLEAR_USER_MESSAGES;
+    public final ChannelChatMessageType CHANNEL_CHAT_MESSAGE;
     public final ChannelMessageDeleteType CHANNEL_CHAT_MESSAGE_DELETE;
     public final ChannelChatNotificationType CHANNEL_CHAT_NOTIFICATION;
     public final @ApiStatus.Experimental BetaChannelChatSettingsUpdateType BETA_CHANNEL_CHAT_SETTINGS_UPDATE;
@@ -79,6 +80,7 @@ public class SubscriptionTypes {
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHAT_CLEAR = new ChannelChatClearType(),
                 CHANNEL_CLEAR_USER_MESSAGES = new ChannelClearUserMessagesType(),
+                CHANNEL_CHAT_MESSAGE = new ChannelChatMessageType(),
                 CHANNEL_CHAT_MESSAGE_DELETE = new ChannelMessageDeleteType(),
                 CHANNEL_CHAT_NOTIFICATION = new ChannelChatNotificationType(),
                 BETA_CHANNEL_CHAT_SETTINGS_UPDATE = new BetaChannelChatSettingsUpdateType(),


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `channel.chat.message` eventsub subscription type

### Additional Information
https://discuss.dev.twitch.com/t/available-today-twitch-chat-on-eventsub-an-api-for-sending-chat-and-the-conduit-transport-method-for-eventsub/54596#an-eventsub-subscription-type-for-channel-chat-messages-1