### PR TITLE
docs: update links in javadoc overview

### DIFF
--- a/buildSrc/overview-general.html
+++ b/buildSrc/overview-general.html
@@ -1,10 +1,10 @@
 <html lang="en">
 <body>
-<p><img alt="Twitch4J Logo" width="64" height="64" src="https://twitch4j.github.io/assets/images/logo.svg"/></p>
-<p>Check out our documentation at <a href="https://twitch4j.github.io/docs">twitch4j.github.io</a></p>
+<p><img alt="Twitch4J Logo" width="64" height="64" src="https://twitch4j.github.io/img/logo.svg"/></p>
+<p>Check out our documentation at <a href="https://twitch4j.github.io">twitch4j.github.io</a></p>
 <ul>
-	<li><a href="https://twitch4j.github.io/docs/getting-started/installation/">Installation</a></li>
-	<li><a href="https://twitch4j.github.io/docs/getting-started/client-builder/">Usage</a></li>
+	<li><a href="https://twitch4j.github.io/getting-started/installation">Installation</a></li>
+	<li><a href="https://twitch4j.github.io/getting-started/client-builder">Usage</a></li>
 </ul>
 </body>
 </html>

--- a/buildSrc/overview-single.html
+++ b/buildSrc/overview-single.html
@@ -1,11 +1,11 @@
 <html lang="en">
 <body>
-<p><img alt="Twitch4J Logo" width="64" height="64" src="https://twitch4j.github.io/assets/images/logo.svg"/></p>
-<p>Check out our documentation at <a href="https://twitch4j.github.io/docs">twitch4j.github.io</a></p>
+<p><img alt="Twitch4J Logo" width="64" height="64" src="https://twitch4j.github.io/img/logo.svg"/></p>
+<p>Check out our documentation at <a href="https://twitch4j.github.io">twitch4j.github.io</a></p>
 <ul>
 	<li><a href="https://twitch4j.github.io/javadoc">Aggregated Javadocs (all modules)</a></li>
-	<li><a href="https://twitch4j.github.io/docs/getting-started/installation/">Installation</a></li>
-	<li><a href="https://twitch4j.github.io/docs/getting-started/client-builder/">Usage</a></li>
+	<li><a href="https://twitch4j.github.io/getting-started/installation">Installation</a></li>
+	<li><a href="https://twitch4j.github.io/getting-started/client-builder">Usage</a></li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Broken links in javadoc overview pages

### Changes Proposed
* Update links in `overview-general.html` and `overview-single.html`

### Additional Information
Reported by @Awakened-Redstone
