### PR TITLE
feat(chat): support stream together shared chat

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/TwitchChat.java
@@ -371,7 +371,7 @@ public class TwitchChat implements ITwitchChat {
         this.eventManager.getServiceMediator().addService("twitch4j-chat", this);
 
         // register event listeners
-        IRCEventHandler ircEventHandler = new IRCEventHandler(this);
+        IRCEventHandler ircEventHandler = new IRCEventHandler(eventManager);
 
         // connect to irc
         connection.connect();
@@ -833,6 +833,11 @@ public class TwitchChat implements ITwitchChat {
      * @param event ChannelMessageEvent
      */
     private void onChannelMessage(ChannelMessageEvent event) {
+        // avoid firing CommandEvent if the message did not originate from the local channel
+        if (event.isMirrored()) {
+            return;
+        }
+
         Optional<String> prefix = Optional.empty();
         Optional<String> commandWithoutPrefix = Optional.empty();
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat.events;
 
 import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
+import com.github.twitch4j.chat.events.channel.MirrorableEvent;
 import com.github.twitch4j.chat.events.channel.ReplyableEvent;
 import com.github.twitch4j.chat.flag.AutoModFlag;
 import com.github.twitch4j.common.annotation.Unofficial;
@@ -12,6 +13,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 import java.util.Set;
@@ -19,7 +21,7 @@ import java.util.Set;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = false)
-public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent implements ReplyableEvent {
+public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent implements ReplyableEvent, MirrorableEvent {
 
     /**
      * RAW Message Event
@@ -53,6 +55,7 @@ public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent i
     @Getter(lazy = true)
     private final String nonce = getMessageEvent().getNonce().orElse(null);
 
+    @ApiStatus.Internal
     public AbstractChannelMessageEvent(EventChannel channel, IRCMessageEvent messageEvent, EventUser user, String message) {
         super(channel);
         this.messageEvent = messageEvent;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -522,7 +522,7 @@ public class IRCEventHandler {
             String message = event.getMessage().orElse("");
             boolean wasActionMessage = message.startsWith("\u0001ACTION ") && message.endsWith("\u0001");
             String trimmedMsg = wasActionMessage ? message.substring("\u0001ACTION ".length(), message.length() - "\u0001".length()) : message;
-            eventManager.publish(new DeleteMessageEvent(channel, userName, msgId, trimmedMsg, wasActionMessage));
+            eventManager.publish(new DeleteMessageEvent(event, channel, userName, msgId, trimmedMsg, wasActionMessage));
             return true;
         }
         return false;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -1,7 +1,7 @@
 package com.github.twitch4j.chat.events;
 
+import com.github.philippheuer.events4j.api.IEventManager;
 import com.github.philippheuer.events4j.core.EventManager;
-import com.github.twitch4j.chat.TwitchChat;
 import com.github.twitch4j.chat.enums.NoticeTag;
 import com.github.twitch4j.chat.events.channel.*;
 import com.github.twitch4j.chat.events.roomstate.*;
@@ -16,6 +16,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Month;
 import java.util.Arrays;
@@ -41,24 +42,18 @@ import static com.github.twitch4j.common.util.TwitchUtils.ANONYMOUS_GIFTER;
 public class IRCEventHandler {
 
     /**
-     * Twitch Client
-     */
-    private final TwitchChat twitchChat;
-
-    /**
      * Event Manager
      */
-    private final EventManager eventManager;
+    private final IEventManager eventManager;
 
     /**
      * Constructor
      *
-     * @param twitchChat The Twitch Chat instance
+     * @param eventManager The event manager
      */
     @ApiStatus.Internal
-    public IRCEventHandler(TwitchChat twitchChat) {
-        this.twitchChat = twitchChat;
-        this.eventManager = twitchChat.getEventManager();
+    public IRCEventHandler(EventManager eventManager) {
+        this.eventManager = eventManager;
 
         // register event handlers
         eventManager.onEvent("twitch4j-chat-event-trigger", IRCMessageEvent.class, this::handle);
@@ -92,7 +87,7 @@ public class IRCEventHandler {
 
     @Unofficial
     public boolean onAnnouncement(IRCMessageEvent event) {
-        if ("USERNOTICE".equals(event.getCommandType()) && StringUtils.equalsIgnoreCase("announcement", event.getRawTag("msg-id"))) {
+        if ("USERNOTICE".equals(event.getCommandType()) && StringUtils.equalsIgnoreCase("announcement", getNoticeType(event))) {
             // Load Info
             EventChannel channel = event.getChannel();
             EventUser user = event.getUser();
@@ -215,7 +210,7 @@ public class IRCEventHandler {
      */
     public boolean onChannelSubscription(IRCMessageEvent event) {
         final String msgId;
-        if (event.getCommandType().equals("USERNOTICE") && (msgId = Objects.toString(event.getRawTag("msg-id"), null)) != null) {
+        if (event.getCommandType().equals("USERNOTICE") && (msgId = Objects.toString(getNoticeType(event), null)) != null) {
             EventChannel channel = event.getChannel();
 
             // Resub message for a multi-month gifted subscription
@@ -281,7 +276,7 @@ public class IRCEventHandler {
                 Integer subsGiftedTotal = event.getTagValue("msg-param-sender-count").map(Integer::parseInt).orElse(0);
 
                 // Dispatch Event
-                eventManager.publish(new GiftSubscriptionsEvent(channel, user != null ? user : ANONYMOUS_GIFTER, subPlan, subsGifted, subsGiftedTotal));
+                eventManager.publish(new GiftSubscriptionsEvent(event, channel, user != null ? user : ANONYMOUS_GIFTER, subPlan, subsGifted, subsGiftedTotal));
                 return true;
             }
             // Upgrading from a gifted sub
@@ -295,7 +290,7 @@ public class IRCEventHandler {
                 String senderName = event.getTagValue("msg-param-sender-name").orElse(null);
 
                 // Dispatch Event
-                eventManager.publish(new GiftSubUpgradeEvent(channel, user, promoName, giftTotal, senderLogin, senderName));
+                eventManager.publish(new GiftSubUpgradeEvent(event, channel, user, promoName, giftTotal, senderLogin, senderName));
                 return true;
             }
             // Upgrading from a Prime sub to a normal one
@@ -305,7 +300,7 @@ public class IRCEventHandler {
                 SubscriptionPlan subPlan = event.getTagValue("msg-param-sub-plan").map(SubscriptionPlan::fromString).orElse(null);
 
                 // Dispatch Event
-                eventManager.publish(new PrimeSubUpgradeEvent(channel, user, subPlan));
+                eventManager.publish(new PrimeSubUpgradeEvent(event, channel, user, subPlan));
                 return true;
             }
             // Extend Subscription
@@ -356,7 +351,7 @@ public class IRCEventHandler {
      */
     public boolean onPayForward(IRCMessageEvent event) {
         CharSequence msgId;
-        if ("USERNOTICE".equals(event.getCommandType()) && (msgId = event.getRawTag("msg-id")) != null
+        if ("USERNOTICE".equals(event.getCommandType()) && (msgId = getNoticeType(event)) != null
             && (StringUtils.equalsIgnoreCase(msgId, "standardpayforward") || StringUtils.equalsIgnoreCase(msgId,"communitypayforward"))) {
             // Load Info
             EventChannel channel = event.getChannel();
@@ -377,7 +372,7 @@ public class IRCEventHandler {
             EventUser recipient = recipientId != null ? new EventUser(recipientId, recipientName) : null;
 
             // Dispatch Event
-            eventManager.publish(new PayForwardEvent(channel, user, gifter, recipient));
+            eventManager.publish(new PayForwardEvent(event, channel, user, gifter, recipient));
             return true;
         }
         return false;
@@ -397,7 +392,7 @@ public class IRCEventHandler {
      * @param event IRCMessageEvent
      */
     public boolean onRaid(IRCMessageEvent event) {
-        if (event.getCommandType().equals("USERNOTICE") && StringUtils.equalsIgnoreCase("raid", event.getRawTag("msg-id"))) {
+        if (event.getCommandType().equals("USERNOTICE") && StringUtils.equalsIgnoreCase("raid", getNoticeType(event))) {
             EventChannel channel = event.getChannel();
             EventUser raider = event.getUser();
             Integer viewers;
@@ -406,7 +401,7 @@ public class IRCEventHandler {
             } catch (NumberFormatException ex) {
                 viewers = 0;
             }
-            eventManager.publish(new RaidEvent(channel, raider, viewers));
+            eventManager.publish(new RaidEvent(event, channel, raider, viewers));
             return true;
         }
         return false;
@@ -780,6 +775,15 @@ public class IRCEventHandler {
             return true;
         }
         return false;
+    }
+
+    @Nullable
+    private static CharSequence getNoticeType(IRCMessageEvent userNoticeEvent) {
+        CharSequence value = userNoticeEvent.getRawTag("msg-id");
+        if (StringUtils.equals("sharedchatnotice", value)) {
+            return userNoticeEvent.getRawTag("source-msg-id");
+        }
+        return value;
     }
 
     @NonNull

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/CheerEvent.java
@@ -8,7 +8,6 @@ import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
@@ -18,11 +17,10 @@ import java.util.List;
  * This event gets called when a user receives bits.
  */
 @Data
-@Getter
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class CheerEvent extends AbstractChannelEvent implements ReplyableEvent {
+public class CheerEvent extends AbstractChannelEvent implements ReplyableEvent, MirrorableEvent {
 
     /**
      * Raw IRC Message Event

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/DeleteMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/DeleteMessageEvent.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when a single message was deleted over IRC by a moderator via {@code /delete <target-msg-id>}
@@ -13,7 +14,14 @@ import lombok.experimental.Accessors;
 @Value
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class DeleteMessageEvent extends AbstractChannelEvent {
+public class DeleteMessageEvent extends AbstractChannelEvent implements MirrorableEvent {
+
+    /**
+     * The raw message event.
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    IRCMessageEvent messageEvent;
 
     /**
      * The login name of the user whose message was deleted.
@@ -36,8 +44,10 @@ public class DeleteMessageEvent extends AbstractChannelEvent {
     @Accessors(fluent = true)
     boolean wasActionMessage;
 
-    public DeleteMessageEvent(EventChannel channel, String userName, String msgId, String message, boolean wasActionMessage) {
+    @ApiStatus.Internal
+    public DeleteMessageEvent(IRCMessageEvent messageEvent, EventChannel channel, String userName, String msgId, String message, boolean wasActionMessage) {
         super(channel);
+        this.messageEvent = messageEvent;
         this.userName = userName;
         this.msgId = msgId;
         this.message = message;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubUpgradeEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubUpgradeEvent.java
@@ -6,6 +6,7 @@ import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Called when a user upgrades to a paid subscription from previously being gifted a subscription.
@@ -13,7 +14,15 @@ import lombok.Value;
 @Value
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class GiftSubUpgradeEvent extends AbstractChannelEvent {
+public class GiftSubUpgradeEvent extends AbstractChannelEvent implements MirrorableEvent {
+
+    /**
+     * Raw Message Event
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    IRCMessageEvent messageEvent;
+
     /**
      * The user that is upgrading their subscription.
      */
@@ -42,6 +51,7 @@ public class GiftSubUpgradeEvent extends AbstractChannelEvent {
     /**
      * Constructor
      *
+     * @param event          the raw message event
      * @param channel        the channel where the event took place
      * @param upgradingUser  the user that is upgrading their subscription
      * @param promoName      the ongoing subscriptions promo, if applicable
@@ -49,8 +59,10 @@ public class GiftSubUpgradeEvent extends AbstractChannelEvent {
      * @param gifterLogin    the login of the user who gifted the subscription, if applicable
      * @param gifterName     the display name of the user who gifted the subscription, if applicable
      */
-    public GiftSubUpgradeEvent(EventChannel channel, EventUser upgradingUser, String promoName, Integer promoGiftTotal, String gifterLogin, String gifterName) {
+    @ApiStatus.Internal
+    public GiftSubUpgradeEvent(IRCMessageEvent event, EventChannel channel, EventUser upgradingUser, String promoName, Integer promoGiftTotal, String gifterLogin, String gifterName) {
         super(channel);
+        this.messageEvent = event;
         this.upgradingUser = upgradingUser;
         this.promoName = promoName;
         this.promoGiftTotal = promoGiftTotal;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
@@ -4,9 +4,9 @@ import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * This event gets called when a user gifts x subscriptions to *random* users in chat.
@@ -15,10 +15,16 @@ import lombok.Value;
  * not necessarily when the user presses the subscription button.
  */
 @Value
-@Getter
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class GiftSubscriptionsEvent extends AbstractChannelEvent {
+public class GiftSubscriptionsEvent extends AbstractChannelEvent implements MirrorableEvent {
+
+    /**
+     * Raw Message Event
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private IRCMessageEvent messageEvent;
 
     /**
      * Event Target User
@@ -43,14 +49,17 @@ public class GiftSubscriptionsEvent extends AbstractChannelEvent {
     /**
      * Event Constructor
      *
+     * @param event            The raw message event
      * @param channel          The channel that this event originates from.
      * @param user             The user that gifted the subscriptions
      * @param subscriptionPlan The subscription plan
      * @param count            The total amount of subs gifted
      * @param totalCount       The amount the user gifted in total (all time)
      */
-    public GiftSubscriptionsEvent(EventChannel channel, EventUser user, String subscriptionPlan, Integer count, Integer totalCount) {
+    @ApiStatus.Internal
+    public GiftSubscriptionsEvent(IRCMessageEvent event, EventChannel channel, EventUser user, String subscriptionPlan, Integer count, Integer totalCount) {
         super(channel);
+        this.messageEvent = event;
         this.user = user;
         this.subscriptionPlan = subscriptionPlan;
         this.count = count;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftedMultiMonthSubCourtesyEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftedMultiMonthSubCourtesyEvent.java
@@ -5,6 +5,7 @@ import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 
@@ -22,13 +23,15 @@ import static com.github.twitch4j.common.util.TwitchUtils.ANONYMOUS_GIFTER;
  * The parameters specific to this event are not officially documented.
  */
 @Value
+@ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = false)
 @Unofficial
-public class GiftedMultiMonthSubCourtesyEvent extends AbstractChannelEvent {
+public class GiftedMultiMonthSubCourtesyEvent extends AbstractChannelEvent implements MirrorableEvent {
 
     /**
      * Raw message event.
      */
+    @ToString.Exclude
     IRCMessageEvent messageEvent;
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/MirrorableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/MirrorableEvent.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  * Be wary of edge cases when your bot is joined to multiple channels in a single shared chat session.
  * You can obtain the other channels in a shared chat session via {@code TwitchHelix#getSharedChatSession}.
  *
- * @see <a href="https://dev.twitch.tv/docs/chat/irc/#shared-chat">Official Developer Explanier</a>
+ * @see <a href="https://dev.twitch.tv/docs/chat/irc/#shared-chat">Official Developer Explainer</a>
  */
 public interface MirrorableEvent {
 

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/MirrorableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/MirrorableEvent.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.common.util.TwitchUtils;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Map;
 import java.util.Optional;
@@ -17,7 +16,6 @@ import java.util.Optional;
  *
  * @see <a href="https://dev.twitch.tv/docs/chat/irc/#shared-chat">Official Developer Explanier</a>
  */
-@ApiStatus.Experimental // in open beta
 public interface MirrorableEvent {
 
     /**

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/MirrorableEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/MirrorableEvent.java
@@ -1,0 +1,71 @@
+package com.github.twitch4j.chat.events.channel;
+
+import com.github.twitch4j.common.util.TwitchUtils;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Indicates chat events that can be mirrored when channels are using the Stream Together Shared Chat feature.
+ * <p>
+ * When chats are merged, all PRIVMSG events and most USERNOTICE events are forwarded to the other channels.
+ * In addition, bans/timeouts in one channel apply to all channels.
+ * Thus, certain applications may wish to ignore any mirrored events while others may wish to act upon them.
+ * Be wary of edge cases when your bot is joined to multiple channels in a single shared chat session.
+ * You can obtain the other channels in a shared chat session via {@code TwitchHelix#getSharedChatSession}.
+ *
+ * @see <a href="https://dev.twitch.tv/docs/chat/irc/#shared-chat">Official Developer Explanier</a>
+ */
+@ApiStatus.Experimental // in open beta
+public interface MirrorableEvent {
+
+    /**
+     * @return the raw message event
+     */
+    IRCMessageEvent getMessageEvent();
+
+    /**
+     * @return whether the message originated from a different source channel
+     */
+    default boolean isMirrored() {
+        String roomId = getMessageEvent().getChannelId();
+        return getSourceChannelId().filter(otherId -> !otherId.equals(roomId)).isPresent();
+    }
+
+    /**
+     * @return the room id of the source channel
+     */
+    default Optional<String> getSourceChannelId() {
+        return getMessageEvent().getTagValue("source-room-id");
+    }
+
+    /**
+     * @return the id of the source message in the source channel
+     */
+    default Optional<String> getSourceMessageId() {
+        return getMessageEvent().getTagValue("source-id");
+    }
+
+    /**
+     * @return the user's chat badges in the source channel
+     */
+    default Optional<Map<String, String>> getSourceBadges() {
+        return getMessageEvent().getTagValue("source-badges").map(TwitchUtils::parseBadges);
+    }
+
+    /**
+     * @return the user's badge info in the source channel
+     */
+    default Optional<Map<String, String>> getSourceBadgeInfo() {
+        return getMessageEvent().getTagValue("source-badge-info").map(TwitchUtils::parseBadges);
+    }
+
+    /**
+     * @return the msg-id of the USERNOTICE in the source channel
+     */
+    default Optional<String> getSourceNoticeType() {
+        return getMessageEvent().getTagValue("source-msg-id");
+    }
+
+}

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/ModAnnouncementEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/ModAnnouncementEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Unofficial
-public class ModAnnouncementEvent extends AbstractChannelEvent {
+public class ModAnnouncementEvent extends AbstractChannelEvent implements MirrorableEvent {
 
     /**
      * The raw message event.

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/PayForwardEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/PayForwardEvent.java
@@ -7,6 +7,7 @@ import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Calls when a user pays forward a gift.
@@ -15,7 +16,15 @@ import lombok.Value;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Unofficial
-public class PayForwardEvent extends AbstractChannelEvent {
+public class PayForwardEvent extends AbstractChannelEvent implements MirrorableEvent {
+
+    /**
+     * Raw Message Event
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    IRCMessageEvent messageEvent;
+
     /**
      * The user that is paying forward their gift.
      */
@@ -34,13 +43,16 @@ public class PayForwardEvent extends AbstractChannelEvent {
     /**
      * Event Constructor
      *
+     * @param event       The raw message event.
      * @param channel     The channel that this event originates from.
      * @param user        The user that is paying forward their gift.
      * @param priorGifter The previous user that gifted to this one, if not anonymous.
      * @param recipient   The user that is receiving this gift, if it is not for the community at-large.
      */
-    public PayForwardEvent(EventChannel channel, EventUser user, EventUser priorGifter, EventUser recipient) {
+    @ApiStatus.Internal
+    public PayForwardEvent(IRCMessageEvent event, EventChannel channel, EventUser user, EventUser priorGifter, EventUser recipient) {
         super(channel);
+        this.messageEvent = event;
         this.user = user;
         this.priorGifter = priorGifter;
         this.recipient = recipient;

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/PrimeSubUpgradeEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/PrimeSubUpgradeEvent.java
@@ -8,6 +8,7 @@ import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Called when a user upgrades from a prime sub to a tiered subscription.
@@ -16,7 +17,15 @@ import lombok.Value;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Unofficial
-public class PrimeSubUpgradeEvent extends AbstractChannelEvent {
+public class PrimeSubUpgradeEvent extends AbstractChannelEvent implements MirrorableEvent {
+
+    /**
+     * Raw Message Event
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    IRCMessageEvent messageEvent;
+
     /**
      * The user that is upgrading their subscription.
      */
@@ -30,12 +39,15 @@ public class PrimeSubUpgradeEvent extends AbstractChannelEvent {
     /**
      * Constructor
      *
+     * @param event            the raw message event
      * @param channel          the channel where the event took place
      * @param user             the user that is upgrading their subscription
      * @param subscriptionPlan the new subscription plan of the user
      */
-    public PrimeSubUpgradeEvent(EventChannel channel, EventUser user, SubscriptionPlan subscriptionPlan) {
+    @ApiStatus.Internal
+    public PrimeSubUpgradeEvent(IRCMessageEvent event, EventChannel channel, EventUser user, SubscriptionPlan subscriptionPlan) {
         super(channel);
+        this.messageEvent = event;
         this.user = user;
         this.subscriptionPlan = subscriptionPlan;
     }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/RaidEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/RaidEvent.java
@@ -4,8 +4,9 @@ import com.github.twitch4j.chat.events.AbstractChannelEvent;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * This event gets called when a user receives a raid.
@@ -13,29 +14,40 @@ import lombok.Value;
  * This event is <i>not</i> called when a user receives a host that is not part of a raid.
  */
 @Value
-@Getter
-@EqualsAndHashCode(callSuper = false)
-public class RaidEvent extends AbstractChannelEvent {
-    
-        /**
-	 * Event User who initiated the raid
-	 */
-	private EventUser raider;
-        
-        /**
-         * Number of viewers in the raid
-         */
-        private Integer viewers;
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class RaidEvent extends AbstractChannelEvent implements MirrorableEvent {
 
-        /**
-         * 
-         * @param channel ChatChannel receiving the raid
-         * @param raider User who is sending the raid
-         * @param viewers number of viewers from the raid
-         */
-        public RaidEvent(EventChannel channel, EventUser raider, Integer viewers) {
-            super(channel);
-            this.raider = raider;
-            this.viewers = viewers;
-        }
+    /**
+     * Raw Message Event
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    IRCMessageEvent messageEvent;
+
+    /**
+     * Event User who initiated the raid
+     */
+    EventUser raider;
+
+    /**
+     * Number of viewers in the raid
+     */
+    Integer viewers;
+
+    /**
+     * Inbound Raid Event Constructor
+     *
+     * @param event   Raw Message Event
+     * @param channel ChatChannel receiving the raid
+     * @param raider  User who is sending the raid
+     * @param viewers number of viewers from the raid
+     */
+    @ApiStatus.Internal
+    public RaidEvent(IRCMessageEvent event, EventChannel channel, EventUser raider, Integer viewers) {
+        super(channel);
+        this.messageEvent = event;
+        this.raider = raider;
+        this.viewers = viewers;
+    }
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/SubscriptionEvent.java
@@ -23,14 +23,14 @@ import java.util.Optional;
  * not necessary when the user presses the subscription button.
  */
 @Value
-@Getter
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class SubscriptionEvent extends AbstractChannelEvent implements ReplyableEvent {
+public class SubscriptionEvent extends AbstractChannelEvent implements ReplyableEvent, MirrorableEvent {
 
     /**
      * Raw IRC Message Event
      */
+    @ToString.Exclude
     IRCMessageEvent messageEvent;
 
     /**

--- a/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
@@ -6,7 +6,6 @@ import com.github.twitch4j.chat.events.IRCEventHandler;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.util.EventManagerUtils;
-import org.jetbrains.annotations.ApiStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -208,7 +207,6 @@ public class IRCMessageEventTest {
 
     @Test
     @DisplayName("Test that stream together shared chat PRIVMSG is parsed by IRCMessageEvnet and sub-event")
-    @ApiStatus.Experimental
     void parseSharedChatMessage() {
         IRCMessageEvent raw = parse("@badge-info=;badges=glitchcon2020/1;color=#00FF7F;display-name=OGprodigy;emotes=;flags=;id=e16cc51a-7fce-4a92-8387-4ac8b7794ee7;mod=0;reply-parent-display-name=OGprodigy;reply-parent-msg-body=@Alca\\soh\\sur\\sright;reply-parent-msg-id=3c231d98-fc47-44a0-81db-be3820102d79;reply-parent-user-id=53888434;reply-parent-user-login=ogprodigy;reply-thread-parent-display-name=Alca;reply-thread-parent-msg-id=c449d446-cd01-4460-b890-ad935f32b92a;reply-thread-parent-user-id=7676884;reply-thread-parent-user-login=alca;room-id=1025594235;source-badge-info=;source-badges=glitchcon2020/1;source-id=0b1e60f3-5990-4b26-94e2-885231614e07;source-room-id=1025597036;subscriber=0;tmi-sent-ts=1726007886662;turbo=0;user-id=53888434;user-type= " +
             ":ogprodigy!ogprodigy@ogprodigy.tmi.twitch.tv PRIVMSG #shared_chat_test_01 :@OGprodigy test3");
@@ -235,7 +233,6 @@ public class IRCMessageEventTest {
 
     @Test
     @DisplayName("Test that stream together shared chat USERNOTICE is parsed by IRCMessageEvnet and sub-event")
-    @ApiStatus.Experimental
     void parseSharedChatNotification() {
         IRCMessageEvent raw = parse("@badge-info=;badges=staff/1,raging-wolf-helm/1;color=#DAA520;display-name=lahoooo;emotes=;flags=;id=01cd601f-bc3f-49d5-ab4b-136fa9d6ec22;login=lahoooo;mod=0;msg-id=sharedchatnotice;msg-param-color=PRIMARY;room-id=1025597036;source-badge-info=;source-badges=staff/1,moderator/1,bits-leader/1;source-id=4083dadc-9f20-40f9-ba92-949ebf6bc294;source-msg-id=announcement;source-room-id=1025594235;subscriber=0;system-msg=;tmi-sent-ts=1726118378465;user-id=612865661;user-type=staff;vip=0 " +
             ":tmi.twitch.tv USERNOTICE #shared_chat_test_02 :hi this is an announcement from 1");


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `MirrorableEvent` interface, and apply it to the appropriate classes
* Avoid firing `CommandEvent` when the message was forwarded from another channel
* Refactor `IRCEventHandler` constructor to simplify testing
* Add unit test for forwarded `ChannelMessageEvent` (PRIVMSG) & `ModAnnouncementEvent` (USERNOTICE)

### Additional Information
2024-09-10 changelog entry: https://dev.twitch.tv/docs/change-log/

IRC complement of #1032

I expect the feature to be officially announced at the upcoming TwitchCon next weekend