### PR TITLE
feat(pubsub): add stream together view count field

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/VideoPlaybackData.java
@@ -1,9 +1,14 @@
 package com.github.twitch4j.pubsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.twitch4j.common.enums.TwitchEnum;
+import com.github.twitch4j.common.util.TwitchEnumDeserializer;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
 @Data
 @Setter(onMethod_ = { @Deprecated })
@@ -21,21 +26,39 @@ public class VideoPlaybackData {
     /**
      * Sent when {@link #getType()} is {@link Type#STREAM_UP}.
      */
+    @Nullable
     private Integer playDelay;
 
     /**
      * Sent when {@link #getType()} is {@link Type#VIEW_COUNT}.
      */
+    @Nullable
     private Integer viewers;
+
+    /**
+     * Sent when {@link #getType()} is {@link Type#VIEW_COUNT}.
+     * <p>
+     * Only positive if the channel is in a Stream Together session.
+     */
+    @Nullable
+    private Integer collaborationViewers;
+
+    /**
+     * Sent when {@link #getType()} is {@link Type#VIEW_COUNT}.
+     */
+    @JsonDeserialize(using = TwitchEnumDeserializer.class)
+    private TwitchEnum<CollaborationStatus> collaborationStatus;
 
     /**
      * Sent when {@link #getType()} is {@link Type#COMMERCIAL}.
      */
+    @Nullable
     private Integer length;
 
     /**
      * Sent when {@link #getType()} is {@link Type#COMMERCIAL}.
      */
+    @Nullable
     private Boolean scheduled;
 
     @RequiredArgsConstructor
@@ -62,5 +85,23 @@ public class VideoPlaybackData {
 
             return null;
         }
+    }
+
+    public enum CollaborationStatus {
+        /**
+         * Channel is not in a Stream Together session.
+         */
+        NONE,
+
+        /**
+         * Channel is engaged in a Stream Together session.
+         */
+        IN_COLLABORATION,
+
+        /**
+         * Unknown collaboration status; please report to our issue tracker!
+         */
+        @JsonEnumDefaultValue
+        UNKNOWN
     }
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add shared viewership statistic to `VideoPlaybackEvent` (unofficial pubsub)

### Additional Information
https://blog.twitch.tv/en/2024/12/05/shared-viewership/

