### PR TITLE
refactor: remove broadcasterId param for getUserEmotes

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -546,19 +546,15 @@ public interface TwitchHelix {
      *
      * @param authToken     User access token (scope: user:read:emotes).
      * @param userId        The ID of the user. This ID must match the user ID in the user access token.
-     * @param broadcasterId Returns all emotes available to the user within the chat owned by the specified broadcaster.
-     *                      This includes the Global and Subscriber Emotes the user has access to,
-     *                      as well as channel-only specific emotes such as Follower Emotes.
      * @param cursor        The cursor used to get the next page of results.
      * @return {@link EmoteList}
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_USER_EMOTES_READ
      */
-    @RequestLine("GET /chat/emotes/user?user_id={user_id}&broadcaster_id={broadcaster_id}&after={after}")
+    @RequestLine("GET /chat/emotes/user?user_id={user_id}&after={after}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<EmoteList> getUserEmotes(
         @Param("token") String authToken,
         @NotNull @Param("user_id") String userId,
-        @Nullable @Param("broadcaster_id") String broadcasterId,
         @Nullable @Param("after") String cursor
     );
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
@@ -36,7 +36,7 @@ public class Emote {
     /**
      * The image URLs for the emote.
      * <p>
-     * This is <i>not</i> present for {@link TwitchHelix#getUserEmotes(String, String, String, String)};
+     * This is <i>not</i> present for {@link TwitchHelix#getUserEmotes(String, String, String)};
      * use {@link EmoteList#getPopulatedTemplateUrl(String, Format, Theme, Scale)}.
      */
     @Nullable
@@ -48,7 +48,7 @@ public class Emote {
      * This is <i>not</i> present for {@link TwitchHelix#getGlobalEmotes(String)}.
      * This <i>is</i> present for {@link TwitchHelix#getChannelEmotes(String, String)},
      * {@link TwitchHelix#getEmoteSets(String, Collection)},
-     * and {@link TwitchHelix#getUserEmotes(String, String, String, String)}.
+     * and {@link TwitchHelix#getUserEmotes(String, String, String)}.
      */
     @Nullable
     private String emoteSetId;
@@ -75,7 +75,7 @@ public class Emote {
      * User ID of the broadcaster who owns the emote.
      * <p>
      * This is <i>only</i> present for {@link TwitchHelix#getEmoteSets(String, Collection)}
-     * and {@link TwitchHelix#getUserEmotes(String, String, String, String)}.
+     * and {@link TwitchHelix#getUserEmotes(String, String, String)}.
      */
     @Nullable
     private String ownerId;
@@ -85,7 +85,7 @@ public class Emote {
      * <p>
      * This is <i>only</i> present for {@link TwitchHelix#getChannelEmotes(String, String)}
      * {@link TwitchHelix#getEmoteSets(String, Collection)},
-     * and {@link TwitchHelix#getUserEmotes(String, String, String, String)}.
+     * and {@link TwitchHelix#getUserEmotes(String, String, String)}.
      */
     @Nullable
     private String emoteType;
@@ -150,7 +150,6 @@ public class Emote {
         /**
          * Indicates a channel points reward emote.
          */
-        @Unofficial
         CHANNEL_POINTS,
 
         /**
@@ -161,37 +160,36 @@ public class Emote {
         /**
          * Indicates a global emote.
          */
-        @Unofficial
         GLOBALS,
 
         /**
          * Indicates a hype train emote.
          */
-        @Unofficial
         HYPE_TRAIN,
 
         /**
          * Indicates a limited time emote.
          */
-        @Unofficial
         LIMITED_TIME("limitedtime", "owl2019"),
+
+        /**
+         * No emote type was assigned to this emote.
+         */
+        NONE,
 
         /**
          * Indicates a prime or turbo emote.
          */
-        @Unofficial
         PRIME("prime", "turbo"),
 
         /**
          * Indicates a rewards emote.
          */
-        @Unofficial
         REWARDS("rewards", "megacommerce", "megacheer"),
 
         /**
          * Indicates a smiley emote.
          */
-        @Unofficial
         SMILIES,
 
         /**
@@ -202,7 +200,6 @@ public class Emote {
         /**
          * Indicates a two-factor emote.
          */
-        @Unofficial
         TWO_FACTOR,
 
         /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://github.com/twitchdev/issues/issues/928

### Changes Proposed
* Remove `broadcasterId` argument from `TwitchHelix#getUserEmotes`
* Add more documented `emote_type`'s

### Additional Information
On [2024-04-05](https://dev.twitch.tv/docs/change-log/), Twitch decided to make a breaking change to a helix endpoint that was marked as stable for the past three weeks: "Removed broadcaster_id query parameter" from [Get User Emotes](https://dev.twitch.tv/docs/api/reference/#get-user-emotes) endpoint
