### PR TITLE
chore: improve shadow jar building

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 	id("io.freefair.lombok").version("8.6").apply(false)
 	id("com.coditory.manifest").version("0.2.6").apply(false)
 	id("me.champeau.jmh").version("0.7.2").apply(false)
-	id("com.github.johnrengelman.shadow").version("8.1.1").apply(false)
+	id("io.github.goooler.shadow").version("8.1.7").apply(false)
 	id("com.github.gmazzo.buildconfig").version("5.3.5").apply(false)
 }
 
@@ -189,6 +189,16 @@ subprojects {
 				archiveClassifier.set("shaded")
 				isEnableRelocation = true
 				relocationPrefix = "com.github.twitch4j.shaded.${"$version".replace(".", "_")}"
+
+				// support for multi-release jars since we depend upon jackson-core, which leverages FastDoubleParser
+				dependencies {
+					// https://github.com/johnrengelman/shadow/issues/729
+					exclude("META-INF/versions/**/module-info.class")
+				}
+				manifest {
+					// https://github.com/johnrengelman/shadow/issues/449
+					attributes("Multi-Release" to true)
+				}
 			}
 			if (enableManifest) {
 				manifest.from(File(buildDir, "resources/main/META-INF/MANIFEST.MF"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -188,7 +188,7 @@ subprojects {
 			if (this is ShadowJar) {
 				archiveClassifier.set("shaded")
 				isEnableRelocation = true
-				relocationPrefix = "com.github.twitch4j.shaded.${"$version".replace(".", "_")}"
+				relocationPrefix = "com.github.twitch4j.shaded"
 
 				// support for multi-release jars since we depend upon jackson-core, which leverages FastDoubleParser
 				dependencies {

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("com.github.johnrengelman.shadow")
+	id("io.github.goooler.shadow")
 }
 
 dependencies {

--- a/eventsub-websocket/build.gradle.kts
+++ b/eventsub-websocket/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("com.github.johnrengelman.shadow")
+	id("io.github.goooler.shadow")
 }
 
 dependencies {

--- a/pubsub/build.gradle.kts
+++ b/pubsub/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("com.github.johnrengelman.shadow")
+	id("io.github.goooler.shadow")
 }
 
 dependencies {

--- a/rest-helix/build.gradle.kts
+++ b/rest-helix/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("com.github.johnrengelman.shadow")
+	id("io.github.goooler.shadow")
 }
 
 dependencies {

--- a/twitch4j/build.gradle.kts
+++ b/twitch4j/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("com.github.johnrengelman.shadow")
+	id("io.github.goooler.shadow")
 }
 
 dependencies {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* https://togithub.com/johnrengelman/shadow/issues/894 (we were already using goooler fork for previous release)
* https://togithub.com/johnrengelman/shadow/issues/908 (we'll switch to the new coordinates when available)

### Changes Proposed
* Explicitly use Goooler's shadow plugin [fork](https://plugins.gradle.org/plugin/io.github.goooler.shadow) (for now)
* Exclude `module-info.class` from jackson-core
* Mark shadow jar as a multi-release jar (due to [FastDoubleParser](https://github.com/wrandelshofer/FastDoubleParser/) impls)

### Additional Information
JDK 21+ classes were coming from jackson-core's multi-release jar - https://togithub.com/FasterXML/jackson-core/issues/1185
