### PR TITLE
chore: support for apiNote, implSpec and implNote in javadoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -233,9 +233,11 @@ subprojects {
 				locale = "en"
 
 				// additional javadoc tags
-				addStringOption("tag", "apiNote:a:API Note:")
-				addStringOption("tag", "implSpec:a:Implementation Requirements:")
-				addStringOption("tag", "implNote:a:Implementation Note:")
+				tags = listOf(
+					"apiNote:a:API Note:",
+					"implSpec:a:Implementation Requirements:",
+					"implNote:a:Implementation Note:"
+				)
 			}
 		}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -231,6 +231,11 @@ subprojects {
 						"https://twitch4j.github.io/javadoc"
 				)
 				locale = "en"
+
+				// additional javadoc tags
+				addStringOption("tag", "apiNote:a:API Note:")
+				addStringOption("tag", "implSpec:a:Implementation Requirements:")
+				addStringOption("tag", "implNote:a:Implementation Note:")
 			}
 		}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,7 +248,6 @@ subprojects {
 				// hide javadoc warnings (a lot from delombok)
 				addStringOption("Xdoclint:none", "-quiet")
 				if (JavaVersion.current().isJava9Compatible) {
-					// javadoc / html5 support
 					addBooleanOption("html5", true)
 				}
 			}
@@ -284,7 +283,10 @@ tasks.register<Javadoc>("aggregateJavadoc") {
 		group("GraphQL", "com.github.twitch4j.graphql*")
 		group("Extensions API", "com.github.twitch4j.extensions*")
 		group("Kraken API v5 (deprecated)", "com.github.twitch4j.kraken*")
-		addBooleanOption("html5").setValue(true)
+		addStringOption("Xdoclint:none", "-quiet")
+		if (JavaVersion.current().isJava9Compatible) {
+			addBooleanOption("html5", true)
+		}
 	}
 
 	source(subprojects.map { it.tasks.javadoc.get().source })


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* support for tags `apiNote`, `implSpec` and `implNote` in javadoc config (as of now the comments do not show up)
* unify configuration for javadoc tasks (aggregateJavadoc task had slightly different settings, only relevant for our doc page)
