### PR TITLE
feat(eventsub): add automod caught message topics

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/enums/TwitchEnum.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/TwitchEnum.java
@@ -1,0 +1,29 @@
+package com.github.twitch4j.common.enums;
+
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Wrapper for a Twitch-specified enum where all of the possible values may not be documented.
+ *
+ * @param <E> the underlying enum type
+ */
+@Value
+public class TwitchEnum<E extends Enum<E>> {
+
+    /**
+     * The parsed enum value.
+     */
+    @NotNull
+    E value;
+
+    /**
+     * The raw string provided by Twitch to represent this enum.
+     * <p>
+     * This field is useful when {@link #getValue()} yields {@code UNKNOWN}.
+     * Please report such cases to our issue tracker.
+     */
+    @NotNull
+    String rawValue;
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchEnumDeserializer.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchEnumDeserializer.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.common.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.github.twitch4j.common.enums.TwitchEnum;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.IOException;
+
+@ApiStatus.Internal
+@NoArgsConstructor
+@AllArgsConstructor
+public class TwitchEnumDeserializer<E extends Enum<E>> extends JsonDeserializer<TwitchEnum<E>> implements ContextualDeserializer {
+
+    private JavaType type;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public TwitchEnum<E> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        JavaType enumType = type.containedType(0);
+        String rawValue = jsonParser.getValueAsString();
+        E enumValue = (E) jsonParser.readValueAs(enumType.getRawClass());
+        return new TwitchEnum<>(enumValue, rawValue);
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext deserializationContext, BeanProperty beanProperty) {
+        JavaType type = deserializationContext.getContextualType() != null
+            ? deserializationContext.getContextualType()
+            : beanProperty.getMember().getType();
+        assert TwitchEnum.class.isAssignableFrom(type.getRawClass());
+        return new TwitchEnumDeserializer<>(type);
+    }
+
+}

--- a/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TypeConvert.java
@@ -19,6 +19,7 @@ public class TypeConvert {
     private static final ObjectMapper objectMapper = JsonMapper.builder()
         .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
         .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)

--- a/common/src/test/java/com/github/twitch4j/common/enums/TwitchEnumTest.java
+++ b/common/src/test/java/com/github/twitch4j/common/enums/TwitchEnumTest.java
@@ -1,0 +1,90 @@
+package com.github.twitch4j.common.enums;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.twitch4j.common.util.TwitchEnumDeserializer;
+import com.github.twitch4j.common.util.TypeConvert;
+import lombok.Data;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Tag("unittest")
+class TwitchEnumTest {
+
+    @Test
+    void deserialize() {
+        String json = "{\"a\":\"X\"}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertEquals(A.X, twitchEnum.getValue());
+        assertEquals("X", twitchEnum.getRawValue());
+    }
+
+    @Test
+    void deserializeCasing() {
+        String json = "{\"a\":\"y\"}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertEquals(A.Y, twitchEnum.getValue());
+        assertEquals("y", twitchEnum.getRawValue());
+    }
+
+    @Test
+    void deserializeAbsent() {
+        String json = "{}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertNull(twitchEnum);
+    }
+
+    @Test
+    void deserializeNull() {
+        String json = "{\"a\":null}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertNull(twitchEnum);
+    }
+
+    @Test
+    void deserializeUnknown() {
+        String json = "{\"a\":\"W\"}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertEquals(A.UNKNOWN, twitchEnum.getValue());
+        assertEquals("W", twitchEnum.getRawValue());
+    }
+
+    @Test
+    void deserializeNamed() {
+        String json = "{\"a\":\"test\"}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertEquals(A.Z, twitchEnum.getValue());
+        assertEquals("test", twitchEnum.getRawValue());
+    }
+
+    @Test
+    void deserializeAlias() {
+        String json = "{\"a\":\"Q\"}";
+        TwitchEnum<A> twitchEnum = TypeConvert.jsonToObject(json, B.class).getTwitchEnum();
+        assertEquals(A.Z, twitchEnum.getValue());
+        assertEquals("Q", twitchEnum.getRawValue());
+    }
+
+    enum A {
+        X,
+        Y,
+        @JsonAlias("Q")
+        @JsonProperty("test")
+        Z,
+        @JsonEnumDefaultValue
+        UNKNOWN
+    }
+
+    @Data
+    static class B {
+        @JsonProperty("a")
+        @JsonDeserialize(using = TwitchEnumDeserializer.class)
+        TwitchEnum<A> twitchEnum;
+    }
+
+}

--- a/common/src/test/java/com/github/twitch4j/common/util/EscapeUtilsTest.java
+++ b/common/src/test/java/com/github/twitch4j/common/util/EscapeUtilsTest.java
@@ -1,9 +1,11 @@
 package com.github.twitch4j.common.util;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("unittest")
 class EscapeUtilsTest {
 
     @Test

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomodCategory.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomodCategory.java
@@ -1,0 +1,18 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.github.twitch4j.common.annotation.Unofficial;
+
+@Unofficial
+public enum AutomodCategory {
+    AGGRESSIVE,
+    BULLYING,
+    DISABILITY,
+    SEXUALITY,
+    MISOGYNY,
+    RACISM,
+    SEXUAL,
+    PROFANITY,
+    @JsonEnumDefaultValue
+    UNKNOWN
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomodMessageStatus.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/AutomodMessageStatus.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.eventsub.domain;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum AutomodMessageStatus {
+
+    /**
+     * A moderator allowed this message flagged by AutoMod to be sent in chat.
+     */
+    APPROVED,
+
+    /**
+     * A moderator denied this message flagged by AutoMod from being sent in chat.
+     */
+    DENIED,
+
+    /**
+     * This message caught by AutoMod was not approved or denied by a moderator in time, so it was not sent in chat.
+     */
+    EXPIRED,
+
+    /**
+     * An invalid message status; please report to our issue tracker.
+     */
+    @JsonEnumDefaultValue
+    INVALID
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageHoldEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageHoldEvent.java
@@ -1,0 +1,41 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.chat.Message;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+public class AutomodMessageHoldEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The ID of the message that was flagged by automod.
+     */
+    private String messageId;
+
+    /**
+     * The body of the message.
+     */
+    private Message message;
+
+    /**
+     * The category of the message offense.
+     */
+    private String category;
+
+    /**
+     * The level of severity. Measured between 1 to 4.
+     */
+    private int level;
+
+    /**
+     * The timestamp of when automod saved the message.
+     */
+    private Instant heldAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageHoldEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageHoldEvent.java
@@ -1,5 +1,9 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.twitch4j.common.enums.TwitchEnum;
+import com.github.twitch4j.common.util.TwitchEnumDeserializer;
+import com.github.twitch4j.eventsub.domain.AutomodCategory;
 import com.github.twitch4j.eventsub.domain.chat.Message;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -26,7 +30,8 @@ public class AutomodMessageHoldEvent extends EventSubUserChannelEvent {
     /**
      * The category of the message offense.
      */
-    private String category;
+    @JsonDeserialize(using = TwitchEnumDeserializer.class)
+    private TwitchEnum<AutomodCategory> category;
 
     /**
      * The level of severity. Measured between 1 to 4.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageUpdateEvent.java
@@ -1,0 +1,47 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.AutomodMessageStatus;
+import com.github.twitch4j.eventsub.domain.chat.Message;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+public class AutomodMessageUpdateEvent extends EventSubModerationEvent {
+
+    /**
+     * The ID of the message that was flagged by automod.
+     */
+    private String messageId;
+
+    /**
+     * The body of the message.
+     */
+    private Message message;
+
+    /**
+     * The category of the message offense.
+     */
+    private String category;
+
+    /**
+     * The level of severity. Measured between 1 to 4.
+     */
+    private int level;
+
+    /**
+     * The message's updated status.
+     */
+    private AutomodMessageStatus status;
+
+    /**
+     * The timestamp of when automod saved the message.
+     */
+    private Instant heldAt;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/AutomodMessageUpdateEvent.java
@@ -1,5 +1,9 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.twitch4j.common.enums.TwitchEnum;
+import com.github.twitch4j.common.util.TwitchEnumDeserializer;
+import com.github.twitch4j.eventsub.domain.AutomodCategory;
 import com.github.twitch4j.eventsub.domain.AutomodMessageStatus;
 import com.github.twitch4j.eventsub.domain.chat.Message;
 import lombok.AccessLevel;
@@ -27,7 +31,8 @@ public class AutomodMessageUpdateEvent extends EventSubModerationEvent {
     /**
      * The category of the message offense.
      */
-    private String category;
+    @JsonDeserialize(using = TwitchEnumDeserializer.class)
+    private TwitchEnum<AutomodCategory> category;
 
     /**
      * The level of severity. Measured between 1 to 4.

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserMessageHoldEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserMessageHoldEvent.java
@@ -1,0 +1,24 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.chat.Message;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+public class UserMessageHoldEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The ID of the message that was flagged by automod.
+     */
+    private String messageId;
+
+    /**
+     * The body of the message.
+     */
+    private Message message;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserMessageUpdateEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/UserMessageUpdateEvent.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.eventsub.events;
+
+import com.github.twitch4j.eventsub.domain.AutomodMessageStatus;
+import com.github.twitch4j.eventsub.domain.chat.Message;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = true)
+public class UserMessageUpdateEvent extends EventSubUserChannelEvent {
+
+    /**
+     * The ID of the message that was flagged by automod.
+     */
+    private String messageId;
+
+    /**
+     * The body of the message.
+     */
+    private Message message;
+
+    /**
+     * The message’s updated status.
+     */
+    private AutomodMessageStatus status;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodMessageHoldType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodMessageHoldType.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
+import com.github.twitch4j.eventsub.events.AutomodMessageHoldEvent;
+
+/**
+ * Notifies moderators when AutoMod held a user's message for review.
+ * <p>
+ * Requires a user access token that includes the moderator:manage:automod scope.
+ * The ID in the moderator_user_id condition parameter must match the user ID in the access token.
+ * If app access token used, then additionally requires the moderator:manage:automod scope for the moderator.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_AUTOMOD_MANAGE
+ */
+public class AutomodMessageHoldType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, AutomodMessageHoldEvent> {
+    @Override
+    public String getName() {
+        return "automod.message.hold";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ModeratorEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<AutomodMessageHoldEvent> getEventClass() {
+        return AutomodMessageHoldEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodMessageUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/AutomodMessageUpdateType.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
+import com.github.twitch4j.eventsub.events.AutomodMessageUpdateEvent;
+
+/**
+ * Notifies when a message in the AutoMod queue has its status changed.
+ * <p>
+ * Requires a user access token that includes the moderator:manage:automod scope.
+ * The ID in the moderator_user_id condition parameter must match the user ID in the access token.
+ * If app access token used, then additionally requires the moderator:manage:automod scope for the moderator.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_AUTOMOD_MANAGE
+ */
+public class AutomodMessageUpdateType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, AutomodMessageUpdateEvent> {
+    @Override
+    public String getName() {
+        return "automod.message.update";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?> getConditionBuilder() {
+        return ModeratorEventSubCondition.builder();
+    }
+
+    @Override
+    public Class<AutomodMessageUpdateEvent> getEventClass() {
+        return AutomodMessageUpdateEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -14,6 +14,8 @@ import java.util.stream.Stream;
 public class SubscriptionTypes {
     private final Map<String, SubscriptionType<?, ?, ?>> SUBSCRIPTION_TYPES;
 
+    public final AutomodMessageHoldType AUTOMOD_MESSAGE_HOLD;
+    public final AutomodMessageUpdateType AUTOMOD_MESSAGE_UPDATE;
     public final AutomodSettingsUpdateType AUTOMOD_SETTINGS_UPDATE;
     public final AutomodTermsUpdateType AUTOMOD_TERMS_UPDATE;
     public final ChannelAdBreakBeginType CHANNEL_AD_BREAK_BEGIN;
@@ -69,6 +71,8 @@ public class SubscriptionTypes {
     public final ShoutoutReceiveType SHOUTOUT_RECEIVE_TYPE;
     public final StreamOfflineType STREAM_OFFLINE;
     public final StreamOnlineType STREAM_ONLINE;
+    public final UserMessageHoldType USER_MESSAGE_HOLD;
+    public final UserMessageUpdateType USER_MESSAGE_UPDATE;
     public final UnbanRequestCreateType UNBAN_REQUEST_CREATE;
     public final UnbanRequestResolveType UNBAN_REQUEST_RESOLVE;
     public final UserAuthorizationGrantType USER_AUTHORIZATION_GRANT;
@@ -83,6 +87,8 @@ public class SubscriptionTypes {
     static {
         SUBSCRIPTION_TYPES = Collections.unmodifiableMap(
             Stream.of(
+                AUTOMOD_MESSAGE_HOLD = new AutomodMessageHoldType(),
+                AUTOMOD_MESSAGE_UPDATE = new AutomodMessageUpdateType(),
                 AUTOMOD_SETTINGS_UPDATE = new AutomodSettingsUpdateType(),
                 AUTOMOD_TERMS_UPDATE = new AutomodTermsUpdateType(),
                 CHANNEL_AD_BREAK_BEGIN = new ChannelAdBreakBeginType(),
@@ -138,6 +144,8 @@ public class SubscriptionTypes {
                 SHOUTOUT_RECEIVE_TYPE = new ShoutoutReceiveType(),
                 STREAM_OFFLINE = new StreamOfflineType(),
                 STREAM_ONLINE = new StreamOnlineType(),
+                USER_MESSAGE_HOLD  = new UserMessageHoldType(),
+                USER_MESSAGE_UPDATE = new UserMessageUpdateType(),
                 UNBAN_REQUEST_CREATE = new UnbanRequestCreateType(),
                 UNBAN_REQUEST_RESOLVE = new UnbanRequestResolveType(),
                 USER_AUTHORIZATION_GRANT = new UserAuthorizationGrantType(),

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UserMessageHoldType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UserMessageHoldType.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelChatCondition;
+import com.github.twitch4j.eventsub.events.UserMessageHoldEvent;
+
+/**
+ * Notifies a user if their message is caught by AutoMod.
+ * <p>
+ * Requires user:read:chat scope from chatting user.
+ * If app access token used, then additionally requires user:bot scope from chatting user.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_USER_READ
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_USER_BOT
+ */
+public class UserMessageHoldType implements SubscriptionType<ChannelChatCondition, ChannelChatCondition.ChannelChatConditionBuilder<?, ?>, UserMessageHoldEvent> {
+    @Override
+    public String getName() {
+        return "channel.chat.user_message_hold";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ChannelChatCondition.ChannelChatConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelChatCondition.builder();
+    }
+
+    @Override
+    public Class<UserMessageHoldEvent> getEventClass() {
+        return UserMessageHoldEvent.class;
+    }
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UserMessageUpdateType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/UserMessageUpdateType.java
@@ -1,0 +1,35 @@
+package com.github.twitch4j.eventsub.subscriptions;
+
+import com.github.twitch4j.eventsub.condition.ChannelChatCondition;
+import com.github.twitch4j.eventsub.events.UserMessageUpdateEvent;
+
+/**
+ * Notifies a user if their message’s AutoMod status is updated.
+ * <p>
+ * Requires user:read:chat scope from chatting user.
+ * If app access token used, then additionally requires user:bot scope from chatting user.
+ *
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_USER_READ
+ * @see com.github.twitch4j.auth.domain.TwitchScopes#CHAT_USER_BOT
+ */
+public class UserMessageUpdateType implements SubscriptionType<ChannelChatCondition, ChannelChatCondition.ChannelChatConditionBuilder<?, ?>, UserMessageUpdateEvent> {
+    @Override
+    public String getName() {
+        return "channel.chat.user_message_update";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1";
+    }
+
+    @Override
+    public ChannelChatCondition.ChannelChatConditionBuilder<?, ?> getConditionBuilder() {
+        return ChannelChatCondition.builder();
+    }
+
+    @Override
+    public Class<UserMessageUpdateEvent> getEventClass() {
+        return UserMessageUpdateEvent.class;
+    }
+}

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.eventsub.events;
 
 import com.github.twitch4j.common.enums.AnnouncementColor;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
+import com.github.twitch4j.eventsub.domain.AutomodMessageStatus;
 import com.github.twitch4j.eventsub.domain.ContentClassification;
 import com.github.twitch4j.eventsub.domain.Contribution;
 import com.github.twitch4j.eventsub.domain.PollStatus;
@@ -469,6 +470,52 @@ public class EventSubEventTest {
         assertEquals(SubscriptionPlan.TIER1, resub.getSubTier());
         assertTrue(resub.isPrime());
         assertFalse(resub.isGift());
+    }
+
+    @Test
+    @DisplayName("Deserialize Automod Message Hold Event")
+    public void deserializeAutomodHeld() {
+        AutomodMessageHoldEvent event = jsonToObject(
+            "{\"broadcaster_user_id\":\"1234\",\"broadcaster_user_login\":\"redacted_channel\",\"broadcaster_user_name\":\"redacted_channel\",\"user_id\":\"6789\",\"user_login\":\"redacted_user\",\"user_name\":\"redacted_user\",\"message_id\":\"aa72e85e-77f5-4b7b-95e5-1e5efd8d8373\",\"message\":{\"text\":\"fuck israel\",\"fragments\":[{\"type\":\"text\",\"text\":\"fuck israel\",\"cheermote\":null,\"emote\":null}]},\"category\":\"racism\",\"level\":1,\"held_at\":\"2024-05-27T20:33:37.988487508Z\"}",
+            AutomodMessageHoldEvent.class
+        );
+
+        assertEquals("1234", event.getBroadcasterUserId());
+        assertEquals("6789", event.getUserId());
+        assertEquals("aa72e85e-77f5-4b7b-95e5-1e5efd8d8373", event.getMessageId());
+        assertEquals("fuck israel", event.getMessage().getText());
+        assertEquals("racism", event.getCategory());
+        assertEquals(1, event.getLevel());
+        assertEquals(Instant.parse("2024-05-27T20:33:37.988487508Z"), event.getHeldAt());
+        assertNotNull(event.getMessage().getFragments());
+        assertEquals(1, event.getMessage().getFragments().size());
+        Fragment fragment = event.getMessage().getFragments().get(0);
+        assertEquals(Fragment.Type.TEXT, fragment.getType());
+        assertEquals("fuck israel", fragment.getText());
+    }
+
+    @Test
+    @DisplayName("Deserialize Automod Message Update Event")
+    public void deserializeAutomodUpdate() {
+        AutomodMessageUpdateEvent event = jsonToObject(
+            "{\"broadcaster_user_id\":\"1234\",\"broadcaster_user_login\":\"redacted_channel\",\"broadcaster_user_name\":\"redacted_channel\",\"user_id\":\"6789\",\"user_login\":\"redacted_user\",\"user_name\":\"redacted_user\",\"moderator_user_id\":\"53888434\",\"moderator_user_login\":\"ogprodigy\",\"moderator_user_name\":\"OGprodigy\",\"message_id\":\"aa72e85e-77f5-4b7b-95e5-1e5efd8d8373\",\"message\":{\"text\":\"fuck israel\",\"fragments\":[{\"type\":\"text\",\"text\":\"fuck israel\",\"cheermote\":null,\"emote\":null}]},\"category\":\"racism\",\"level\":1,\"status\":\"approved\",\"held_at\":\"2024-05-27T20:33:37.988487508Z\"}",
+            AutomodMessageUpdateEvent.class
+        );
+
+        assertEquals(AutomodMessageStatus.APPROVED, event.getStatus());
+        assertEquals("53888434", event.getModeratorUserId());
+        assertEquals("1234", event.getBroadcasterUserId());
+        assertEquals("6789", event.getUserId());
+        assertEquals("aa72e85e-77f5-4b7b-95e5-1e5efd8d8373", event.getMessageId());
+        assertEquals("fuck israel", event.getMessage().getText());
+        assertEquals("racism", event.getCategory());
+        assertEquals(1, event.getLevel());
+        assertEquals(Instant.parse("2024-05-27T20:33:37.988487508Z"), event.getHeldAt());
+        assertNotNull(event.getMessage().getFragments());
+        assertEquals(1, event.getMessage().getFragments().size());
+        Fragment fragment = event.getMessage().getFragments().get(0);
+        assertEquals(Fragment.Type.TEXT, fragment.getType());
+        assertEquals("fuck israel", fragment.getText());
     }
 
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -2,6 +2,7 @@ package com.github.twitch4j.eventsub.events;
 
 import com.github.twitch4j.common.enums.AnnouncementColor;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
+import com.github.twitch4j.eventsub.domain.AutomodCategory;
 import com.github.twitch4j.eventsub.domain.AutomodMessageStatus;
 import com.github.twitch4j.eventsub.domain.ContentClassification;
 import com.github.twitch4j.eventsub.domain.Contribution;
@@ -484,7 +485,7 @@ public class EventSubEventTest {
         assertEquals("6789", event.getUserId());
         assertEquals("aa72e85e-77f5-4b7b-95e5-1e5efd8d8373", event.getMessageId());
         assertEquals("fuck israel", event.getMessage().getText());
-        assertEquals("racism", event.getCategory());
+        assertEquals(AutomodCategory.RACISM, event.getCategory().getValue());
         assertEquals(1, event.getLevel());
         assertEquals(Instant.parse("2024-05-27T20:33:37.988487508Z"), event.getHeldAt());
         assertNotNull(event.getMessage().getFragments());
@@ -508,7 +509,7 @@ public class EventSubEventTest {
         assertEquals("6789", event.getUserId());
         assertEquals("aa72e85e-77f5-4b7b-95e5-1e5efd8d8373", event.getMessageId());
         assertEquals("fuck israel", event.getMessage().getText());
-        assertEquals("racism", event.getCategory());
+        assertEquals(AutomodCategory.RACISM, event.getCategory().getValue());
         assertEquals(1, event.getLevel());
         assertEquals(Instant.parse("2024-05-27T20:33:37.988487508Z"), event.getHeldAt());
         assertNotNull(event.getMessage().getFragments());

--- a/twitch4j/build.gradle.kts
+++ b/twitch4j/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
 
 	// Regex
 	api(group = "com.github.tony19", name = "named-regexp")
+
+	// Testing
+	testImplementation(group = "org.reflections", name = "reflections", version = "0.10.2")
 }
 
 base {

--- a/twitch4j/src/test/java/com/github/twitch4j/internal/TwitchEnumVerificationTest.java
+++ b/twitch4j/src/test/java/com/github/twitch4j/internal/TwitchEnumVerificationTest.java
@@ -1,0 +1,55 @@
+package com.github.twitch4j.internal;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.github.twitch4j.common.enums.TwitchEnum;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unittest")
+class TwitchEnumVerificationTest {
+
+    @Test
+    void validateTwitchEnumHasDefaultValue() {
+        findTwitchEnumGenericTypes().forEach(clazz -> {
+            assertNotNull(clazz, "Raw use of TwitchEnum detected");
+
+            boolean hasDefaultValue = Arrays.stream(clazz.getDeclaredFields())
+                .anyMatch(field -> field.isAnnotationPresent(JsonEnumDefaultValue.class));
+            assertTrue(hasDefaultValue, "TwitchEnum is missing @JsonEnumDefaultValue: " + clazz);
+        });
+    }
+
+    private Stream<? extends Class<?>> findTwitchEnumGenericTypes() {
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
+            .forPackages("com.github.twitch4j")
+            .addScanners(Scanners.SubTypes.filterResultsBy(s -> true))
+        );
+
+        return reflections.getSubTypesOf(Object.class).stream()
+            .flatMap(clazz -> Arrays.stream(clazz.getDeclaredFields()))
+            .filter(field -> field.getType() == TwitchEnum.class)
+            .map(field -> {
+                Type genericType = field.getGenericType();
+                if (genericType instanceof ParameterizedType) {
+                    ParameterizedType parameterizedType = (ParameterizedType) genericType;
+                    Type[] typeArguments = parameterizedType.getActualTypeArguments();
+                    if (typeArguments.length > 0 && typeArguments[0] instanceof Class) {
+                        return (Class<?>) typeArguments[0];
+                    }
+                }
+                return null;
+            });
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Related Issues
* standard twitch docs inaccuracies

### Changes Proposed
* Add `SubscriptionTypes.AUTOMOD_MESSAGE_HOLD` (`automod.message.hold`)
* Add `SubscriptionTypes.AUTOMOD_MESSAGE_UPDATE` (`automod.message.update`)
* Add `SubscriptionTypes.USER_MESSAGE_HOLD` (`channel.chat.user_message_hold`)
* Add `SubscriptionTypes.USER_MESSAGE_UPDATE` (`channel.chat.user_message_update`)

### Additional Information
Topics were released as open beta on 2024-03-07 and promoted to v1 on 2024-03-15: https://dev.twitch.tv/docs/change-log/

Follow-up to https://github.com/twitch4j/twitch4j/pull/957
