### PR TITLE
feat(eventsub): add new automatic reward types

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomaticReward.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomaticReward.java
@@ -1,8 +1,11 @@
 package com.github.twitch4j.eventsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 @Data
@@ -12,6 +15,7 @@ public class AutomaticReward {
     /**
      * The type of reward.
      */
+    @JsonAlias("reward_type") // official changelog uses a different name for this field than the eventsub reference
     private Type type;
 
     /**
@@ -26,10 +30,55 @@ public class AutomaticReward {
     private SimpleEmote unlockedEmote;
 
     public enum Type {
+
+        /**
+         * "Send a Message in Sub-Only Mode" was redeemed.
+         */
         SINGLE_MESSAGE_BYPASS_SUB_MODE,
+
+        /**
+         * "Highlight My Message" was redeemed.
+         */
         SEND_HIGHLIGHTED_MESSAGE,
+
+        /**
+         * "Unlock a Random Sub Emote" was redeemed.
+         */
         RANDOM_SUB_EMOTE_UNLOCK,
+
+        /**
+         * "Choose an Emote to Unlock" was redeemed.
+         */
         CHOSEN_SUB_EMOTE_UNLOCK,
-        CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK
+
+        /**
+         * "Modify a Single Emote" was redeemed.
+         */
+        CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK,
+
+        /**
+         * "Animate My Message" was redeemed.
+         */
+        @ApiStatus.Experimental // twitch feature is not in production yet (and could be reverted)
+        SEND_ANIMATED_MESSAGE,
+
+        /**
+         * Send a gigantified emote was redeemed.
+         */
+        @ApiStatus.Experimental // twitch feature is not in production yet (and could be reverted)
+        SEND_GIGANTIFIED_EMOTE,
+
+        /**
+         * Trigger a celebration alert was redeemed.
+         */
+        @ApiStatus.Experimental // twitch feature is not in production yet (and could be reverted)
+        CELEBRATION,
+
+        /**
+         * An unrecognized automatic reward type; please report to our issue tracker.
+         */
+        @JsonEnumDefaultValue
+        OTHER
+
     }
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/MessageType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/MessageType.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.eventsub.domain.chat;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * EventSub equivalent of the {@code msg-id} IRC tag.
@@ -28,6 +29,18 @@ public enum MessageType {
      * @see <a href="https://twitter.com/TwitchSupport/status/1481008097749573641">Twitch Announcement</a>
      */
     USER_INTRO,
+
+    /**
+     * Channel points were used to animate the chat message.
+     */
+    @ApiStatus.Experimental // twitch feature is not in production yet (and could be reverted)
+    ANIMATED,
+
+    /**
+     * Channel points were used to attach a gigantic emote to the chat message.
+     */
+    @ApiStatus.Experimental // twitch feature is not in production yet (and could be reverted)
+    GIGANTIFIED_EMOTE,
 
     /**
      * An unrecognized message type; please report to our issue tracker.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatMessageEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatMessageEvent.java
@@ -11,6 +11,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,5 +69,14 @@ public class ChannelChatMessageEvent extends ChannelChatUserEvent {
      */
     @Nullable
     private String channelPointsCustomRewardId;
+
+    /**
+     * An ID for the type of animation selected as part of an "animate my message" redemption.
+     *
+     * @see MessageType#ANIMATED
+     */
+    @Nullable
+    @ApiStatus.Experimental // twitch feature is not in production yet (and could be reverted)
+    private String channelPointsAnimationId;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add eventsub support for upcoming twitch experimental automatic rewards: animate my message, send gigantified emote, trigger celebration animation

### Additional Information
2024-05-22 changelog entry https://dev.twitch.tv/docs/change-log/

i expect all of these to be reverted or largely disabled by broadcasters
