### PR TITLE
feat(pubsub): add unofficial clips leaderboard events

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/ITwitchPubSub.java
@@ -328,6 +328,11 @@ public interface ITwitchPubSub extends AutoCloseable {
     }
 
     @Unofficial
+    default PubSubSubscription listenForChannelClipsLeaderboardEvents(OAuth2Credential credential, String channelId) {
+        return listenOnTopic(PubSubType.LISTEN, credential, "leaderboard-events-v1.clips-" + channelId);
+    }
+
+    @Unofficial
     @Deprecated
     default PubSubSubscription listenForChannelPrimeGiftStatusEvents(OAuth2Credential credential, String channelId) {
         return listenOnTopic(PubSubType.LISTEN, credential, "channel-prime-gifting-status." + channelId);

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClipsLeaderboard.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/ClipsLeaderboard.java
@@ -1,0 +1,34 @@
+package com.github.twitch4j.pubsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class ClipsLeaderboard {
+    private String type; // e.g., "clips-leaderboard-update"
+    private String broadcasterId;
+    private String timeUnit; // e.g., "DAY"
+    private Instant endTime;
+    private List<Entry> newLeaderboard;
+
+    @Data
+    @Setter(AccessLevel.PRIVATE)
+    public static class Entry {
+        private int rank;
+        private String curatorId;
+        private String curatorDisplayName;
+        private String curatorLogin;
+        private String clipId;
+        private String clipSlug;
+        private String clipAssetId;
+        private String clipTitle;
+        private String clipThumbnailUrl;
+        private String clipUrl;
+        private int score;
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ClipsLeaderboardEvent.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/events/ClipsLeaderboardEvent.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.pubsub.events;
+
+import com.github.twitch4j.common.events.TwitchEvent;
+import com.github.twitch4j.pubsub.domain.ClipsLeaderboard;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ClipsLeaderboardEvent extends TwitchEvent {
+    ClipsLeaderboard leaderboard;
+
+    public String getChannelId() {
+        return leaderboard.getBroadcasterId();
+    }
+}

--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/handlers/LeaderboardHandler.java
@@ -2,8 +2,10 @@ package com.github.twitch4j.pubsub.handlers;
 
 import com.github.twitch4j.common.events.TwitchEvent;
 import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.pubsub.domain.ClipsLeaderboard;
 import com.github.twitch4j.pubsub.domain.Leaderboard;
 import com.github.twitch4j.pubsub.events.BitsLeaderboardEvent;
+import com.github.twitch4j.pubsub.events.ClipsLeaderboardEvent;
 import com.github.twitch4j.pubsub.events.SubLeaderboardEvent;
 
 class LeaderboardHandler implements TopicHandler {
@@ -14,6 +16,11 @@ class LeaderboardHandler implements TopicHandler {
 
     @Override
     public TwitchEvent apply(Args args) {
+        if (args.getLastTopicPart().startsWith("clips-")) {
+            ClipsLeaderboard clipsLeaderboard = TypeConvert.jsonToObject(args.getRawMessage(), ClipsLeaderboard.class);
+            return new ClipsLeaderboardEvent(clipsLeaderboard);
+        }
+
         Leaderboard leaderboard = TypeConvert.jsonToObject(args.getRawMessage(), Leaderboard.class);
         switch (leaderboard.getIdentifier().getDomain()) {
             case "bits-usage-by-channel-v1":


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ITwitchPubSub#listenForChannelClipsLeaderboardEvents` which fires `ClipsLeaderboardEvent`

### Additional Information
Feature is still in experiment phase, being rolled out to more channels https://x.com/TwitchSupport/status/1917278352081117331
