### PR TITLE
feat: support source only shared chat messages

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Data
@@ -78,6 +79,13 @@ public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent i
     @Unofficial
     public List<AutoModFlag> getFlags() {
         return this.getMessageEvent().getFlags();
+    }
+
+    /**
+     * @return whether a message delivered during a shared chat session is only sent to the source channel.
+     */
+    public Optional<Boolean> isSourceOnly() {
+        return messageEvent.getTagValue("source-only").map(Boolean::parseBoolean);
     }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatMessageEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatMessageEvent.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.twitch4j.eventsub.domain.chat.Badge;
 import com.github.twitch4j.eventsub.domain.chat.Cheer;
 import com.github.twitch4j.eventsub.domain.chat.Message;
@@ -11,6 +12,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -121,5 +123,15 @@ public class ChannelChatMessageEvent extends ChannelChatUserEvent {
      */
     @Nullable
     private List<Badge> sourceBadges;
+
+    /**
+     * Optional: Determines if a message delivered during a shared chat session is only sent to the source channel.
+     * <p>
+     * Has no effect if the message is not sent during a shared chat session.
+     */
+    @Nullable
+    @Accessors(fluent = true)
+    @JsonProperty("is_source_only")
+    private Boolean isSourceOnly;
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatMessage.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatMessage.java
@@ -50,4 +50,21 @@ public class ChatMessage {
     @Nullable
     String replyParentMessageId;
 
+    /**
+     * Whether the chat message is sent only to the source channel (broadcaster_id) during a shared chat session.
+     * <p>
+     * NOTE: Can only be set when utilizing an App Access Token at the top.
+     * Cannot be specified when a User Access Token is used and will result in a 400 error.
+     * <p>
+     * Has no effect if the message is not sent during a shared chat session.
+     * <p>
+     * Introduced in April 2025, the default is temporarily “false”.
+     * On May 19, 2025 the default value for the for_source_only parameter will be updated to “true”
+     * (i.e. chat messages will be only shared with the source channel by default).
+     * If you prefer to send a chat message to both channels in a shared chat session,
+     * make sure this parameter is explicitly set to “false” in your API request before May 19.
+     */
+    @Nullable
+    Boolean forSourceOnly;
+
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatMessage.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatMessage.java
@@ -67,4 +67,21 @@ public class ChatMessage {
     @Nullable
     Boolean forSourceOnly;
 
+    /**
+     * Legacy Constructor
+     *
+     * @param broadcasterId        The ID of the broadcaster whose chat room the message will be sent to.
+     * @param senderId             The ID of the user sending the message.
+     * @param message              The message to send.
+     * @param replyParentMessageId The ID of the chat message being replied to, if any.
+     * @deprecated in favor of {@link ChatMessage#ChatMessage(String, String, String, String, Boolean)} or {@link ChatMessage#builder()}
+     */
+    @Deprecated
+    public ChatMessage(@NotNull String broadcasterId, @NotNull String senderId, @NotNull String message, @Nullable String replyParentMessageId) {
+        this.broadcasterId = broadcasterId;
+        this.senderId = senderId;
+        this.message = message;
+        this.replyParentMessageId = replyParentMessageId;
+    }
+
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Allow specifying `for_source_only` in `TwitchHelix#sendChatMessage`
* Add `AbstractChannelMessageEvent#isSourceOnly` (IRC)
* Add `ChannelChatMessageEvent#isSourceOnly` (EventSub)

### Additional Information
2025-04-10 changelog entry: https://dev.twitch.tv/docs/change-log
