### PR TITLE
refactor(helix): utilize ValueWrapper in more classes

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdScheduleWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AdScheduleWrapper.java
@@ -1,26 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
-
-@Data
-@Setter(AccessLevel.PRIVATE)
-public class AdScheduleWrapper {
-
-    /**
-     * A list that contains information related to the channel’s ad schedule.
-     */
-    private List<AdSchedule> data;
-
-    /**
-     * @return information related to the channel’s ad schedule
-     */
-    public AdSchedule get() {
-        if (data == null || data.isEmpty()) return null;
-        return data.get(0);
-    }
-
-}
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class AdScheduleWrapper extends ValueWrapper<AdSchedule> {}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutoModSettingsWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/AutoModSettingsWrapper.java
@@ -1,29 +1,17 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
-
-@Data
-@Setter(AccessLevel.PRIVATE)
-@NoArgsConstructor
-public class AutoModSettingsWrapper {
-
-    /**
-     * The list of AutoMod settings. The list contains a single object that contains all the AutoMod settings.
-     */
-    @Getter(AccessLevel.PRIVATE)
-    private List<AutoModSettings> data;
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class AutoModSettingsWrapper extends ValueWrapper<AutoModSettings> {
 
     /**
      * @return a single object that contains all of the AutoMod settings.
      */
     public AutoModSettings getAutoModSettings() {
-        return data == null || data.isEmpty() ? null : data.get(0);
+        return this.get();
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CharityCampaignWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/CharityCampaignWrapper.java
@@ -1,32 +1,19 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
 import java.util.Optional;
 
-@Data
-@Setter(AccessLevel.PRIVATE)
-@NoArgsConstructor
-public class CharityCampaignWrapper {
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CharityCampaignWrapper extends ValueWrapper<CharityCampaign> {
 
     /**
-     * A list that contains the charity campaign that the broadcaster is currently running.
-     * <p>
-     * The array is empty if the broadcaster is not running a charity campaign;
-     * the campaign information is no longer available as soon as the campaign ends.
-     */
-    private List<CharityCampaign> data;
-
-    /**
-     * @return the currently running charity campaign, in an optional wrapper.
+     * @return the currently running charity campaign, or empty if the broadcaster is not running a charity campaign.
      */
     public Optional<CharityCampaign> getCurrentCampaign() {
-        if (data == null || data.isEmpty()) return Optional.empty();
-        return Optional.ofNullable(data.get(0));
+        return Optional.ofNullable(this.get());
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatSettingsWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatSettingsWrapper.java
@@ -1,29 +1,17 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
-
-@Data
-@Setter(AccessLevel.PRIVATE)
-@NoArgsConstructor
-public class ChatSettingsWrapper {
-
-    /**
-     * The list of chat settings. The list contains a single object with all the settings.
-     */
-    @Getter(AccessLevel.PRIVATE)
-    private List<ChatSettings> data;
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChatSettingsWrapper extends ValueWrapper<ChatSettings> {
 
     /**
      * @return a single object with all of the settings.
      */
     public ChatSettings getChatSettings() {
-        return data == null || data.isEmpty() ? null : data.get(0);
+        return this.get();
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SentChatMessageWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SentChatMessageWrapper.java
@@ -1,26 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
-
-@Data
-@Setter(AccessLevel.PRIVATE)
-public class SentChatMessageWrapper {
-
-    /**
-     * Contains a single object with metadata about the sent message.
-     */
-    private List<SentChatMessage> data;
-
-    /**
-     * @return metadata about the sent message
-     */
-    public SentChatMessage get() {
-        if (data == null || data.isEmpty()) return null; // should never happen
-        return data.get(0);
-    }
-
-}
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class SentChatMessageWrapper extends ValueWrapper<SentChatMessage> {}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ShieldModeStatusWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ShieldModeStatusWrapper.java
@@ -1,25 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
-
-@Data
-@Setter(AccessLevel.PRIVATE)
-public class ShieldModeStatusWrapper {
-
-    /**
-     * A list that contains a single object with the broadcaster’s Shield Mode status.
-     */
-    private List<ShieldModeStatus> data;
-
-    /**
-     * @return a single object with the broadcaster’s Shield Mode status.
-     */
-    public ShieldModeStatus get() {
-        return data.get(0);
-    }
-
-}
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ShieldModeStatusWrapper extends ValueWrapper<ShieldModeStatus> {}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SnoozedAdWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SnoozedAdWrapper.java
@@ -1,26 +1,8 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
-
-@Data
-@Setter(AccessLevel.PRIVATE)
-public class SnoozedAdWrapper {
-
-    /**
-     * A list that contains information about the channel’s snoozes and next upcoming ad after successfully snoozing.
-     */
-    private List<SnoozedAd> data;
-
-    /**
-     * @return information about the channel’s snoozes and next upcoming ad after successfully snoozing
-     */
-    public SnoozedAd get() {
-        if (data == null || data.isEmpty()) return null;
-        return data.get(0);
-    }
-
-}
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class SnoozedAdWrapper extends ValueWrapper<SnoozedAd> {}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SoundtrackCurrentTrackWrapper.java
@@ -1,32 +1,23 @@
 package com.github.twitch4j.helix.domain;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
  * @deprecated <a href="https://discuss.dev.twitch.tv/t/withdrawal-of-twitch-api-endpoints-for-soundtrack/">Twitch is decommissioning Soundtrack on 2023-07-17</a>
  */
-@Data
-@Setter(AccessLevel.PRIVATE)
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 @Deprecated
-public class SoundtrackCurrentTrackWrapper {
-
-    /**
-     * A list that contains the Soundtrack track that the broadcaster is playing.
-     */
-    private List<SoundtrackCurrentTrack> data;
+public class SoundtrackCurrentTrackWrapper extends ValueWrapper<SoundtrackCurrentTrack> {
 
     /**
      * @return the Soundtrack track that the broadcaster is playing.
      */
     public Optional<SoundtrackCurrentTrack> getTrack() {
-        if (data == null || data.isEmpty())
-            return Optional.empty();
-        return Optional.ofNullable(data.get(0));
+        return Optional.ofNullable(this.get());
     }
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Reduce code duplication by extending `ValueWrapper` in more helix pojos

### Additional Information
Classes that extend `ValueWrapper` will likely be removed in 2.0.0
