### PR TITLE
refactor(helix): clarify Stream thumbnail url getters

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -9,15 +9,14 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 /**
  * Stream (LiveStream)
@@ -52,6 +51,7 @@ public class Stream {
     /** Array of community IDs. */
     @Nullable
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     private List<UUID> communityIds;
 
     /** Stream type: "live" or "" (in case of error). */
@@ -82,6 +82,7 @@ public class Stream {
      */
     @Nullable
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     private List<UUID> tagIds;
 
     /** Indicates if the broadcaster has specified their channel contains mature content that may be inappropriate for younger audiences. */
@@ -111,10 +112,29 @@ public class Stream {
      *
      * @param width  thumbnail width
      * @param height thumbnail height
-     * @return String
+     * @return populated thumbnail url for a specific resolution
      */
-    public String getThumbnailUrl(Integer width, Integer height) {
-        return thumbnailUrl.replaceAll(Pattern.quote("{width}"), width.toString()).replaceAll(Pattern.quote("{height}"), height.toString());
+    public String getThumbnailUrl(int width, int height) {
+        return thumbnailUrl.replace("{width}x{height}", String.format("%dx%d", width, height));
+    }
+
+    /**
+     * @return the template for the thumbnail URL; contains "{width}" and "{height}" placeholders
+     * @apiNote To obtain a populated URL, prefer using the {@link #getThumbnailUrl(int, int)} method
+     */
+    public String getThumbnailUrlTemplate() {
+        return this.thumbnailUrl;
+    }
+
+    /**
+     * @return the thumbnail url template
+     * @deprecated in favor of {@link #getThumbnailUrlTemplate()} or {@link #getThumbnailUrl(int, int)}
+     */
+    @NonNull
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getThumbnailUrl() {
+        return this.thumbnailUrl;
     }
 
     /**
@@ -123,6 +143,7 @@ public class Stream {
      */
     @JsonIgnore
     @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public Calendar getStartedAt() {
         return TimeUtils.fromInstant(startedAtInstant);
     }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Stream.java
@@ -94,9 +94,15 @@ public class Stream {
     @NonNull
     private String language;
 
-    /** Thumbnail URL of the stream. All image URLs have variable width and height. You can replace {width} and {height} with any values to get that size image */
+    /**
+     * A template URL to an image of a frame from the last 5 minutes of the stream.
+     * Contains "{width}" and "{height}" placeholders to obtain the size of the image you want, in pixels.
+     * <p>
+     * To obtain a populated URL, prefer calling {@link #getThumbnailUrl(int, int)} instead.
+     */
     @NonNull
-    private String thumbnailUrl;
+    @JsonProperty("thumbnail_url")
+    private String thumbnailUrlTemplate;
 
     /**
      * Gets the stream uptime based on the start date.
@@ -115,15 +121,7 @@ public class Stream {
      * @return populated thumbnail url for a specific resolution
      */
     public String getThumbnailUrl(int width, int height) {
-        return thumbnailUrl.replace("{width}x{height}", String.format("%dx%d", width, height));
-    }
-
-    /**
-     * @return the template for the thumbnail URL; contains "{width}" and "{height}" placeholders
-     * @apiNote To obtain a populated URL, prefer using the {@link #getThumbnailUrl(int, int)} method
-     */
-    public String getThumbnailUrlTemplate() {
-        return this.thumbnailUrl;
+        return thumbnailUrlTemplate.replace("{width}x{height}", String.format("%dx%d", width, height));
     }
 
     /**
@@ -131,10 +129,11 @@ public class Stream {
      * @deprecated in favor of {@link #getThumbnailUrlTemplate()} or {@link #getThumbnailUrl(int, int)}
      */
     @NonNull
+    @JsonIgnore
     @Deprecated
     @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public String getThumbnailUrl() {
-        return this.thumbnailUrl;
+        return this.thumbnailUrlTemplate;
     }
 
     /**

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/AdScheduleTest.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.helix.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Tag("unittest")
 class AdScheduleTest {
 
     @Test

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/ChannelInformationTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/ChannelInformationTest.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.helix.domain;
 
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.eventsub.domain.ContentClassification;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("unittest")
 class ChannelInformationTest {
 
     @Test

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/StreamTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/StreamTest.java
@@ -1,0 +1,37 @@
+package com.github.twitch4j.helix.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unittest")
+class StreamTest {
+
+    @Test
+    void deserializeLive() {
+        Stream stream = TypeConvert.jsonToObject(
+            "{\"game_id\":\"509658\",\"game_name\":\"Just Chatting\",\"id\":\"44096493851\",\"is_mature\":true,\"language\":\"en\",\"started_at\":\"2024-04-26T18:28:16Z\",\"tag_ids\":[],\"tags\":[\"news\",\"politics\",\"adhd\",\"English\"],\"thumbnail_url\":\"https://static-cdn.jtvnw.net/previews-ttv/live_user_hasanabi-{width}x{height}.jpg\",\"title\":\"RECAPPING UCLA FREE PALESTINE PROTEST - VIOLENT EMORY PROFESSOR ARREST - BRANDON ON HOWARD STERN - WALKING DEAD S3 FINALE!\",\"type\":\"live\",\"user_id\":\"207813352\",\"user_login\":\"hasanabi\",\"user_name\":\"HasanAbi\",\"viewer_count\":22648}",
+            Stream.class
+        );
+        assertEquals("509658", stream.getGameId());
+        assertEquals("Just Chatting", stream.getGameName());
+        assertEquals("44096493851", stream.getId());
+        assertTrue(stream.isMature());
+        assertEquals("en", stream.getLanguage());
+        assertEquals(Instant.parse("2024-04-26T18:28:16Z"), stream.getStartedAtInstant());
+        assertEquals(Arrays.asList("news", "politics", "adhd", "English"), stream.getTags());
+        assertEquals("https://static-cdn.jtvnw.net/previews-ttv/live_user_hasanabi-{width}x{height}.jpg", stream.getThumbnailUrlTemplate());
+        assertEquals("https://static-cdn.jtvnw.net/previews-ttv/live_user_hasanabi-1280x720.jpg", stream.getThumbnailUrl(1280, 720));
+        assertEquals("RECAPPING UCLA FREE PALESTINE PROTEST - VIOLENT EMORY PROFESSOR ARREST - BRANDON ON HOWARD STERN - WALKING DEAD S3 FINALE!", stream.getTitle());
+        assertEquals("207813352", stream.getUserId());
+        assertEquals("HasanAbi", stream.getUserName());
+        assertEquals(22648, stream.getViewerCount());
+    }
+
+}

--- a/util/src/main/java/com/github/twitch4j/common/util/TimeUtils.java
+++ b/util/src/main/java/com/github/twitch4j/common/util/TimeUtils.java
@@ -1,5 +1,7 @@
 package com.github.twitch4j.common.util;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -20,7 +22,10 @@ public class TimeUtils {
     /**
      * @param time an {@link Instant}
      * @return a {@link Calendar} instance for the instant, in the system default zone
+     * @deprecated Will no longer be used by Twitch4J from version 2.0.0
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
     public static Calendar fromInstant(Instant time) {
         return GregorianCalendar.from(ZonedDateTime.ofInstant(time, ZoneId.systemDefault()));
     }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Newcomers tend to assume `Stream#getThumbnailUrl` already yields a valid thumbnail (when they should be using `Stream#getThumbnailUrl(Integer, Integer)` instead)

### Changes Proposed
* Add `Stream#getThumbnailUrlTemplate` and deprecate `Stream#getThumbnailUrl`
* Optimize `getThumbnailUrl(int, int)` by avoiding regex
