### PR TITLE
feat(chat): add parsed tier and giftId to GiftSubscriptionsEvent

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/IRCEventHandler.java
@@ -272,11 +272,13 @@ public class IRCEventHandler {
                 // Load Info
                 EventUser user = event.getUser();
                 String subPlan = event.getTagValue("msg-param-sub-plan").get();
-                Integer subsGifted = event.getTagValue("msg-param-mass-gift-count").map(Integer::parseInt).orElse(0);
-                Integer subsGiftedTotal = event.getTagValue("msg-param-sender-count").map(Integer::parseInt).orElse(0);
+                int subsGifted = event.getTagValue("msg-param-mass-gift-count").map(Integer::parseInt).orElse(1);
+                int subsGiftedTotal = event.getTagValue("msg-param-sender-count").map(Integer::parseInt).orElse(1);
+                String giftId = event.getTagValue("msg-param-community-gift-id")
+                    .orElseGet(() -> event.getTagValue("msg-param-origin-id").orElse(null));
 
                 // Dispatch Event
-                eventManager.publish(new GiftSubscriptionsEvent(event, channel, user != null ? user : ANONYMOUS_GIFTER, subPlan, subsGifted, subsGiftedTotal));
+                eventManager.publish(new GiftSubscriptionsEvent(event, channel, user != null ? user : ANONYMOUS_GIFTER, subPlan, subsGifted, subsGiftedTotal, giftId));
                 return true;
             }
             // Upgrading from a gifted sub

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
 import lombok.EqualsAndHashCode;
@@ -64,6 +65,23 @@ public class GiftSubscriptionsEvent extends AbstractChannelEvent implements Mirr
         this.subscriptionPlan = subscriptionPlan;
         this.count = count;
         this.totalCount = totalCount;
+    }
+
+    /**
+     * @return the raw subscription plan
+     * @deprecated in favor of {@link #getTier()}
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0.0")
+    public String getSubscriptionPlan() {
+        return subscriptionPlan;
+    }
+
+    /**
+     * @return the tier of the subscription that was gifted
+     */
+    public SubscriptionPlan getTier() {
+        return SubscriptionPlan.fromString(this.subscriptionPlan);
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/channel/GiftSubscriptionsEvent.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.chat.events.channel;
 
 import com.github.twitch4j.chat.events.AbstractChannelEvent;
+import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.SubscriptionPlan;
 import com.github.twitch4j.common.events.domain.EventChannel;
 import com.github.twitch4j.common.events.domain.EventUser;
@@ -25,27 +26,35 @@ public class GiftSubscriptionsEvent extends AbstractChannelEvent implements Mirr
      */
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
-    private IRCMessageEvent messageEvent;
+    IRCMessageEvent messageEvent;
 
     /**
      * Event Target User
      */
-    private EventUser user;
+    EventUser user;
 
     /**
      * The Subscription
      */
-    private String subscriptionPlan;
+    String subscriptionPlan;
 
     /**
      * X subscriptions gifted
      */
-    private Integer count;
+    int count;
 
     /**
      * X subscriptions gifted totally
      */
-    private Integer totalCount;
+    int totalCount;
+
+    /**
+     * A unique identifier that links the community gift event to each individual recipient gifted event.
+     *
+     * @apiNote While this field is undocumented in irc, it is equivalent to the documented eventsub field {@code community_gift_id}.
+     */
+    @Unofficial
+    String giftId;
 
     /**
      * Event Constructor
@@ -58,13 +67,14 @@ public class GiftSubscriptionsEvent extends AbstractChannelEvent implements Mirr
      * @param totalCount       The amount the user gifted in total (all time)
      */
     @ApiStatus.Internal
-    public GiftSubscriptionsEvent(IRCMessageEvent event, EventChannel channel, EventUser user, String subscriptionPlan, Integer count, Integer totalCount) {
+    public GiftSubscriptionsEvent(IRCMessageEvent event, EventChannel channel, EventUser user, String subscriptionPlan, int count, int totalCount, String giftId) {
         super(channel);
         this.messageEvent = event;
         this.user = user;
         this.subscriptionPlan = subscriptionPlan;
         this.count = count;
         this.totalCount = totalCount;
+        this.giftId = giftId;
     }
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `GiftSubscriptionsEvent#getTier` that yields `SubscriptionPlan` rather than `String`
* Add `GiftSubscriptionsEvent#getGiftId` that is equivalent to eventsub's `CommunitySubGift#getId`

### Additional Information
Requested at https://discord.com/channels/143001431388061696/268348117919858688/1325474541731840051

sample irc message: `@system-msg=boymeetsmini\sis\sgifting\s4\sTier\s1\sSubs\sto\sDoodleBirb's\scommunity!\sThey've\sgifted\sa\stotal\sof\s14\sin\sthe\schannel!;tmi-sent-ts=1738900918148;display-name=boymeetsmini;room-id=569880943;emotes=;badge-info=subscriber/12;msg-param-community-gift-id=16548143234047877033;id=91439900-0bf7-4a81-a36e-c629c76567ef;rm-received-ts=1738900918254;user-type=;badges=subscriber/12,sub-gifter/10;msg-param-mass-gift-count=4;msg-param-goal-target-contributions=15;msg-param-goal-current-contributions=9;vip=0;login=boymeetsmini;user-id=544451214;color=#8A2BE2;msg-param-goal-user-contributions=4;flags=;mod=0;msg-id=submysterygift;msg-param-goal-contribution-type=NEW_SUBS;subscriber=1;historical=1;msg-param-sub-plan=1000;msg-param-sender-count=14;msg-param-origin-id=16548143234047877033 :tmi.twitch.tv USERNOTICE #doodlebirb`