### PR TITLE
refactor(eventsub): change superclass for shield mode events

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ShieldModeBeginEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ShieldModeBeginEvent.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Instant;
 
@@ -14,11 +15,29 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ShieldModeBeginEvent extends EventSubModerationEvent {
+public class ShieldModeBeginEvent extends EventSubModeratorEvent {
 
     /**
      * The UTC timestamp of when the moderator activated Shield Mode.
      */
     private Instant startedAt;
+
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getUserId() {
+        return getModeratorUserId();
+    }
+
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getUserName() {
+        return getModeratorUserName();
+    }
+
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getUserLogin() {
+        return getModeratorUserLogin();
+    }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ShieldModeEndEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ShieldModeEndEvent.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Instant;
 
@@ -14,11 +15,29 @@ import java.time.Instant;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ShieldModeEndEvent extends EventSubModerationEvent {
+public class ShieldModeEndEvent extends EventSubModeratorEvent {
 
     /**
      * The UTC timestamp of when the moderator deactivated Shield Mode.
      */
     private Instant endedAt;
+
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getUserId() {
+        return getModeratorUserId();
+    }
+
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getUserName() {
+        return getModeratorUserName();
+    }
+
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getUserLogin() {
+        return getModeratorUserLogin();
+    }
 
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -49,6 +49,20 @@ public class EventSubEventTest {
     }
 
     @Test
+    @DisplayName("Deserialize ShieldModeBeginEvent")
+    public void deserializeModeratorEvent() {
+        ShieldModeBeginEvent event = jsonToObject(
+            "{\"broadcaster_user_id\":\"12345\",\"broadcaster_user_name\":\"SimplySimple\",\"broadcaster_user_login\":\"simplysimple\",\"moderator_user_id\":\"98765\",\"moderator_user_name\":\"ParticularlyParticular123\",\"moderator_user_login\":\"particularlyparticular123\",\"started_at\":\"2022-07-26T17:00:03.17106713Z\"}",
+            ShieldModeBeginEvent.class
+        );
+        assertEquals("12345", event.getBroadcasterUserId());
+        assertEquals("SimplySimple", event.getBroadcasterUserName());
+        assertEquals("98765", event.getModeratorUserId());
+        assertEquals("ParticularlyParticular123", event.getModeratorUserName());
+        assertEquals(Instant.parse("2022-07-26T17:00:03.17106713Z"), event.getStartedAt());
+    }
+
+    @Test
     @DisplayName("Deserialize ChannelBanEvent: Timeout")
     public void deserializeModerationEvent() {
         ChannelBanEvent event = jsonToObject(
@@ -105,8 +119,6 @@ public class EventSubEventTest {
         assertEquals(3, event.getChoices().size());
         assertEquals("123", event.getChoices().get(0).getId());
         assertEquals("Maybe!", event.getChoices().get(2).getTitle());
-        assertNotNull(event.getBitsVoting());
-        assertTrue(event.getBitsVoting().isEnabled());
         assertNotNull(event.getChannelPointsVoting());
         assertEquals(10, event.getChannelPointsVoting().getAmountPerVote());
         assertEquals(Instant.parse("2020-07-15T17:16:03.17106713Z"), event.getStartedAt());
@@ -127,8 +139,6 @@ public class EventSubEventTest {
         assertNotNull(event);
         assertNotNull(event.getChoices());
         assertEquals(3, event.getChoices().size());
-        assertNotNull(event.getChoices().get(0));
-        assertEquals(5, event.getChoices().get(0).getBitsVotes());
         assertNotNull(event.getChoices().get(1));
         assertEquals(4, event.getChoices().get(1).getChannelPointsVotes());
         assertNotNull(event.getChoices().get(2));


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Switch `ShieldModeBeginEvent`/`ShieldModeEndEvent` superclass to `EventSubModeratorEvent`

### Additional Information
EventSub shield mode events have `moderator_id` but not `user_id`, so `EventSubModerationEvent` has extraneous fields for this topic
