### PR TITLE
feat(eventsub): add golden kappa train indicator

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/HypeTrainEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.eventsub.domain.Contribution;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -7,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 import java.time.Instant;
 import java.util.List;
@@ -37,5 +39,12 @@ public abstract class HypeTrainEvent extends EventSubChannelEvent {
      * The timestamp at which the hype train started.
      */
     private Instant startedAt;
+
+    /**
+     * Whether the hype train rewards contributors with a temporary golden Kappa emote.
+     */
+    @Accessors(fluent = true)
+    @JsonProperty("is_golden_kappa_train")
+    private boolean isGoldenKappaTrain;
 
 }

--- a/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
+++ b/eventsub-common/src/test/java/com/github/twitch4j/eventsub/events/EventSubEventTest.java
@@ -411,7 +411,7 @@ public class EventSubEventTest {
     public void deserializeComplexHypeTrainEvent() {
         String json = "{\"broadcaster_user_id\":\"1337\",\"broadcaster_user_name\":\"cool_user\",\"level\":2,\"total\":700,\"progress\":200,\"goal\":1000," +
             "\"top_contributions\":[{\"user_id\":\"123\",\"user_name\":\"pogchamp\",\"type\":\"bits\",\"total\":50},{\"user_id\":\"456\",\"user_name\":\"kappa\",\"type\":\"subscription\",\"total\":45}]," +
-            "\"last_contribution\":{\"user_id\":\"123\",\"user_name\":\"pogchamp\",\"type\":\"bits\",\"total\":50},\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"expires_at\":\"2020-07-15T17:16:11.17106713Z\"}";
+            "\"last_contribution\":{\"user_id\":\"123\",\"user_name\":\"pogchamp\",\"type\":\"bits\",\"total\":50},\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"expires_at\":\"2020-07-15T17:16:11.17106713Z\",\"is_golden_kappa_train\":true}";
 
         HypeTrainProgressEvent event = jsonToObject(json, HypeTrainProgressEvent.class);
         assertEquals("1337", event.getBroadcasterUserId());
@@ -427,6 +427,7 @@ public class EventSubEventTest {
         assertEquals(Contribution.Type.BITS, event.getLastContribution().getType());
         assertNotNull(event.getStartedAt());
         assertEquals(Instant.parse("2020-07-15T17:16:11.17106713Z"), event.getExpiresAt());
+        assertTrue(event.isGoldenKappaTrain());
     }
 
     @Test


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `HypeTrainEvent#isGoldenKappaTrain` for eventsub

### Additional Information
2024-11-21 changelog entry https://dev.twitch.tv/docs/change-log/

We already had this field for unofficial pubsub: #1001
