### PR TITLE
chore: add msg_concurrent_channel_limit_reached to NoticeTag

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
@@ -362,6 +362,12 @@ public enum NoticeTag {
     MSG_CHANNEL_SUSPENDED,
 
     /**
+     * You are connected to too many chat channels. Please close some existing chat connections to join a new chat.
+     */
+    @Unofficial
+    MSG_CONCURRENT_CHANNEL_LIMIT_REACHED,
+
+    /**
      * Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago.
      */
     MSG_DUPLICATE,


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `NoticeTag.MSG_CONCURRENT_CHANNEL_LIMIT_REACHED` (undocumented)

### Additional Information
Twitch has lowered the number of (non-modded) channels a user can concurrently join to **100** (with the exception for verified bots being removed in a month): https://discuss.dev.twitch.com/t/giving-broadcasters-control-concurrent-join-limits-for-irc-and-eventsub/
