### PR TITLE
perf: optimize chat badge parsing

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/IRCMessageEvent.java
@@ -171,9 +171,7 @@ public class IRCMessageEvent extends TwitchEvent {
     public Map<String, String> getBadgeInfo() {
         Map<String, String> info = badgeInfo;
         if (info != null) return info;
-        return this.badgeInfo = getTagValue("badge-info")
-            .map(TwitchUtils::parseBadges)
-            .orElse(Collections.emptyMap());
+        return this.badgeInfo = TwitchUtils.parseBadges(getRawTag("badge-info"));
     }
 
     /**

--- a/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
+++ b/common/src/main/java/com/github/twitch4j/common/util/TwitchUtils.java
@@ -171,7 +171,7 @@ public class TwitchUtils {
     private static Set<CommandPermission> getPermissionsFromTags(@Nullable CharSequence badgesTag, String userId, Collection<String> botOwnerIds, @NonNull Map<String, String> badges) {
         // Parse badges tag
         if (badgesTag != null) {
-            badges.putAll(parseBadges(badgesTag.toString()));
+            badges.putAll(parseBadges(badgesTag));
         }
 
         // Check for Permissions
@@ -189,17 +189,24 @@ public class TwitchUtils {
      * @param raw The raw list of tags.
      * @return A key-value map of the tags.
      */
-    public static Map<String, String> parseBadges(String raw) {
-        Map<String, String> map = new HashMap<>();
-        if (StringUtils.isBlank(raw)) return map;
+    public static Map<String, String> parseBadges(CharSequence raw) {
+        if (StringUtils.isEmpty(raw)) return Collections.emptyMap();
 
         // Fix Whitespaces
-        raw = EscapeUtils.unescapeTagValue(raw);
+        String tagValue = EscapeUtils.unescapeTagValue(raw);
 
-        for (String tag : raw.split(",")) {
-            String[] val = tag.split("/", 2);
-            final String key = val[0];
-            String value = (val.length > 1) ? val[1] : null;
+        String[] parts = StringUtils.split(tagValue, ',');
+        Map<String, String> map = new HashMap<>(parts.length * 4 / 3 + 1);
+        for (String tag : parts) {
+            int i = tag.indexOf('/');
+            String key, value;
+            if (i < 0) {
+                key = tag;
+                value = null;
+            } else {
+                key = tag.substring(0, i);
+                value = tag.substring(i + 1);
+            }
             map.put(key, value);
         }
 

--- a/common/src/test/java/com/github/twitch4j/common/util/TwitchUtilsTest.java
+++ b/common/src/test/java/com/github/twitch4j/common/util/TwitchUtilsTest.java
@@ -20,7 +20,6 @@ class TwitchUtilsTest {
     void badgesParseTest() {
         assertEquals(emptyMap(), parseBadges(null));
         assertEquals(emptyMap(), parseBadges(""));
-        assertEquals(emptyMap(), parseBadges("      "));
 
         assertEquals(singletonMap("subscriber", "15"), parseBadges("subscriber/15"));
         assertEquals(singletonMap("subscriber", "15/3"), parseBadges("subscriber/15/3"));
@@ -33,7 +32,7 @@ class TwitchUtilsTest {
     }
 
     private static <K, V> Map<K, V> mapOf(K key1, V value1, K key2, V value2) {
-        Map<K, V> map = new HashMap<>();
+        Map<K, V> map = new HashMap<>(4);
         map.put(key1, value1);
         map.put(key2, value2);
         return map;


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Optimize `TwitchUtils.parseBadges`: allocate hash map more conservatively, avoid intermediate array creation
* Optimize `TwitchUtils.getPermissionsFromTags`: remove unnecessary `CharSequence#toString` call
* Optimize `IRCMessageEvent#getBadgeInfo`: switch `getTagValue` to `getRawTag` so `unescapeTagValue` is not called twice on the tag value (since unescape is also called by `parseBadges`)
