### PR TITLE
fix: support refreshed tokens in pubsub module

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -45,7 +45,7 @@ public interface ITwitchPubSub extends AutoCloseable {
         PubSubRequest request = new PubSubRequest();
         request.setType(type);
         request.setNonce(CryptoUtils.generateNonce(30));
-        request.getData().put("auth_token", credential != null ? credential.getAccessToken() : "");
+        request.setCredential(credential);
         request.getData().put("topics", topics);
 
         return listenOnTopic(request);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/TwitchPubSub.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.pubsub;
 
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.twitch4j.client.websocket.WebsocketConnection;
 import com.github.twitch4j.client.websocket.domain.WebsocketConnectionState;
@@ -413,6 +414,13 @@ public class TwitchPubSub implements ITwitchPubSub {
      * @param request PubSub request (or Topic)
      */
     private void queueRequest(PubSubRequest request) {
+        // use latest token (in case of expiry)
+        OAuth2Credential credential = request.getCredential();
+        if (credential != null) {
+            request.getData().put("auth_token", credential.getAccessToken());
+        }
+
+        // queue the request
         commandQueue.add(TypeConvert.objectToJson(request));
 
         // Expedite command execution if we aren't already flushing the queue and another expedition hasn't already been requested

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubRequest.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/PubSubRequest.java
@@ -1,8 +1,12 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.pubsub.enums.PubSubType;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,7 +17,7 @@ import java.util.Map;
  * Will ignore null values when serializing the request
  */
 @Data
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class PubSubRequest {
 
     /**
@@ -24,11 +28,26 @@ public class PubSubRequest {
     /**
      * Random string to identify the response associated with this request.
      */
+    @EqualsAndHashCode.Exclude // topic matters more than nonce
     private String nonce;
 
     /**
      * Data (Body)
      */
-    private Map<String, Object> data = new HashMap<>();
+    @EqualsAndHashCode.Exclude // covered by getTopics()
+    private Map<String, Object> data = new HashMap<>(4);
+
+    /**
+     * Credential for {@link PubSubType#LISTEN} requests.
+     */
+    @JsonIgnore
+    @ApiStatus.Internal
+    @EqualsAndHashCode.Exclude // user_id in topic matters more than the specific credential
+    private OAuth2Credential credential;
+
+    @EqualsAndHashCode.Include // avoid duplicate LISTENs for same topic
+    private Object getTopics() {
+        return data.get("topics");
+    }
 
 }

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/TwitchPubSubTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/TwitchPubSubTest.java
@@ -6,6 +6,7 @@ import com.github.twitch4j.client.websocket.domain.WebsocketConnectionState;
 import com.github.twitch4j.common.test.TestEventManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -17,6 +18,7 @@ import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.times;
 
 @Slf4j
+@Tag("unittest")
 public class TwitchPubSubTest {
     private WebsocketConnection connection;
 
@@ -55,9 +57,9 @@ public class TwitchPubSubTest {
         await().atMost(Duration.ofSeconds(1)).until(() -> pubSub.commandQueue.size() == 0);
 
         // verify
-        Mockito.verify(connection, times(1)).sendText(matches(noncePattern("{\"type\":\"LISTEN\",\"nonce\":\"NONCE_ANY\",\"data\":{\"topics\":[\"channel-bits-events-v2.149223493\"],\"auth_token\":\"my-secret-token\"}}")));
-        Mockito.verify(connection, times(1)).sendText(matches(noncePattern("{\"type\":\"LISTEN\",\"nonce\":\"NONCE_ANY\",\"data\":{\"topics\":[\"channel-subscribe-events-v1.149223493\"],\"auth_token\":\"my-secret-token\"}}")));
-        Mockito.verify(connection, times(1)).sendText(matches(noncePattern("{\"type\":\"LISTEN\",\"nonce\":\"NONCE_ANY\",\"data\":{\"topics\":[\"whispers.149223493\"],\"auth_token\":\"my-secret-token\"}}")));
+        Mockito.verify(connection, times(1)).sendText(matches(noncePattern("{\"type\":\"LISTEN\",\"nonce\":\"NONCE_ANY\",\"data\":{\"auth_token\":\"my-secret-token\",\"topics\":[\"channel-bits-events-v2.149223493\"]}}")));
+        Mockito.verify(connection, times(1)).sendText(matches(noncePattern("{\"type\":\"LISTEN\",\"nonce\":\"NONCE_ANY\",\"data\":{\"auth_token\":\"my-secret-token\",\"topics\":[\"channel-subscribe-events-v1.149223493\"]}}")));
+        Mockito.verify(connection, times(1)).sendText(matches(noncePattern("{\"type\":\"LISTEN\",\"nonce\":\"NONCE_ANY\",\"data\":{\"auth_token\":\"my-secret-token\",\"topics\":[\"whispers.149223493\"]}}")));
     }
 
     private String noncePattern(String input) {

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/BanSharingSettingsTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/BanSharingSettingsTest.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("unittest")
 class BanSharingSettingsTest {
 
     @Test

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/PubSubRequestTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/PubSubRequestTest.java
@@ -1,0 +1,91 @@
+package com.github.twitch4j.pubsub.domain;
+
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.enums.PubSubType;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Tag("unittest")
+class PubSubRequestTest {
+
+    @Test
+    void equals() {
+        PubSubRequest a = new PubSubRequest();
+        a.setType(PubSubType.LISTEN);
+        a.setNonce("1234");
+        a.getData().put("topics", Collections.singletonList("ads.6789"));
+
+        PubSubRequest b = new PubSubRequest();
+        b.setType(PubSubType.LISTEN);
+        b.setNonce("5555");
+        b.getData().put("topics", Collections.singletonList("ads.6789"));
+
+        PubSubRequest c = new PubSubRequest();
+        c.setType(PubSubType.LISTEN);
+        c.setNonce("5555");
+        c.getData().put("topics", Collections.singletonList("ads.9999"));
+
+        PubSubRequest d = new PubSubRequest();
+        d.setType(PubSubType.LISTEN);
+        d.setNonce("5555");
+        d.getData().put("topics", Collections.singletonList("ads.9999"));
+        d.getData().put("unimportant", true);
+
+        PubSubRequest e = new PubSubRequest();
+        e.setType(PubSubType.UNLISTEN);
+        e.setNonce("1234");
+        e.getData().put("topics", Collections.singletonList("ads.6789"));
+
+        assertEquals(a, b); // nonce is ignored
+        assertNotEquals(b, c); // topic is used
+        assertEquals(c, d); // extraneous data is ignored
+        assertNotEquals(a, e); // type is used
+    }
+
+    @Test
+    void serialize() {
+        PubSubRequest req = new PubSubRequest();
+        req.setType(PubSubType.LISTEN);
+        req.setNonce("1234");
+        req.getData().put("topics", Collections.singletonList("ads.6789"));
+        String json = TypeConvert.objectToJson(req);
+        assertEquals("{\"type\":\"LISTEN\",\"nonce\":\"1234\",\"data\":{\"topics\":[\"ads.6789\"]}}", json);
+    }
+
+    @Test
+    void serializeAuthorized() {
+        PubSubRequest req = new PubSubRequest();
+        req.setType(PubSubType.LISTEN);
+        req.setNonce("1234");
+        req.setCredential(new OAuth2Credential("twitch", "qwerty"));
+        req.setData(new LinkedHashMap<>(4));
+        req.getData().put("auth_token", "qwerty");
+        req.getData().put("topics", Collections.singletonList("ads.6789"));
+        String json = TypeConvert.objectToJson(req);
+        assertEquals("{\"type\":\"LISTEN\",\"nonce\":\"1234\",\"data\":{\"auth_token\":\"qwerty\",\"topics\":[\"ads.6789\"]}}", json);
+    }
+
+    @Test
+    void serializePing() {
+        PubSubRequest ping = new PubSubRequest();
+        ping.setType(PubSubType.PING);
+        String json = TypeConvert.objectToJson(ping);
+        assertEquals("{\"type\":\"PING\"}", json);
+    }
+
+    @Test
+    void deserialize() {
+        String json = "{\"type\":\"AUTH_REVOKED\",\"data\":{\"topics\":[\"channel-bits-events-v1.44322889\"]}}";
+        PubSubRequest revocation = TypeConvert.jsonToObject(json, PubSubRequest.class);
+        assertEquals(PubSubType.AUTH_REVOKED, revocation.getType());
+        assertEquals(Collections.singletonList("channel-bits-events-v1.44322889"), revocation.getData().get("topics"));
+    }
+
+}

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/RevocationTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/RevocationTest.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.pubsub.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.pubsub.enums.PubSubType;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -9,6 +10,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@Tag("unittest")
 class RevocationTest {
 
     @Test

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/ScheduleUpdateTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/ScheduleUpdateTest.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -10,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("unittest")
 class ScheduleUpdateTest {
 
     @Test

--- a/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/WhisperThreadTest.java
+++ b/pubsub/src/test/java/com/github/twitch4j/pubsub/domain/WhisperThreadTest.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@Tag("unittest")
 class WhisperThreadTest {
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Bugs Fixed
If token used to listen to a pubsub topic expired, the subscription would not successfully be recreated upon a reconnect (even if credential was refreshed)

### Changes Proposed
* When `LISTEN` requests are sent, always use the latest access token stored in the passed `OAuth2Credential`

### Additional Information
also fixes stability of PubSubRequest hashCode since it's used as a set key (only PubSubType and topic name/args should be used since data.auth_token is now mutable)
