### PR TITLE
feat: add conduit endpoints and eventsub topic

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/Conduit.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/Conduit.java
@@ -1,0 +1,21 @@
+package com.github.twitch4j.eventsub;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class Conduit {
+
+    /**
+     * Conduit ID.
+     */
+    private String id;
+
+    /**
+     * Number of shards created for this conduit.
+     */
+    private int shardCount;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ConduitShard.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ConduitShard.java
@@ -1,0 +1,42 @@
+package com.github.twitch4j.eventsub;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConduitShard {
+
+    /**
+     * Shard ID.
+     */
+    @JsonProperty("id")
+    private String shardId;
+
+    /**
+     * The shard status.
+     * <p>
+     * The subscriber receives events only for enabled shards.
+     */
+    private ShardStatus status;
+
+    /**
+     * The transport details used to send the notifications.
+     */
+    private EventSubTransport transport;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscriptionStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscriptionStatus.java
@@ -47,8 +47,13 @@ public enum EventSubSubscriptionStatus {
     /**
      * A beta eventsub subscription is temporarily not enabled due to maintenance.
      */
-    @Unofficial
     BETA_MAINTENANCE,
+
+    /**
+     * Twitch revoked your subscription to a chat topic because your chatter user was banned by a moderator of the channel.
+     */
+    @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
+    CHAT_USER_BANNED,
 
     /**
      * When you connect to the server, you must create a subscription within 10 seconds or the connection is closed.
@@ -66,6 +71,12 @@ public enum EventSubSubscriptionStatus {
      * You must respond to ping messages with a pong message.
      */
     WEBSOCKET_FAILED_PING_PONG,
+
+    /**
+     * A websocket conduit shard did not reconnect to a Twitch-specified url upon their request.
+     */
+    @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
+    WEBSOCKET_FAILED_TO_RECONNECT,
 
     /**
      * Indicates a problem with the server (similar to an HTTP 500 status code).

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscriptionStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscriptionStatus.java
@@ -73,7 +73,7 @@ public enum EventSubSubscriptionStatus {
     WEBSOCKET_FAILED_PING_PONG,
 
     /**
-     * A websocket conduit shard did not reconnect to a Twitch-specified url upon their request.
+     * A websocket conduit shard did not reconnect after being disconnected.
      */
     @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
     WEBSOCKET_FAILED_TO_RECONNECT,

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubTransport.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubTransport.java
@@ -49,6 +49,16 @@ public class EventSubTransport {
     private String secret;
 
     /**
+     * An ID that identifies the conduit to send notifications to.
+     * <p>
+     * When you create a conduit, the server returns the conduit ID.
+     * <p>
+     * Specify this field only if method is set to conduit.
+     */
+    @Nullable
+    private String conduitId;
+
+    /**
      * An ID that identifies the WebSocket that notifications are sent to.
      * <p>
      * Specify this field only if method is set to websocket.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubTransportMethod.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubTransportMethod.java
@@ -6,7 +6,9 @@ public enum EventSubTransportMethod {
     @JsonProperty("webhook")
     WEBHOOK,
     @JsonProperty("websocket")
-    WEBSOCKET;
+    WEBSOCKET,
+    @JsonProperty("conduit")
+    CONDUIT;
 
     @Override
     public String toString() {

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ShardStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ShardStatus.java
@@ -1,0 +1,63 @@
+package com.github.twitch4j.eventsub;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum ShardStatus {
+
+    /**
+     * The shard is enabled.
+     */
+    ENABLED,
+
+    /**
+     * The shard is pending verification of the specified callback URL.
+     */
+    WEBHOOK_CALLBACK_VERIFICATION_PENDING,
+
+    /**
+     * The specified callback URL failed verification.
+     */
+    WEBHOOK_CALLBACK_VERIFICATION_FAILED,
+
+    /**
+     * The notification delivery failure rate was too high.
+     */
+    NOTIFICATION_FAILURES_EXCEEDED,
+
+    /**
+     * The client closed the connection.s
+     */
+    WEBSOCKET_DISCONNECTED,
+
+    /**
+     * The client failed to respond to a ping message.
+     */
+    WEBSOCKET_FAILED_PING_PONG,
+
+    /**
+     * The client sent a non-pong message.
+     */
+    WEBSOCKET_RECEIVED_INBOUND_TRAFFIC,
+
+    /**
+     * The Twitch WebSocket server experienced an unexpected error.
+     */
+    WEBSOCKET_INTERNAL_ERROR,
+
+    /**
+     * The Twitch WebSocket server timed out writing the message to the client.
+     */
+    WEBSOCKET_NETWORK_TIMEOUT,
+
+    /**
+     * The Twitch WebSocket server experienced a network error writing the message to the client.
+     */
+    WEBSOCKET_NETWORK_ERROR,
+
+    /**
+     * Twitch assigned the shard an undocumented status; please report to our issue tracker!
+     */
+    @JsonEnumDefaultValue
+    UNKNOWN
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ShardStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ShardStatus.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.eventsub;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.github.twitch4j.common.annotation.Unofficial;
 
 public enum ShardStatus {
 
@@ -33,6 +34,12 @@ public enum ShardStatus {
      * The client failed to respond to a ping message.
      */
     WEBSOCKET_FAILED_PING_PONG,
+
+    /**
+     * A websocket conduit shard did not reconnect to a Twitch-specified url upon their request.
+     */
+    @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
+    WEBSOCKET_FAILED_TO_RECONNECT,
 
     /**
      * The client sent a non-pong message.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ConduitCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ConduitCondition.java
@@ -1,0 +1,25 @@
+package com.github.twitch4j.eventsub.condition;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@SuperBuilder
+@EqualsAndHashCode(callSuper = false)
+@Jacksonized
+public class ConduitCondition extends ApplicationEventSubCondition {
+
+    /**
+     * The conduit ID to receive events for.
+     * If omitted, events for all of this client’s conduits are sent.
+     */
+    @Nullable
+    private String conduitId;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ConduitShardDisabledEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ConduitShardDisabledEvent.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.EventSubTransport;
+import com.github.twitch4j.eventsub.ShardStatus;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = false)
+public class ConduitShardDisabledEvent extends EventSubEvent {
+
+    /**
+     * The ID of the conduit.
+     */
+    private String conduitId;
+
+    /**
+     * The ID of the disabled shard.
+     */
+    private String shardId;
+
+    /**
+     * The new status of the transport.
+     */
+    private ShardStatus status;
+
+    /**
+     * The disabled transport.
+     */
+    private EventSubTransport transport;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ConduitShardDisabledType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ConduitShardDisabledType.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ConduitCondition;
+import com.github.twitch4j.eventsub.events.ConduitShardDisabledEvent;
+
+/**
+ * The conduit.shard.disabled subscription type sends a notification when EventSub disables a shard
+ * due to the status of the underlying transport changing.
+ * <p>
+ * App access token where the client ID matches the client ID in the condition.
+ * If {@code conduit_id} is specified, the client must be the owner of the conduit.
+ */
+public class ConduitShardDisabledType implements SubscriptionType<ConduitCondition, ConduitCondition.ConduitConditionBuilder<?, ?>, ConduitShardDisabledEvent> {
+    @Override
+    public String getName() {
+        return "conduit.shard.disabled";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ConduitCondition.ConduitConditionBuilder<?, ?> getConditionBuilder() {
+        return ConduitCondition.builder();
+    }
+
+    @Override
+    public Class<ConduitShardDisabledEvent> getEventClass() {
+        return ConduitShardDisabledEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -46,6 +46,7 @@ public class SubscriptionTypes {
     public final ChannelUnbanType CHANNEL_UNBAN;
     public final @Deprecated ChannelUpdateType CHANNEL_UPDATE;
     public final ChannelUpdateV2Type CHANNEL_UPDATE_V2;
+    public final ConduitShardDisabledType CONDUIT_SHARD_DISABLED;
     public final DropEntitlementGrantType DROP_ENTITLEMENT_GRANT;
     public final ExtensionBitsTransactionCreateType EXTENSION_BITS_TRANSACTION_CREATE;
     public final HypeTrainBeginType HYPE_TRAIN_BEGIN;
@@ -107,6 +108,7 @@ public class SubscriptionTypes {
                 CHANNEL_UNBAN = new ChannelUnbanType(),
                 CHANNEL_UPDATE = new ChannelUpdateType(),
                 CHANNEL_UPDATE_V2 = new ChannelUpdateV2Type(),
+                CONDUIT_SHARD_DISABLED = new ConduitShardDisabledType(),
                 DROP_ENTITLEMENT_GRANT = new DropEntitlementGrantType(),
                 EXTENSION_BITS_TRANSACTION_CREATE = new ExtensionBitsTransactionCreateType(),
                 HYPE_TRAIN_BEGIN = new HypeTrainBeginType(),

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocketPool.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/TwitchEventSocketPool.java
@@ -30,6 +30,8 @@ import java.util.function.UnaryOperator;
 
 /**
  * A pool for EventSub websocket subscriptions across multiple users.
+ * <p>
+ * Should <i>not</i> be used with the "conduit" transport type.
  */
 @Slf4j
 @Builder

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -5,6 +5,7 @@ import com.github.twitch4j.common.feign.JsonStringExpander;
 import com.github.twitch4j.common.feign.ObjectToJsonExpander;
 import com.github.twitch4j.eventsub.EventSubSubscription;
 import com.github.twitch4j.eventsub.EventSubSubscriptionStatus;
+import com.github.twitch4j.eventsub.ShardStatus;
 import com.github.twitch4j.eventsub.domain.RedemptionStatus;
 import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
 import com.github.twitch4j.helix.domain.*;
@@ -726,6 +727,114 @@ public interface TwitchHelix {
     HystrixCommand<UpdatedDropEntitlementsList> updateDropsEntitlements(
         @Param("token") String authToken,
         UpdateDropEntitlementInput input
+    );
+
+    /**
+     * Creates a new EventSub conduit.
+     *
+     * @param authToken  App access token.
+     * @param shardCount The number of shards to create for this conduit.
+     * @return ConduitList
+     */
+    @RequestLine("POST /eventsub/conduits")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    @Body("%7B\"shard_count\":{shard_count}%7D")
+    HystrixCommand<ConduitList> createConduit(
+        @Param("token") String authToken,
+        @Param("shard_count") int shardCount
+    );
+
+    /**
+     * Gets the conduits for a client ID.
+     *
+     * @param authToken App access token.
+     * @return ConduitList
+     */
+    @RequestLine("GET /eventsub/conduits")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ConduitList> getConduits(
+        @Param("token") String authToken
+    );
+
+    /**
+     * Updates a conduit’s shard count.
+     * <p>
+     * To delete shards, update the count to a lower number, and the shards above the count will be deleted.
+     * For example, if the existing shard count is 100, by resetting shard count to 50, shards 50-99 are disabled.
+     *
+     * @param authToken  App access token.
+     * @param conduitId  The ID of the conduit to update.
+     * @param shardCount The updated shard count for the conduit.
+     * @return ConduitList
+     */
+    @RequestLine("PATCH /eventsub/conduits")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    @Body("%7B\"id\":\"{id}\",\"shard_count\":{shard_count}%7D")
+    HystrixCommand<ConduitList> updateConduit(
+        @Param("token") String authToken,
+        @Param("id") String conduitId,
+        @Param("shard_count") int shardCount
+    );
+
+    /**
+     * Deletes a specified conduit.
+     * <p>
+     * Note that it may take some time for Eventsub subscriptions on a deleted conduit
+     * to show as disabled when calling Get Eventsub Subscriptions.
+     *
+     * @param authToken App access token.
+     * @param conduitId The ID of the conduit to delete.
+     * @return 204 No Content upon a successful deletion.
+     */
+    @RequestLine("DELETE /eventsub/conduits?id={id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> deleteConduit(
+        @Param("token") String authToken,
+        @Param("id") String conduitId
+    );
+
+    /**
+     * Gets a lists of all shards for a conduit.
+     *
+     * @param authToken App access token.
+     * @param conduitId The Conduit ID.
+     * @param status    Status to filter by.
+     * @param after     The cursor used to get the next page of results.
+     * @return ConduitShardList
+     */
+    @RequestLine("GET /eventsub/conduits/shards?conduit_id={conduit_id}&status={status}&after={after}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ConduitShardList> getConduitShards(
+        @Param("token") String authToken,
+        @Param("conduit_id") String conduitId,
+        @Param("status") @Nullable ShardStatus status,
+        @Param("after") @Nullable String after
+    );
+
+    /**
+     * Updates shard(s) for a conduit.
+     * <p>
+     * NOTE: Shard IDs are indexed starting at 0,
+     * so a conduit with a {@code shard_count} of 5 will have shards with IDs 0 through 4.
+     *
+     * @param authToken App access token.
+     * @param shards    The shards to update.
+     * @return ConduitShardList
+     */
+    @RequestLine("PATCH /eventsub/conduits/shards")
+    @Headers({
+        "Authorization: Bearer {token}",
+        "Content-Type: application/json"
+    })
+    HystrixCommand<ConduitShardList> updateConduitShards(
+        @Param("token") String authToken,
+        ShardsInput shards
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -778,7 +778,7 @@ public interface TwitchHelix {
     @Body("%7B\"id\":\"{id}\",\"shard_count\":{shard_count}%7D")
     HystrixCommand<ConduitList> updateConduit(
         @Param("token") String authToken,
-        @Param("id") String conduitId,
+        @NotNull @Param("id") String conduitId,
         @Param("shard_count") int shardCount
     );
 
@@ -796,7 +796,7 @@ public interface TwitchHelix {
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> deleteConduit(
         @Param("token") String authToken,
-        @Param("id") String conduitId
+        @NotNull @Param("id") String conduitId
     );
 
     /**
@@ -812,9 +812,9 @@ public interface TwitchHelix {
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<ConduitShardList> getConduitShards(
         @Param("token") String authToken,
-        @Param("conduit_id") String conduitId,
-        @Param("status") @Nullable ShardStatus status,
-        @Param("after") @Nullable String after
+        @NotNull @Param("conduit_id") String conduitId,
+        @Nullable @Param("status") ShardStatus status,
+        @Nullable @Param("after") String after
     );
 
     /**
@@ -834,7 +834,7 @@ public interface TwitchHelix {
     })
     HystrixCommand<ConduitShardList> updateConduitShards(
         @Param("token") String authToken,
-        ShardsInput shards
+        @NotNull ShardsInput shards
     );
 
     /**

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ConduitList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ConduitList.java
@@ -1,0 +1,21 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.Conduit;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ConduitList {
+
+    /**
+     * Information about the client’s conduits.
+     */
+    @JsonProperty("data")
+    private List<Conduit> conduits;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ConduitShardList.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ConduitShardList.java
@@ -1,0 +1,27 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.ConduitShard;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ConduitShardList {
+
+    /**
+     * Information about a conduit's shards.
+     */
+    @JsonProperty("data")
+    private List<ConduitShard> shards;
+
+    /**
+     * Contains information used to page through a list of results.
+     * The object is empty if there are no more pages left to page through.
+     */
+    private HelixPagination pagination;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ShardsInput.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ShardsInput.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.twitch4j.eventsub.ConduitShard;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Singular;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ShardsInput {
+
+    /**
+     * Conduit ID.
+     */
+    @NotNull
+    private String conduitId;
+
+    /**
+     * The shards to update.
+     */
+    @NotNull
+    @Singular
+    private Collection<ConduitShard> shards;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add new conduits helix endpoints (CRUD conduits/shards)
* Add `conduit.shard.disabled` eventsub subscription type

### Additional Information
https://discuss.dev.twitch.com/t/available-today-twitch-chat-on-eventsub-an-api-for-sending-chat-and-the-conduit-transport-method-for-eventsub/54596#introducing-conduits-an-eventsub-transport-method-for-scale-4

Follow-up PR will create a websocket pool intended for conduit use
