### PR TITLE
fix: reassociate conduit shards with pool after unexpected disconnects

### DIFF
--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/conduit/TwitchConduitSocketPool.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/conduit/TwitchConduitSocketPool.java
@@ -20,6 +20,7 @@ import com.github.twitch4j.eventsub.socket.conduit.exceptions.ConduitResizeExcep
 import com.github.twitch4j.eventsub.socket.conduit.exceptions.CreateConduitException;
 import com.github.twitch4j.eventsub.socket.conduit.exceptions.ShardRegistrationException;
 import com.github.twitch4j.eventsub.socket.conduit.exceptions.ShardTimeoutException;
+import com.github.twitch4j.eventsub.socket.events.ConduitShardReassociationFailureEvent;
 import com.github.twitch4j.eventsub.socket.events.EventSocketWelcomedEvent;
 import com.github.twitch4j.eventsub.subscriptions.SubscriptionType;
 import com.github.twitch4j.helix.TwitchHelix;
@@ -270,6 +271,7 @@ public final class TwitchConduitSocketPool implements IEventSubConduit {
                     api.updateConduitShards(token, new ShardsInput(this.conduitId, Collections.singletonList(updatedShard))).execute();
                 } catch (Exception ex) {
                     log.warn("Failed to re-associate websocket (ID: {}) with conduit (ID: {}) after reconnect", id, this.conduitId, ex);
+                    eventManager.publish(new ConduitShardReassociationFailureEvent(e.getConnection(), this, id, ex));
                 }
             });
         });

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/events/ConduitShardReassociationFailureEvent.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/events/ConduitShardReassociationFailureEvent.java
@@ -1,0 +1,36 @@
+package com.github.twitch4j.eventsub.socket.events;
+
+import com.github.twitch4j.eventsub.socket.TwitchEventSocket;
+import com.github.twitch4j.eventsub.socket.conduit.TwitchConduitSocketPool;
+import com.github.twitch4j.helix.domain.ShardsInput;
+import lombok.Value;
+
+/**
+ * Fired when a websocket shard unexpected disconnected and could not be re-associated with the conduit after reconnecting.
+ */
+@Value
+public class ConduitShardReassociationFailureEvent {
+
+    /**
+     * The websocket that reconnected after an unexpected connection loss,
+     * but could not be re-associated as a conduit shard.
+     */
+    TwitchEventSocket socket;
+
+    /**
+     * The Conduit pool containing the disconnected conduit shard.
+     */
+    TwitchConduitSocketPool pool;
+
+    /**
+     * The ID of the shard that disconnected.
+     */
+    String shardId;
+
+    /**
+     * The exception thrown by {@link com.github.twitch4j.helix.TwitchHelix#updateConduitShards(String, ShardsInput)}
+     * when trying to re-associate the websocket as a conduit shard for the given ID.
+     */
+    Exception exception;
+
+}

--- a/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/events/EventSocketWelcomedEvent.java
+++ b/eventsub-websocket/src/main/java/com/github/twitch4j/eventsub/socket/events/EventSocketWelcomedEvent.java
@@ -23,4 +23,14 @@ public class EventSocketWelcomedEvent {
      */
     String sessionId;
 
+    /**
+     * Whether the Session ID changed due to the session_welcome handshake.
+     * <p>
+     * If false (i.e., the Session ID did not change),
+     * then the websocket simply reconnected at the request of Twitch (while preserving any subscriptions).
+     * <p>
+     * This field is always true upon the initial connection.
+     */
+    boolean sessionChanged;
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed 
* If a websocket shard lost connection due to a transient network issue, when it eventually reconnected, it was not re-associated with the conduit from an API perspective

### Changes Proposed
* On websocket reconnect, update the conduit shard in the API to point to the updated session ID.
* Fire meta event if re-association fails: `ConduitShardReassociationFailureEvent`
