### PR TITLE
refactor(pubsub): migrate unofficial hype topic to v2

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -394,10 +394,12 @@ public interface ITwitchPubSub extends AutoCloseable {
 
     @Unofficial
     default PubSubSubscription listenForHypeTrainEvents(OAuth2Credential credential, String channelId) {
-        return listenOnTopic(PubSubType.LISTEN, credential, "hype-train-events-v1." + channelId);
+        return listenOnTopic(PubSubType.LISTEN, credential, "hype-train-events-v2." + channelId);
     }
 
     @Unofficial
+    @Deprecated // implemented, but no longer used by first-party
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default PubSubSubscription listenForHypeTrainRewardEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "hype-train-events-v1.rewards." + channelId);
     }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Emote.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/Emote.java
@@ -1,0 +1,12 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class Emote {
+    private String id;
+    private String token;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeProgression.java
@@ -7,6 +7,9 @@ import lombok.experimental.Accessors;
 @Data
 public class HypeProgression {
     private String userId;
+    private String userLogin;
+    private String userDisplayName;
+    private String userProfileImageUrl;
     private Integer sequenceId;
     private String action;
     private String source;
@@ -15,4 +18,6 @@ public class HypeProgression {
     @Accessors(fluent = true)
     @JsonProperty("is_boost_train")
     private Boolean isBoostTrain;
+    @JsonProperty("is_large_event")
+    private boolean largeEvent;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeReward.java
@@ -1,0 +1,14 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class HypeReward {
+    private String type; // e.g., "EMOTE"
+    private String id;
+    private @Nullable Emote emote;
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainEnd.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import java.time.Instant;
+import java.util.List;
 
 @Data
 public class HypeTrainEnd {
@@ -16,4 +17,6 @@ public class HypeTrainEnd {
     @Accessors(fluent = true)
     @JsonProperty("is_boost_train")
     private Boolean isBoostTrain;
+    private List<HypeTrainParticipation> participationTotals;
+    private List<HypeReward> rewards;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainLevel.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.pubsub.domain;
 
 import lombok.Data;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 
@@ -9,5 +10,7 @@ public class HypeTrainLevel {
     private Integer value;
     private Integer goal;
     private List<HypeTrainReward> rewards;
+    @Deprecated // no longer sent after switch to v2 topic
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     private Integer impressions;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipation.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainParticipation.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.OptionalInt;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class HypeTrainParticipation {
+    private String source;
+    private String action;
+    private int quantity;
+
+    public boolean isCheer() {
+        return "BITS".equals(source);
+    }
+
+    public boolean isSub() {
+        return "SUBS".equals(source);
+    }
+
+    public boolean isGifted() {
+        return action != null && action.endsWith("GIFTED_SUB");
+    }
+
+    public OptionalInt getSubTier() {
+        if (action == null || !isSub()) return OptionalInt.empty();
+        final int tier = action.charAt("TIER_".length()) - '0';
+        return OptionalInt.of(tier);
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainProgress.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainProgress.java
@@ -9,4 +9,9 @@ public class HypeTrainProgress {
     private Integer goal;
     private Integer total;
     private Integer remainingSeconds;
+    private String allTimeHighState; // e.g., "NONE", "APPROACHING", "REACHED"
+
+    public boolean isAllTimeHigh() {
+        return "REACHED".equals(allTimeHighState);
+    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainReward.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/HypeTrainReward.java
@@ -2,6 +2,8 @@ package com.github.twitch4j.pubsub.domain;
 
 import lombok.Data;
 
+import java.time.Instant;
+
 @Data
 public class HypeTrainReward {
     private String type; // e.g. "EMOTE"
@@ -10,4 +12,9 @@ public class HypeTrainReward {
     private Integer rewardLevel;
     private String setId;
     private String token;
+    private Instant rewardEndDate; // 0001-01-01T00:00:00Z corresponds to forever
+
+    public boolean isTemporary() {
+        return rewardEndDate != null && rewardEndDate.isAfter(Instant.EPOCH);
+    }
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
@@ -21,10 +21,18 @@ import com.github.twitch4j.pubsub.events.HypeTrainRewardsEvent;
 import com.github.twitch4j.pubsub.events.HypeTrainStartEvent;
 import com.github.twitch4j.pubsub.events.SupportActivityFeedEvent;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 class TrainHandler implements TopicHandler {
     @Override
     public String topicName() {
-        return "hype-train-events-v1";
+        return "hype-train-events-v2";
+    }
+
+    @Override
+    public Collection<String> topicNames() {
+        return Arrays.asList(topicName(), "hype-train-events-v1");
     }
 
     @Override


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Migrate `ITwitchPubSub#listenForHypeTrainEvents` to `hype-train-events-v2`
* Deprecate `ITwitchPubSub#listenForHypeTrainRewardEvents` (superceded by new `HypeTrainEnd#getRewards` method)

### Additional Information
Web platform has recently switched to v2, mobile platforms are awaiting rollout
