### PR TITLE
feat: allow auth requests to be directed to cli mock api

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
@@ -34,17 +34,8 @@ public class TwitchAuth {
         // register the twitch identityProvider
         Optional<TwitchIdentityProvider> ip = credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class);
         if (!ip.isPresent()) {
-            if (useMock) {
-                IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl, TwitchIdentityProvider.CLI_MOCK_BASE_URL);
-                try {
-                    credentialManager.registerIdentityProvider(identityProvider);
-                } catch (Exception e) {
-                    log.error("TwitchAuth: Encountered conflicting identity provider!", e);
-                }
-                return;
-            }
-
-            IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl);
+            String baseUrl = useMock ? TwitchIdentityProvider.CLI_MOCK_BASE_URL : TwitchIdentityProvider.OFFICIAL_BASE_URL;
+            IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl, baseUrl);
             try {
                 credentialManager.registerIdentityProvider(identityProvider);
             } catch (Exception e) {

--- a/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
@@ -2,7 +2,6 @@ package com.github.twitch4j.auth;
 
 import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.domain.IdentityProvider;
-import com.github.philippheuer.credentialmanager.identityprovider.OAuth2IdentityProvider;
 import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +32,7 @@ public class TwitchAuth {
 
     public static void registerIdentityProvider(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl) {
         // register the twitch identityProvider
-        Optional<TwitchIdentityProvider> ip = credentialManager.getIdentityProviderByName("twitch", TwitchIdentityProvider.class);
+        Optional<TwitchIdentityProvider> ip = credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class);
         if (!ip.isPresent()) {
             // register
             IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl);

--- a/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/TwitchAuth.java
@@ -27,14 +27,23 @@ public class TwitchAuth {
      */
     public TwitchAuth(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl) {
         this.credentialManager = credentialManager;
-        registerIdentityProvider(credentialManager, clientId, clientSecret, redirectUrl);
+        registerIdentityProvider(credentialManager, clientId, clientSecret, redirectUrl, false);
     }
 
-    public static void registerIdentityProvider(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl) {
+    public static void registerIdentityProvider(CredentialManager credentialManager, String clientId, String clientSecret, String redirectUrl, boolean useMock) {
         // register the twitch identityProvider
         Optional<TwitchIdentityProvider> ip = credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class);
         if (!ip.isPresent()) {
-            // register
+            if (useMock) {
+                IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl, TwitchIdentityProvider.CLI_MOCK_BASE_URL);
+                try {
+                    credentialManager.registerIdentityProvider(identityProvider);
+                } catch (Exception e) {
+                    log.error("TwitchAuth: Encountered conflicting identity provider!", e);
+                }
+                return;
+            }
+
             IdentityProvider identityProvider = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl);
             try {
                 credentialManager.registerIdentityProvider(identityProvider);

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -333,7 +333,7 @@ public class TwitchChat implements ITwitchChat {
         }
 
         this.identityProvider = credentialManager.getIdentityProviderByName("twitch", TwitchIdentityProvider.class)
-            .orElse(new TwitchIdentityProvider(null, null, null));
+            .orElseGet(() -> new TwitchIdentityProvider(null, null, null));
 
         // credential validation
         if (this.chatCredential == null) {

--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChatBuilder.java
@@ -326,7 +326,7 @@ public class TwitchChatBuilder {
         if (credentialManager == null) {
             credentialManager = CredentialManagerBuilder.builder().build();
         }
-        TwitchAuth.registerIdentityProvider(credentialManager, clientId, clientSecret, null);
+        TwitchAuth.registerIdentityProvider(credentialManager, clientId, clientSecret, null, false);
 
         // Register rate limits across the user id contained within the chat token
         final String userId;

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelixBuilder.java
@@ -12,11 +12,11 @@ import com.github.twitch4j.common.util.ThreadUtils;
 import com.github.twitch4j.common.util.TypeConvert;
 import com.github.twitch4j.helix.domain.CustomReward;
 import com.github.twitch4j.helix.interceptor.CustomRewardEncodeMixIn;
-import com.github.twitch4j.helix.interceptor.TwitchHelixTokenManager;
 import com.github.twitch4j.helix.interceptor.TwitchHelixClientIdInterceptor;
 import com.github.twitch4j.helix.interceptor.TwitchHelixDecoder;
 import com.github.twitch4j.helix.interceptor.TwitchHelixHttpClient;
 import com.github.twitch4j.helix.interceptor.TwitchHelixRateLimitTracker;
+import com.github.twitch4j.helix.interceptor.TwitchHelixTokenManager;
 import com.netflix.config.ConfigurationManager;
 import feign.Logger;
 import feign.Request;
@@ -27,7 +27,11 @@ import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import io.github.bucket4j.Bandwidth;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -192,7 +196,7 @@ public class TwitchHelixBuilder {
         if (credentialManager == null) {
             credentialManager = CredentialManagerBuilder.builder().build();
         }
-        TwitchAuth.registerIdentityProvider(credentialManager, clientId, clientSecret, redirectUrl);
+        TwitchAuth.registerIdentityProvider(credentialManager, clientId, clientSecret, redirectUrl, MOCK_BASE_URL.equals(baseUrl));
 
         // Feign
         TwitchHelixTokenManager tokenManager = new TwitchHelixTokenManager(credentialManager, clientId, clientSecret, defaultAuthToken);

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixTokenManager.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.interceptor;
 
+import com.github.philippheuer.credentialmanager.CredentialManager;
 import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.twitch4j.auth.providers.TwitchIdentityProvider;
 import io.github.xanthic.cache.api.Cache;
@@ -9,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,10 +57,12 @@ public final class TwitchHelixTokenManager {
      */
     private volatile OAuth2Credential defaultAuthToken;
 
-    public TwitchHelixTokenManager(String clientId, String clientSecret, OAuth2Credential defaultAuthToken) {
+    @ApiStatus.Internal
+    public TwitchHelixTokenManager(CredentialManager credentialManager, String clientId, String clientSecret, OAuth2Credential defaultAuthToken) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.twitchIdentityProvider = new TwitchIdentityProvider(clientId, clientSecret, null);
+        this.twitchIdentityProvider = credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class)
+            .orElseGet(() -> new TwitchIdentityProvider(clientId, clientSecret, null));
         this.defaultClientId = clientId;
         this.defaultAuthToken = defaultAuthToken;
 

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -395,7 +395,7 @@ public class TwitchClientBuilder {
         log.debug("TwitchClient: Initializing ErrorTracking ...");
 
         // Module: Auth (registers Twitch Identity Providers)
-        TwitchAuth.registerIdentityProvider(credentialManager, getClientId(), getClientSecret(), redirectUrl);
+        TwitchAuth.registerIdentityProvider(credentialManager, getClientId(), getClientSecret(), redirectUrl, TwitchHelixBuilder.MOCK_BASE_URL.equals(helixBaseUrl));
 
         // Initialize/Check EventManager
         eventManager = EventManagerUtils.validateOrInitializeEventManager(eventManager, defaultEventHandler);

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -521,6 +521,10 @@ public class TwitchClientBuilder {
                 .executor(scheduledThreadPoolExecutor)
                 .fallbackToken(defaultAuthToken)
                 .helix(helix)
+                .identityProvider(
+                    credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class)
+                        .orElseGet(() -> new TwitchIdentityProvider(clientId, clientSecret, redirectUrl))
+                )
                 .advancedConfiguration(builder ->
                     builder.proxyConfig(() -> proxyConfig)
                 )

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientBuilder.java
@@ -438,6 +438,8 @@ public class TwitchClientBuilder {
                 .withBaseUrl(helixBaseUrl)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
+                .withRedirectUrl(redirectUrl)
+                .withCredentialManager(credentialManager)
                 .withUserAgent(userAgent)
                 .withDefaultAuthToken(defaultAuthToken)
                 .withRequestQueueSize(requestQueueSize)
@@ -499,7 +501,7 @@ public class TwitchClientBuilder {
                     chatCommandsViaHelix && enableHelix && (chatAccount != null || defaultAuthToken != null) ? new ChatCommandHelixForwarder(
                         helix,
                         chatAccount != null ? chatAccount : defaultAuthToken,
-                        credentialManager.getIdentityProviderByName("twitch", TwitchIdentityProvider.class).orElse(null),
+                        credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class).orElse(null),
                         scheduledThreadPoolExecutor,
                         forwardedChatCommandHelixLimitPerChannel
                     ) : null

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -570,6 +570,10 @@ public class TwitchClientPoolBuilder {
                 .executor(scheduledThreadPoolExecutor)
                 .fallbackToken(defaultAuthToken)
                 .helix(helix)
+                .identityProvider(
+                    credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class)
+                        .orElseGet(() -> new TwitchIdentityProvider(clientId, clientSecret, redirectUrl))
+                )
                 .advancedConfiguration(builder ->
                     builder.proxyConfig(() -> proxyConfig)
                 )

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -462,6 +462,8 @@ public class TwitchClientPoolBuilder {
                 .withBaseUrl(helixBaseUrl)
                 .withClientId(clientId)
                 .withClientSecret(clientSecret)
+                .withRedirectUrl(redirectUrl)
+                .withCredentialManager(credentialManager)
                 .withUserAgent(userAgent)
                 .withDefaultAuthToken(defaultAuthToken)
                 .withRequestQueueSize(requestQueueSize)
@@ -507,7 +509,7 @@ public class TwitchClientPoolBuilder {
             new ChatCommandHelixForwarder(
                 helix,
                 chatAccount != null ? chatAccount : defaultAuthToken,
-                credentialManager.getIdentityProviderByName("twitch", TwitchIdentityProvider.class).orElse(null),
+                credentialManager.getIdentityProviderByName(TwitchIdentityProvider.PROVIDER_NAME, TwitchIdentityProvider.class).orElse(null),
                 scheduledThreadPoolExecutor,
                 forwardedChatCommandHelixLimitPerChannel
             ) : null;

--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPoolBuilder.java
@@ -417,7 +417,7 @@ public class TwitchClientPoolBuilder {
         log.debug("TwitchClientPool: Initializing ErrorTracking ...");
 
         // Module: Auth (registers Twitch Identity Providers)
-        TwitchAuth.registerIdentityProvider(credentialManager, getClientId(), getClientSecret(), redirectUrl);
+        TwitchAuth.registerIdentityProvider(credentialManager, getClientId(), getClientSecret(), redirectUrl, TwitchHelixBuilder.MOCK_BASE_URL.equals(helixBaseUrl));
 
         // Initialize/Check EventManager
         eventManager = EventManagerUtils.validateOrInitializeEventManager(eventManager, defaultEventHandler);


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* Closes #989

### Changes Proposed
* Allow `baseUrl` for `TwitchIdentityProvider` to be adjustable

### Additional Information
sample usage:
```java
TwitchIdentityProvider tip = new TwitchIdentityProvider(clientId, clientSecret, redirectUrl, TwitchIdentityProvider.CLI_MOCK_BASE_URL);
CredentialManager credentialManager = CredentialManagerBuilder.builder().build();
credentialManager.registerIdentityProvider(tip);
TwitchHelix api = TwitchHelixBuilder.builder()
    .withBaseUrl(TwitchHelixBuilder.MOCK_BASE_URL)
    .withCredentialManager(credentialManager)
    .withClientId(clientId)
    .withClientSecret(clientSecret)
    .withRedirectUrl(redirectUrl)
    .build();
```
