### PR TITLE
fix(pubsub): add more goal types

### DIFF
--- a/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatorGoal.java
+++ b/pubsub/src/main/java/com/github/twitch4j/pubsub/domain/CreatorGoal.java
@@ -1,10 +1,15 @@
 package com.github.twitch4j.pubsub.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
 
 @Data
 @Setter(AccessLevel.PRIVATE)
@@ -16,11 +21,50 @@ public class CreatorGoal {
     private String description;
     private Integer currentContributions;
     private Integer targetContributions;
+    private Instant createdAt;
+    private String progressBarAccentColor;
+    private String progressBarBackgroundColor;
+
+    @Nullable
+    @JsonProperty("shouldAutoIncrement")
+    @Accessors(fluent = true)
+    private Boolean shouldAutoIncrement;
 
     public enum Type {
+        /**
+         * Followers
+         */
         FOLLOWERS,
+
+        /**
+         * Bits cheers
+         */
+        NEW_BITS,
+
+        /**
+         * New cheerers
+         */
+        NEW_CHEERERS,
+
+        /**
+         * Total subscriber count
+         */
+        SUBS,
+
+        /**
+         * Total subscriber points
+         */
         SUB_POINTS,
-        NEW_SUB_POINTS
+
+        /**
+         * New subscriber points
+         */
+        NEW_SUB_POINTS,
+
+        /**
+         * New subscribers
+         */
+        NEW_SUBS
     }
 
     public enum State {


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed
Avoids an exception when one of these newer goal types would be deserialized

### Changes Proposed
* Add more creator goal types for unofficial pubsub
* Include auto-increment flag and colors to the unofficial payload

### Additional Information
https://help.twitch.tv/s/article/creator-goals?language=en_US
