### PR TITLE
feat(eventsub): add unban request subscription types

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ModeratorEventSubCondition.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/condition/ModeratorEventSubCondition.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.eventsub.condition;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
@@ -12,6 +13,7 @@ import static org.apache.commons.lang3.StringUtils.defaultString;
 @Setter(AccessLevel.PRIVATE)
 @SuperBuilder
 @Jacksonized
+@ToString(callSuper = true)
 public class ModeratorEventSubCondition extends ChannelEventSubCondition {
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/UnbanRequestStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/UnbanRequestStatus.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.eventsub.domain;
+
+/**
+ * @see com.github.twitch4j.eventsub.events.UnbanRequestResolvedEvent
+ */
+public enum UnbanRequestStatus {
+
+    /**
+     * A moderator approved the unban request.
+     */
+    APPROVED,
+
+    /**
+     * The user withdrew their request for an unban.
+     */
+    CANCELED,
+
+    /**
+     * A moderator denied the unban request.
+     */
+    DENIED
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UnbanRequestCreatedEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UnbanRequestCreatedEvent.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+public class UnbanRequestCreatedEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The ID of the unban request.
+     */
+    @JsonProperty("id")
+    private String requestId;
+
+    /**
+     * Message sent in the unban request.
+     */
+    private String text;
+
+    /**
+     * The UTC timestamp (in RFC3339 format) of when the unban request was created.
+     */
+    private Instant createdAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UnbanRequestResolvedEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UnbanRequestResolvedEvent.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.UnbanRequestStatus;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class UnbanRequestResolvedEvent extends EventSubModerationEvent {
+
+    /**
+     * The ID of the unban request.
+     */
+    @JsonProperty("id")
+    private String requestId;
+
+    /**
+     * Resolution text supplied by the mod/broadcaster upon approval/denial of the request.
+     */
+    @Nullable
+    private String resolutionText;
+
+    /**
+     * Dictates whether the unban request was approved or denied.
+     */
+    private UnbanRequestStatus status;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -65,6 +65,8 @@ public class SubscriptionTypes {
     public final ShoutoutReceiveType SHOUTOUT_RECEIVE_TYPE;
     public final StreamOfflineType STREAM_OFFLINE;
     public final StreamOnlineType STREAM_ONLINE;
+    public final UnbanRequestCreateType UNBAN_REQUEST_CREATE;
+    public final UnbanRequestResolveType UNBAN_REQUEST_RESOLVE;
     public final UserAuthorizationGrantType USER_AUTHORIZATION_GRANT;
     public final UserAuthorizationRevokeType USER_AUTHORIZATION_REVOKE;
     public final UserUpdateType USER_UPDATE;
@@ -127,6 +129,8 @@ public class SubscriptionTypes {
                 SHOUTOUT_RECEIVE_TYPE = new ShoutoutReceiveType(),
                 STREAM_OFFLINE = new StreamOfflineType(),
                 STREAM_ONLINE = new StreamOnlineType(),
+                UNBAN_REQUEST_CREATE = new UnbanRequestCreateType(),
+                UNBAN_REQUEST_RESOLVE = new UnbanRequestResolveType(),
                 USER_AUTHORIZATION_GRANT = new UserAuthorizationGrantType(),
                 USER_AUTHORIZATION_REVOKE = new UserAuthorizationRevokeType(),
                 USER_UPDATE = new UserUpdateType()

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UnbanRequestCreateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UnbanRequestCreateType.java
@@ -1,0 +1,39 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
+import com.github.twitch4j.eventsub.events.UnbanRequestCreatedEvent;
+
+/**
+ * Fires when a user creates an unban request.
+ * <p>
+ * Must have moderator:read:unban_requests or moderator:manage:unban_requests scope.
+ * <p>
+ * If you use webhooks, the user in moderator_id must have granted your app (client ID)
+ * one of the above permissions prior to your app subscribing to this subscription type.
+ * <p>
+ * If you use WebSockets, the ID in moderator_id must match the user ID in the user access token.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_MANAGE
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_READ
+ */
+public class UnbanRequestCreateType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, UnbanRequestCreatedEvent> {
+    @Override
+    public String getName() {
+        return "channel.unban_request.create";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ModeratorEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<UnbanRequestCreatedEvent> getEventClass() {
+        return UnbanRequestCreatedEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UnbanRequestResolveType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UnbanRequestResolveType.java
@@ -1,0 +1,39 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
+import com.github.twitch4j.eventsub.events.UnbanRequestResolvedEvent;
+
+/**
+ * Fires when an unban request has been resolved.
+ * <p>
+ * Must have moderator:read:unban_requests or moderator:manage:unban_requests scope.
+ * <p>
+ * If you use webhooks, the user in moderator_id must have granted your app (client ID)
+ * one of the above permissions prior to your app subscribing to this subscription type.
+ * <p>
+ * If you use WebSockets, the ID in moderator_id must match the user ID in the user access token.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_MANAGE
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_READ
+ */
+public class UnbanRequestResolveType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, UnbanRequestResolvedEvent> {
+    @Override
+    public String getName() {
+        return "channel.unban_request.resolve";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ModeratorEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<UnbanRequestResolvedEvent> getEventClass() {
+        return UnbanRequestResolvedEvent.class;
+    }
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2134,7 +2134,6 @@ public interface TwitchHelix {
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_READ
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_MANAGE
      */
-    @ApiStatus.Experimental
     @RequestLine("GET /moderation/unban_requests?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&status={status}&user_id={user_id}&after={after}&first={first}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<UnbanRequestList> getUnbanRequests(
@@ -2159,7 +2158,6 @@ public interface TwitchHelix {
      * @return UnbanRequestList
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_UNBAN_REQUESTS_MANAGE
      */
-    @ApiStatus.Experimental
     @RequestLine("PATCH /moderation/unban_requests?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&unban_request_id={unban_request_id}&status={status}&resolution_text={resolution_text}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<UnbanRequestList> resolveUnbanRequest(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UnbanRequest.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/UnbanRequest.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.helix.domain;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 
@@ -84,11 +85,13 @@ public class UnbanRequest {
     /**
      * Timestamp of when moderator/broadcaster approved or denied the request.
      */
+    @Nullable
     private Instant resolvedAt;
 
     /**
      * Text input by the resolver (moderator) of the unban request.
      */
+    @Nullable
     private String resolutionText;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/925
* https://github.com/twitchdev/issues/issues/926
* ~~`channel.unban_request.create` v1 doesn't fire (only beta does) -- relevant team has been informed~~

Note: for folks already using unofficial pubsub, the above issues likely prevent migration

### Changes Proposed
* Add `SubscriptionTypes.UNBAN_REQUEST_CREATE`
* Add `SubscriptionTypes.UNBAN_REQUEST_RESOLVE`

### Additional Information
Introduced as open beta on 2024-03-07
Promoted from open beta to v1 on 2024-03-15
