### PR TITLE
fix: populate SentChatMessage#isSent

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SentChatMessage.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SentChatMessage.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -19,6 +20,7 @@ public class SentChatMessage {
     /**
      * Whether the message passed all checks and was sent.
      */
+    @JsonProperty("is_sent")
     private boolean isSent;
 
     /**

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Tag("unittest")
 class AdScheduleTest {
 
     @Test

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/ChannelInformationTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/ChannelInformationTest.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.helix.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.eventsub.domain.ContentClassification;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("unittest")
 class ChannelInformationTest {
 
     @Test

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/SentChatMessageTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/SentChatMessageTest.java
@@ -1,0 +1,31 @@
+package com.github.twitch4j.helix.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unittest")
+class SentChatMessageTest {
+
+    @Test
+    void deserializeSent() {
+        String json = "{\"message_id\":\"e2a18344-83f9-4540-9513-422716fb079e\",\"is_sent\":true}";
+        SentChatMessage data = TypeConvert.jsonToObject(json, SentChatMessage.class);
+        assertEquals("e2a18344-83f9-4540-9513-422716fb079e", data.getMessageId());
+        assertTrue(data.isSent());
+    }
+
+    @Test
+    void deserializeDropped() {
+        String json = "{\"drop_reason\":{\"code\":\"msg_rejected\",\"message\":\"Your message is being checked by mods and has not been sent.\"},\"is_sent\":false,\"message_id\":\"\"}";
+        SentChatMessage data = TypeConvert.jsonToObject(json, SentChatMessage.class);
+        assertTrue(data.getMessageId() == null || data.getMessageId().isEmpty());
+        assertFalse(data.isSent());
+        assertNotNull(data.getDropReason());
+        assertEquals("msg_rejected", data.getDropReason().getCode());
+        assertEquals("Your message is being checked by mods and has not been sent.", data.getDropReason().getMessage());
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `SentChatMessage#isSent` was false, even for successful requests

### Changes Proposed
* Properly deserialize `is_sent` property in `SentChatMessage`

### Additional Information
Not critical since `dropReason == null` conveys the same information

