### PR TITLE
docs: remove unofficial marker for some eventsub statuses

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscriptionStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/EventSubSubscriptionStatus.java
@@ -1,7 +1,5 @@
 package com.github.twitch4j.eventsub;
 
-import com.github.twitch4j.common.annotation.Unofficial;
-
 public enum EventSubSubscriptionStatus {
 
     /**
@@ -50,9 +48,8 @@ public enum EventSubSubscriptionStatus {
     BETA_MAINTENANCE,
 
     /**
-     * Twitch revoked your subscription to a chat topic because your chatter user was banned by a moderator of the channel.
+     * The user specified in the Condition object was banned from the broadcaster's chat.
      */
-    @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
     CHAT_USER_BANNED,
 
     /**
@@ -73,9 +70,8 @@ public enum EventSubSubscriptionStatus {
     WEBSOCKET_FAILED_PING_PONG,
 
     /**
-     * A websocket conduit shard did not reconnect after being disconnected.
+     * The client failed to reconnect to the Twitch WebSocket server within the required time after a Reconnect Message.
      */
-    @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
     WEBSOCKET_FAILED_TO_RECONNECT,
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ShardStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/ShardStatus.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.eventsub;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
-import com.github.twitch4j.common.annotation.Unofficial;
 
 public enum ShardStatus {
 
@@ -36,9 +35,8 @@ public enum ShardStatus {
     WEBSOCKET_FAILED_PING_PONG,
 
     /**
-     * A websocket conduit shard did not reconnect to a Twitch-specified url upon their request.
+     * The client failed to reconnect to the Twitch WebSocket server within the required time after a Reconnect Message..
      */
-    @Unofficial // https://github.com/twitchdev/issues/issues/931#issuecomment-2018532569
     WEBSOCKET_FAILED_TO_RECONNECT,
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues 
* https://github.com/twitchdev/issues/issues/931

### Changes Proposed
* `chat_user_banned` and `websocket_failed_to_reconnect` are no longer undocumented; remove `@Unofficial` annotation & update javadoc

### Additional Information
2024-04-05 changelog entry https://dev.twitch.tv/docs/change-log/
