### PR TITLE
chore(eventsub): mark message emotes as nullable

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Message.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/Message.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -20,6 +21,7 @@ public class Message {
     /**
      * A collection that includes the emote ID and start and end positions for where the emote appears in the text.
      */
+    @Nullable
     private List<Emote> emotes;
 
     @Data

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Poll.java
@@ -70,7 +70,7 @@ public class Poll {
     @Deprecated
     @Accessors(fluent = true)
     @JsonProperty("bits_voting_enabled")
-    private Boolean isBitsVotingEnabled = false;
+    private Boolean isBitsVotingEnabled;
 
     /**
      * Number of Bits required to vote once with Bits. Minimum: 0. Maximum: 10000.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Clarify that `Message#getEmotes` can be null

### Additional Information
Reported at https://discord.com/channels/504015559252377601/776875921654546463/1313246244411277392
