### PR TITLE
feat(eventsub): add automatic reward redemption topic

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/domain/TwitchScopes.java
@@ -33,6 +33,7 @@ public enum TwitchScopes {
     HELIX_CHANNEL_PREDICTIONS_MANAGE("channel:manage:predictions"),
     HELIX_CHANNEL_PREDICTIONS_READ("channel:read:predictions"),
     HELIX_CHANNEL_RAIDS_MANAGE("channel:manage:raids"),
+    HELIX_CHANNEL_REDEMPTIONS_MANAGE("channel:manage:redemptions"),
     HELIX_CHANNEL_REDEMPTIONS_READ("channel:read:redemptions"),
     HELIX_CHANNEL_STREAM_KEY_READ("channel:read:stream_key"),
     HELIX_CHANNEL_SUBSCRIPTIONS_READ("channel:read:subscriptions"),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomaticReward.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomaticReward.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class AutomaticReward {
+
+    /**
+     * The type of reward.
+     */
+    private Type type;
+
+    /**
+     * The reward cost.
+     */
+    private int cost;
+
+    /**
+     * The emote that was unlocked.
+     */
+    @Nullable
+    private SimpleEmote unlockedEmote;
+
+    public enum Type {
+        SINGLE_MESSAGE_BYPASS_SUB_MODE,
+        SEND_HIGHLIGHTED_MESSAGE,
+        RANDOM_SUB_EMOTE_UNLOCK,
+        CHOSEN_SUB_EMOTE_UNLOCK,
+        CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/SimpleEmote.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/SimpleEmote.java
@@ -1,0 +1,21 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class SimpleEmote {
+
+    /**
+     * The emote ID.
+     */
+    private String id;
+
+    /**
+     * The human-readable emote token.
+     */
+    private String name;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomaticRewardRedemptionAddEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomaticRewardRedemptionAddEvent.java
@@ -1,0 +1,50 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.AutomaticReward;
+import com.github.twitch4j.eventsub.domain.Message;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class AutomaticRewardRedemptionAddEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The ID of the Redemption.
+     */
+    @JsonProperty("id")
+    private String redemptionId;
+
+    /**
+     * An object that contains the reward information.
+     */
+    private AutomaticReward reward;
+
+    /**
+     * An object that contains the user message and emote information needed to recreate the message.
+     */
+    private Message message;
+
+    /**
+     * A string that the user entered if the reward requires input.
+     */
+    @Nullable
+    private String userInput;
+
+    /**
+     * The UTC date and time (in RFC3339 format) of when the reward was redeemed.
+     */
+    private Instant redeemedAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsAutomaticRewardRedemptionAddType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelPointsAutomaticRewardRedemptionAddType.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelEventSubCondition;
+import com.github.twitch4j.eventsub.events.AutomaticRewardRedemptionAddEvent;
+
+/**
+ * This subscription type sends a notification when a viewer has redeemed an automatic channel points reward on the specified channel.
+ * <p>
+ * Must have channel:read:redemptions or channel:manage:redemptions scope.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_REDEMPTIONS_READ
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_REDEMPTIONS_MANAGE
+ */
+public class ChannelPointsAutomaticRewardRedemptionAddType implements SubscriptionType<ChannelEventSubCondition, ChannelEventSubCondition.ChannelEventSubConditionBuilder<?, ?>, AutomaticRewardRedemptionAddEvent> {
+    @Override
+    public String getName() {
+        return "channel.channel_points_automatic_reward_redemption.add";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ChannelEventSubCondition.ChannelEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<AutomaticRewardRedemptionAddEvent> getEventClass() {
+        return AutomaticRewardRedemptionAddEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -36,6 +36,7 @@ public class SubscriptionTypes {
     public final ChannelGoalEndType CHANNEL_GOAL_END;
     public final ChannelModeratorAddType CHANNEL_MODERATOR_ADD;
     public final ChannelModeratorRemoveType CHANNEL_MODERATOR_REMOVE;
+    public final ChannelPointsAutomaticRewardRedemptionAddType CHANNEL_POINTS_AUTOMATIC_REWARD_REDEMPTION_ADD;
     public final ChannelPointsCustomRewardAddType CHANNEL_POINTS_CUSTOM_REWARD_ADD;
     public final ChannelPointsCustomRewardRedemptionAddType CHANNEL_POINTS_CUSTOM_REWARD_REDEMPTION_ADD;
     public final ChannelPointsCustomRewardRedemptionUpdateType CHANNEL_POINTS_CUSTOM_REWARD_REDEMPTION_UPDATE;
@@ -103,6 +104,7 @@ public class SubscriptionTypes {
                 CHANNEL_GOAL_END = new ChannelGoalEndType(),
                 CHANNEL_MODERATOR_ADD = new ChannelModeratorAddType(),
                 CHANNEL_MODERATOR_REMOVE = new ChannelModeratorRemoveType(),
+                CHANNEL_POINTS_AUTOMATIC_REWARD_REDEMPTION_ADD = new ChannelPointsAutomaticRewardRedemptionAddType(),
                 CHANNEL_POINTS_CUSTOM_REWARD_ADD = new ChannelPointsCustomRewardAddType(),
                 CHANNEL_POINTS_CUSTOM_REWARD_REDEMPTION_ADD = new ChannelPointsCustomRewardRedemptionAddType(),
                 CHANNEL_POINTS_CUSTOM_REWARD_REDEMPTION_UPDATE = new ChannelPointsCustomRewardRedemptionUpdateType(),


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `SubscriptionTypes.CHANNEL_POINTS_AUTOMATIC_REWARD_REDEMPTION_ADD`

### Additional Information
Promoted to v1 on 2024-04-05
Released as public beta on 2024-03-15
https://dev.twitch.tv/docs/change-log/
