### PR TITLE
fix: shutdown library-created executors on TwitchClientPool close

### DIFF
--- a/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPool.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/TwitchClientPool.java
@@ -240,7 +240,8 @@ public class TwitchClientPool implements ITwitchClient {
         if (scheduledThreadPoolExecutor.getThreadFactory() instanceof BasicThreadFactory) {
             BasicThreadFactory threadFactory = (BasicThreadFactory) scheduledThreadPoolExecutor.getThreadFactory();
 
-            if (threadFactory.getNamingPattern().equalsIgnoreCase("twitch4j-%d")) {
+            String pattern = threadFactory.getNamingPattern();
+            if (pattern != null && pattern.startsWith("twitch4j-") && pattern.endsWith("-%d")) {
                 scheduledThreadPoolExecutor.shutdownNow();
             }
         }


### PR DESCRIPTION
<!--
	Thanks for using and contributing to Twitch4J.
 	Before you submit a pull request, please read the Contributing guidelines.
 	We do not answer questions via Pull Requests.
	If you have any questions, ask them on our Discord: https://discord.gg/FQ5vgW3
-->

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed

* Fixes thread name matching on `TwitchClientPool#close` to be the same of `TwitchClient#close`, 
* Fixes non daemon threads being left running
