### PR TITLE
chore(pubsub): deprecate HypeTrainCooldownExpirationEvent

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainCooldownExpirationEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/HypeTrainCooldownExpirationEvent.java
@@ -3,9 +3,15 @@ package com.github.twitch4j.pubsub.events;
 import com.github.twitch4j.common.events.TwitchEvent;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * @deprecated Twitch no longer fires this event.
+ */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@Deprecated
+@ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
 public class HypeTrainCooldownExpirationEvent extends TwitchEvent {
     private final String channelId;
 }

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/TrainHandler.java
@@ -63,6 +63,7 @@ class TrainHandler implements TopicHandler {
                 final HypeTrainConductor conductorData = TypeConvert.convertValue(msgData, HypeTrainConductor.class);
                 return new HypeTrainConductorUpdateEvent(lastTopicIdentifier, conductorData);
             case "hype-train-cooldown-expiration":
+                //noinspection deprecation
                 return new HypeTrainCooldownExpirationEvent(lastTopicIdentifier);
             case "last-x-experiment-event":
                 // note: this isn't a true hype train event (it can be fired with no train active), but twitch hacked together the feature to use the hype pubsub infrastructure


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Deprecate `HypeTrainCooldownExpirationEvent` (no longer fired by twitch)
