### PR TITLE
chore(pubsub): add automod classification category

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodContentClassification.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/AutomodContentClassification.java
@@ -37,6 +37,12 @@ public class AutomodContentClassification {
         BULLYING,
 
         /**
+         * Unwelcome comments about someone's appearance, sexual requests or advances, sexual objectification.
+         * Currently available in English only.
+         */
+        SEXUAL_HARASSMENT,
+
+        /**
          * Demonstrating hatred or prejudice based on perceived or actual mental or physical abilities.
          */
         @JsonAlias("ableism")


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `AutomodCaughtMessageData#getContentClassification` could yield `UNKNOWN`

### Changes Proposed
* Add `AutomodContentClassification.SEXUAL_HARASSMENT`

### Additional Information
Released in late July https://safety.twitch.tv/s/article/How-We-re-Combatting-Sexual-Harassment-on-Twitch?language=en_US
