### PR TITLE
chore: deprecate IEventSubSocket#register(SubscriptionType, EventSubCondition)

### DIFF
--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/IEventSubSocket.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/IEventSubSocket.java
@@ -9,6 +9,7 @@ import com.github.twitch4j.eventsub.EventSubTransportMethod;
 import com.github.twitch4j.eventsub.condition.EventSubCondition;
 import com.github.twitch4j.eventsub.events.EventSubEvent;
 import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
 import java.util.function.Function;
@@ -103,8 +104,11 @@ public interface IEventSubSocket extends AutoCloseable {
 
     /**
      * Helper method for {@link #register(SubscriptionType, Function)}
+     *
+     * @deprecated in favor of {@link #register(SubscriptionType, Function)}
      */
-    @SuppressWarnings("unused")
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     default <C extends EventSubCondition, B, E extends EventSubEvent> boolean register(SubscriptionType<C, B, E> type, C condition) {
         return this.register(type, (Function<B, C>) b -> condition);
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate `IEventSubSocket#register(SubscriptionType, EventSubCondition)`

### Additional Information
Folks can just do `b -> condition` themselves, and this method tends to cause ambiguous method call issues where folks have to use casting to specify `#register(SubscriptionType, EventSubCondition)` or `register(SubscriptionType, Function)`

