### PR TITLE
feat(helix): honor new chat announcement ratelimit

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/TwitchLimitType.java
@@ -34,7 +34,12 @@ public enum TwitchLimitType {
      *
      * @see <a href="https://discuss.dev.twitch.tv/t/upcoming-changes-to-the-check-automod-status-api-endpoint/38512#rate-limits-2">Twitch Announcement</a>
      */
-    HELIX_AUTOMOD_STATUS_LIMIT("helix-automod_status-limit");
+    HELIX_AUTOMOD_STATUS_LIMIT("helix-automod_status-limit"),
+
+    /**
+     * How fast Chat Announcements can be sent in a given channel.
+     */
+    HELIX_ANNOUNCEMENT_LIMIT("helix-announcement-limit");
 
     /**
      * The identifier for the related bandwidth slot in a bucket for smoother replacement.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -371,6 +371,8 @@ public interface TwitchHelix {
 
     /**
      * Sends an announcement to the broadcaster’s chat room.
+     * <p>
+     * Rate Limits: One announcement may be sent every 2 seconds.
      *
      * @param authToken     User access token (scope: moderator:manage:announcements) of the broadcaster or a moderator.
      * @param broadcasterId The ID of the broadcaster that owns the chat room to send the announcement to.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixHttpClient.java
@@ -89,6 +89,15 @@ public class TwitchHelixHttpClient implements Client {
                 return executeAgainstBucket(vipBucket, () -> client.execute(request, options));
         }
 
+        if (request.httpMethod() == Request.HttpMethod.POST && templatePath.endsWith("/chat/announcements")) {
+            // Obtain the channel id
+            String channelId = getFirstParam("broadcaster_id", request);
+
+            // Conform to endpoint-specific bucket
+            Bucket announceBucket = rateLimitTracker.getChatAnnouncementBucket(channelId);
+            return executeAgainstBucket(announceBucket, () -> client.execute(request, options));
+        }
+
         // Moderation API: Check AutoMod Status has a stricter bucket that applies per channel id
         if (request.httpMethod() == Request.HttpMethod.POST && templatePath.endsWith("/moderation/enforcements/status")) {
             // Obtain the channel id

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixRateLimitTracker.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/interceptor/TwitchHelixRateLimitTracker.java
@@ -18,12 +18,15 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
 @RequiredArgsConstructor
 @SuppressWarnings("unused")
 public final class TwitchHelixRateLimitTracker {
+
+    private static final Bandwidth ANNOUNCE_BANDWIDTH = BucketUtils.simple(1, Duration.ofSeconds(2L));
 
     private static final String AUTOMOD_STATUS_MINUTE_ID = TwitchLimitType.HELIX_AUTOMOD_STATUS_LIMIT + "-min";
     private static final String AUTOMOD_STATUS_HOUR_ID = TwitchLimitType.HELIX_AUTOMOD_STATUS_LIMIT + "-hr";
@@ -254,6 +257,11 @@ public final class TwitchHelixRateLimitTracker {
     @NotNull
     Bucket getExtensionPubSubBucket(@NotNull String clientId, @NotNull String channelId) {
         return extensionPubSubBuckets.computeIfAbsent(clientId + ':' + channelId, k -> BucketUtils.createBucket(EXT_PUBSUB_BANDWIDTH));
+    }
+
+    @NotNull
+    Bucket getChatAnnouncementBucket(@NotNull String channelId) {
+        return TwitchLimitRegistry.getInstance().getOrInitializeBucket(channelId, TwitchLimitType.HELIX_ANNOUNCEMENT_LIMIT, Collections.singletonList(ANNOUNCE_BANDWIDTH));
     }
 
     @NotNull


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Throttle `TwitchHelix#sendChatAnnouncement` to 1 per 2 seconds

### Additional Information
2025-01-21 changelog entry: https://dev.twitch.tv/docs/change-log/
