### PR TITLE
feat: add events for new chat warnings feature

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/enums/NoticeTag.java
@@ -454,6 +454,12 @@ public enum NoticeTag {
     MSG_VERIFIED_EMAIL,
 
     /**
+     * You received a Warning from a moderator in this channel. Acknowledge the Warning in browser to continue chatting in this channel.
+     */
+    @Unofficial
+    MSG_WARNED,
+
+    /**
      * No help available.
      */
     NO_HELP,

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -108,13 +108,18 @@ public class ChatModerationAction {
     public Optional<String> getReason() {
         switch (getModerationAction()) {
             case BAN:
-            case WARN:
                 if (args != null && args.size() > 1)
                     return Optional.of(args.get(1));
 
             case TIMEOUT:
                 if (args != null && args.size() > 2)
                     return Optional.of(args.get(2));
+
+            case WARN:
+                if (args != null && args.size() > 1) {
+                    List<String> reasons = args.subList(1, args.size());
+                    return Optional.of(String.join("\n", reasons).trim());
+                }
 
             default:
                 return Optional.empty();

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -298,6 +298,10 @@ public class ChatModerationAction {
          */
         WARN,
         /**
+         * A user acknowledged their warning reason.
+         */
+        ACKNOWLEDGE_WARNING,
+        /**
          * A user's message was flagged by AutoMod for manual review.
          */
         AUTOMOD_MESSAGE_REJECTED("automod_message_rejected"),

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ChatModerationAction.java
@@ -108,6 +108,7 @@ public class ChatModerationAction {
     public Optional<String> getReason() {
         switch (getModerationAction()) {
             case BAN:
+            case WARN:
                 if (args != null && args.size() > 1)
                     return Optional.of(args.get(1));
 
@@ -287,6 +288,10 @@ public class ChatModerationAction {
          * Channel exited raid mode
          */
         UNRAID,
+        /**
+         * A moderator warned a user.
+         */
+        WARN,
         /**
          * A user's message was flagged by AutoMod for manual review.
          */

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UserModerationActionData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/UserModerationActionData.java
@@ -4,15 +4,18 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
 @Unofficial
+@SuppressWarnings("unused")
 public class UserModerationActionData {
 
     private String action;
     private String targetId;
     private String channelId;
+    private @Nullable String reason;
 
     public boolean isBan() {
         return "ban".equals(action);
@@ -20,6 +23,14 @@ public class UserModerationActionData {
 
     public boolean isUnban() {
         return "unban".equals(action);
+    }
+
+    public boolean isWarning() {
+        return "warn".equals(action);
+    }
+
+    public boolean isWarningAcknowledgement() {
+        return "acknowledge_warning".equals(action);
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatDropReason.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatDropReason.java
@@ -11,7 +11,7 @@ public class ChatDropReason {
     /**
      * Code for why the message was dropped.
      * <p>
-     * For example: "channel_settings", "msg_duplicate", "msg_rejected".
+     * For example: "channel_settings", "msg_duplicate", "msg_rejected", "user_warned".
      */
     private String code;
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* PubSub: add warning support for `chat_moderator_actions` and `chatrooms-user-v1`
* Chat: Add `NoticeTag.MSG_WARNED`
* Helix: Update `ChatDropReason` javadoc

### Additional Information
No official documentation on this feature yet, but announced at https://x.com/TwitchSupport/status/1798403074350002447

No helix endpoint yet; see https://twitch.uservoice.com/forums/310213-developers/suggestions/48491402-provide-an-api-to-trigger-the-new-warning-system-t
