### PR TITLE
chore: remove Mirrorable interface for DeleteMessageEvent

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/DeleteMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/DeleteMessageEvent.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.ApiStatus;
 @Value
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class DeleteMessageEvent extends AbstractChannelEvent implements MirrorableEvent {
+public class DeleteMessageEvent extends AbstractChannelEvent {
 
     /**
      * The raw message event.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Remove `MirrorableEvent` from `DeleteMessageEvent`

### Additional Information
While `CLEARMSG` can be mirrored, none of the extra tags are populated, rendering the interface useless
