### PR TITLE
chore(helix): remove unofficial marker for many emote types

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Emote.java
@@ -150,48 +150,47 @@ public class Emote {
         /**
          * Indicates a channel points reward emote.
          */
-        @Unofficial
         CHANNEL_POINTS,
 
         /**
          * Indicates a custom follower emote.
+         * Note: subscribers can utilize follower emotes in any channel.
          */
         FOLLOWER,
 
         /**
          * Indicates a global emote.
          */
-        @Unofficial
         GLOBALS,
 
         /**
          * Indicates a hype train emote.
          */
-        @Unofficial
         HYPE_TRAIN,
 
         /**
          * Indicates a limited time emote.
          */
-        @Unofficial
         LIMITED_TIME("limitedtime", "owl2019"),
+
+        /**
+         * No emote type was assigned to this emote.
+         */
+        NONE,
 
         /**
          * Indicates a prime or turbo emote.
          */
-        @Unofficial
         PRIME("prime", "turbo"),
 
         /**
          * Indicates a rewards emote.
          */
-        @Unofficial
         REWARDS("rewards", "megacommerce", "megacheer"),
 
         /**
          * Indicates a smiley emote.
          */
-        @Unofficial
         SMILIES,
 
         /**
@@ -202,7 +201,6 @@ public class Emote {
         /**
          * Indicates a two-factor emote.
          */
-        @Unofficial
         TWO_FACTOR,
 
         /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issue 
* https://github.com/twitchdev/issues/issues/928 (supercedes #958)

### Changes Proposed
* Remove `@Unofficial` marker on most helix `Emote.Type`s
* Add `Emote.Type.NONE` (would be interesting to find an empirical example of this)

### Additional Information
2024-04-05 changelog entry https://dev.twitch.tv/docs/change-log/
