### PR TITLE
feat(eventsub): add automod settings and terms topics

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/TermUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/TermUpdateType.java
@@ -1,0 +1,20 @@
+package com.github.twitch4j.eventsub.domain;
+
+/**
+ * The status change applied to the terms.
+ *
+ * @see com.github.twitch4j.eventsub.events.ChannelTermsUpdateEvent
+ */
+public enum TermUpdateType {
+    ADD_PERMITTED,
+    REMOVE_PERMITTED,
+    ADD_BLOCKED,
+    REMOVE_BLOCKED;
+
+    /**
+     * @return whether the update is the addition of a new term. otherwise, a term was removed.
+     */
+    public boolean isAddition() {
+        return this == ADD_PERMITTED || this == ADD_BLOCKED;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodSettingsUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodSettingsUpdateEvent.java
@@ -1,0 +1,63 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class AutomodSettingsUpdateEvent extends EventSubModeratorEvent {
+
+    /**
+     * The default AutoMod level for the broadcaster.
+     * This field is null if the broadcaster has set one or more of the individual settings.
+     */
+    @Nullable
+    private Integer overallLevel;
+
+    /**
+     * The Automod level for hostility involving name calling or insults.
+     */
+    private int bullying;
+
+    /**
+     * The Automod level for discrimination against disability.
+     */
+    private int disability;
+
+    /**
+     * The Automod level for racial discrimination.
+     */
+    private int raceEthnicityOrReligion;
+
+    /**
+     * The Automod level for discrimination against women.
+     */
+    private int misogyny;
+
+    /**
+     * The AutoMod level for discrimination based on sexuality, sex, or gender.
+     */
+    private int sexualitySexOrGender;
+
+    /**
+     * The Automod level for hostility involving aggression.
+     */
+    private int aggression;
+
+    /**
+     * The Automod level for sexual content.
+     */
+    private int sexBasedTerms;
+
+    /**
+     * The Automod level for profanity.
+     */
+    private int swearing;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelTermsUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelTermsUpdateEvent.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.TermUpdateType;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChannelTermsUpdateEvent extends EventSubModeratorEvent {
+
+    /**
+     * The status change applied to the terms.
+     */
+    private TermUpdateType action;
+
+    /**
+     * Whether this term was added due to an Automod message approve/deny action.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("from_automod")
+    private Boolean isFromAutomod;
+
+    /**
+     * The terms that had a status change.
+     */
+    private List<String> terms;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubModeratorEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/EventSubModeratorEvent.java
@@ -1,0 +1,32 @@
+package com.github.twitch4j.eventsub.events;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public abstract class EventSubModeratorEvent extends EventSubChannelEvent implements ModeratorEvent {
+
+    /**
+     * The user ID of the moderator associated with this event.
+     */
+    private String moderatorUserId;
+
+    /**
+     * The user login of the moderator associated with this event.
+     */
+    private String moderatorUserLogin;
+
+    /**
+     * The user name of the  moderator associated with this event.
+     */
+    private String moderatorUserName;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodSettingsUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodSettingsUpdateType.java
@@ -1,0 +1,33 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
+import com.github.twitch4j.eventsub.events.AutomodSettingsUpdateEvent;
+
+/**
+ * Fires when a broadcaster’s automod settings are updated.
+ * <p>
+ * Requires authorization from a moderator of the channel with the moderator:read:automod_settings scope.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_AUTOMOD_SETTINGS_READ
+ */
+public class AutomodSettingsUpdateType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, AutomodSettingsUpdateEvent> {
+    @Override
+    public String getName() {
+        return "automod.settings.update";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ModeratorEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<AutomodSettingsUpdateEvent> getEventClass() {
+        return AutomodSettingsUpdateEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodTermsUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodTermsUpdateType.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
+import com.github.twitch4j.eventsub.events.ChannelTermsUpdateEvent;
+
+/**
+ * Fires when a broadcaster’s AutoMod terms are updated.
+ * Changes to private terms are not sent.
+ * <p>
+ * Requires authorization from a moderator of the channel with the moderator:manage:automod scope.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_AUTOMOD_MANAGE
+ */
+public class AutomodTermsUpdateType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, ChannelTermsUpdateEvent> {
+    @Override
+    public String getName() {
+        return "automod.terms.update";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ModeratorEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<ChannelTermsUpdateEvent> getEventClass() {
+        return ChannelTermsUpdateEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
+    public final AutomodTermsUpdateType AUTOMOD_TERMS_UPDATE;
     public final ChannelAdBreakBeginType CHANNEL_AD_BREAK_BEGIN;
     public final ChannelBanType CHANNEL_BAN;
     public final ChannelChatClearType CHANNEL_CHAT_CLEAR;
@@ -77,6 +78,7 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
+                AUTOMOD_TERMS_UPDATE = new AutomodTermsUpdateType(),
                 CHANNEL_AD_BREAK_BEGIN = new ChannelAdBreakBeginType(),
                 CHANNEL_BAN = new ChannelBanType(),
                 CHANNEL_CHAT_CLEAR = new ChannelChatClearType(),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
+    public final AutomodSettingsUpdateType AUTOMOD_SETTINGS_UPDATE;
     public final AutomodTermsUpdateType AUTOMOD_TERMS_UPDATE;
     public final ChannelAdBreakBeginType CHANNEL_AD_BREAK_BEGIN;
     public final ChannelBanType CHANNEL_BAN;
@@ -78,6 +79,7 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
+                AUTOMOD_SETTINGS_UPDATE = new AutomodSettingsUpdateType(),
                 AUTOMOD_TERMS_UPDATE = new AutomodTermsUpdateType(),
                 CHANNEL_AD_BREAK_BEGIN = new ChannelAdBreakBeginType(),
                 CHANNEL_BAN = new ChannelBanType(),


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Implement `automod.settings.update` eventsub subscription type
* Implement `automod.terms.update` eventsub subscription type

### Additional Information
Added as public beta on 2024-03-07
Promoted to v1 on 2024‑03‑15
https://dev.twitch.tv/docs/change-log/
