### PR TITLE
chore(eventsub,helix): promote chat warnings to v1

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelWarningAcknowledgeType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelWarningAcknowledgeType.java
@@ -2,7 +2,6 @@ package com.github.twitch4j.eventsub.subscriptions;
 
 import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
 import com.github.twitch4j.eventsub.events.ChannelWarningAcknowledgeEvent;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Sends a notification when a warning is acknowledged by a user.
@@ -10,12 +9,10 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>
  * Must have the moderator:read:warnings or moderator:manage:warnings scope.
  *
- * @apiNote This topic is in public beta, and could break without notice.
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_WARNINGS_MANAGE
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_WARNINGS_READ
  */
-@ApiStatus.Experimental
-public class BetaChannelWarningAcknowledgeType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, ChannelWarningAcknowledgeEvent> {
+public class ChannelWarningAcknowledgeType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, ChannelWarningAcknowledgeEvent> {
     @Override
     public String getName() {
         return "channel.warning.acknowledge";
@@ -23,7 +20,7 @@ public class BetaChannelWarningAcknowledgeType implements SubscriptionType<Moder
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelWarningSendType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/ChannelWarningSendType.java
@@ -2,7 +2,6 @@ package com.github.twitch4j.eventsub.subscriptions;
 
 import com.github.twitch4j.eventsub.condition.ModeratorEventSubCondition;
 import com.github.twitch4j.eventsub.events.ChannelWarningSendEvent;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Sends a notification when a warning is sent to a user.
@@ -10,12 +9,10 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>
  * Must have the moderator:read:warnings or moderator:manage:warnings scope.
  *
- * @apiNote This topic is in public beta, and could break without notice.
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_WARNINGS_MANAGE
  * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_WARNINGS_READ
  */
-@ApiStatus.Experimental
-public class BetaChannelWarningSendType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, ChannelWarningSendEvent> {
+public class ChannelWarningSendType implements SubscriptionType<ModeratorEventSubCondition, ModeratorEventSubCondition.ModeratorEventSubConditionBuilder<?, ?>, ChannelWarningSendEvent> {
     @Override
     public String getName() {
         return "channel.warning.send";
@@ -23,7 +20,7 @@ public class BetaChannelWarningSendType implements SubscriptionType<ModeratorEve
 
     @Override
     public String getVersion() {
-        return "beta";
+        return "1";
     }
 
     @Override

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/subscriptions/SubscriptionTypes.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.eventsub.subscriptions;
 
 import lombok.experimental.UtilityClass;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
 import java.util.Map;
@@ -56,8 +55,8 @@ public class SubscriptionTypes {
     public final ChannelUpdateV2Type CHANNEL_UPDATE_V2;
     public final ChannelVipAddType CHANNEL_VIP_ADD;
     public final ChannelVipRemoveType CHANNEL_VIP_REMOVE;
-    public final @ApiStatus.Experimental BetaChannelWarningAcknowledgeType BETA_CHANNEL_WARNING_ACKNOWLEDGE;
-    public final @ApiStatus.Experimental BetaChannelWarningSendType BETA_CHANNEL_WARNING_SEND;
+    public final ChannelWarningAcknowledgeType CHANNEL_WARNING_ACKNOWLEDGE;
+    public final ChannelWarningSendType CHANNEL_WARNING_SEND;
     public final ConduitShardDisabledType CONDUIT_SHARD_DISABLED;
     public final DropEntitlementGrantType DROP_ENTITLEMENT_GRANT;
     public final ExtensionBitsTransactionCreateType EXTENSION_BITS_TRANSACTION_CREATE;
@@ -135,8 +134,8 @@ public class SubscriptionTypes {
                 CHANNEL_UPDATE_V2 = new ChannelUpdateV2Type(),
                 CHANNEL_VIP_ADD = new ChannelVipAddType(),
                 CHANNEL_VIP_REMOVE = new ChannelVipRemoveType(),
-                BETA_CHANNEL_WARNING_ACKNOWLEDGE =  new BetaChannelWarningAcknowledgeType(),
-                BETA_CHANNEL_WARNING_SEND = new BetaChannelWarningSendType(),
+                CHANNEL_WARNING_ACKNOWLEDGE =  new ChannelWarningAcknowledgeType(),
+                CHANNEL_WARNING_SEND = new ChannelWarningSendType(),
                 CONDUIT_SHARD_DISABLED = new ConduitShardDisabledType(),
                 DROP_ENTITLEMENT_GRANT = new DropEntitlementGrantType(),
                 EXTENSION_BITS_TRANSACTION_CREATE = new ExtensionBitsTransactionCreateType(),

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -2314,10 +2314,8 @@ public interface TwitchHelix {
      * @param userId        The ID of the twitch user to be warned.
      * @param reason        A custom reason for the warning. Max: 500 chars.
      * @return ChatUserWarningWrapper
-     * @apiNote This endpoint is in open beta, and could break without notice.
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_WARNINGS_MANAGE
      */
-    @ApiStatus.Experimental // in open beta
     @RequestLine("POST /moderation/warnings?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
     @Headers({
         "Authorization: Bearer {token}",


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove beta markers for `TwitchHelix#warnChatUser` and EventSub topics (`channel.warning.send` and `channel.warning.acknowledge`)

### Additional Information
Promoted out of beta on 2024-07-11 https://dev.twitch.tv/docs/change-log/
