### PR TITLE
feat(helix): add getHypeTrainStatus endpoint

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1745,9 +1745,11 @@ public interface TwitchHelix {
      * @param limit         Maximum number of objects to return. Maximum: 100. Default: 1. (optional)
      * @param after         Cursor for forward pagination (optional)
      * @return HypeTrainEventList
+     * @deprecated Scheduled for removal on December 4, 2025. Use {@link #getHypeTrainStatus(String, String)} instead.
      */
     @RequestLine("GET /hypetrain/events?broadcaster_id={broadcaster_id}&first={first}&after={after}&cursor={after}")
     @Headers("Authorization: Bearer {token}")
+    @Deprecated
     HystrixCommand<HypeTrainEventList> getHypeTrainEvents(
         @Param("token") String authToken,
         @Param("broadcaster_id") String broadcasterId,
@@ -1766,7 +1768,7 @@ public interface TwitchHelix {
      * @param after         Cursor for forward pagination (optional)
      * @return HypeTrainEventList
      * @see <a href="https://discuss.dev.twitch.tv/t/get-hype-train-events-api-endpoint-id-query-parameter-deprecation/37613">id parameter deprecation announcement</a>
-     * @deprecated Use {@link #getHypeTrainEvents(String, String, Integer, String)} instead (no id argument)
+     * @deprecated Scheduled for removal on December 4, 2025. Use {@link #getHypeTrainStatus(String, String)} instead.
      */
     @Deprecated
     default HystrixCommand<HypeTrainEventList> getHypeTrainEvents(

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -1779,6 +1779,21 @@ public interface TwitchHelix {
         return this.getHypeTrainEvents(authToken, broadcasterId, limit, after);
     }
 
+    /**
+     * Get the status of a Hype Train for the specified broadcaster.
+     *
+     * @param authToken User access token from the broadcaster (scope: channel:read:hype_train)
+     * @param broadcasterId The User ID of the channel broadcaster.
+     * @return {@link HypeTrainStatusWrapper}
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHANNEL_HYPE_TRAIN_READ
+     */
+    @RequestLine("GET /hypetrain/status?broadcaster_id={broadcaster_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<HypeTrainStatusWrapper> getHypeTrainStatus(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId
+    );
+
     @RequestLine("GET /ingests")
     HystrixCommand<IngestServerList> getIngestServers(URI baseUrl);
 

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrain.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrain.java
@@ -1,0 +1,113 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.twitch4j.eventsub.domain.Contribution;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class HypeTrain {
+
+    /**
+     * The Hype Train ID.
+     */
+    private String id;
+
+    /**
+     * The broadcaster ID.
+     */
+    private String broadcasterUserId;
+
+    /**
+     * The broadcaster login.
+     */
+    private String broadcasterUserLogin;
+
+    /**
+     * The broadcaster display name.
+     */
+    private String broadcasterUserName;
+
+    /**
+     * The current level of the Hype Train.
+     */
+    private int level;
+
+    /**
+     * Total points contributed to the Hype Train.
+     */
+    private int total;
+
+    /**
+     * The number of points contributed to the Hype Train at the current level.
+     */
+    private int progress;
+
+    /**
+     * The number of points required to reach the next level.
+     */
+    private int goal;
+
+    /**
+     * The contributors with the most points contributed.
+     */
+    private List<Contribution> topContributions;
+
+    /**
+     * The broadcasters participating in the shared Hype Train.
+     * Null if the Hype Train is not shared.
+     */
+    private @Nullable List<SharedChatParticipant> sharedTrainParticipants;
+
+    /**
+     * The time when the Hype Train started.
+     */
+    private Instant startedAt;
+
+    /**
+     * The time when the Hype Train expires.
+     * The expiration is extended when the Hype Train reaches a new level.
+     */
+    private Instant expiresAt;
+
+    /**
+     * The type of the Hype Train.
+     */
+    private Type type;
+
+    /**
+     * Indicates if the Hype Train is shared.
+     * When true, {@link #getSharedTrainParticipants()} will contain the list of broadcasters the train is shared with.
+     */
+    private @JsonProperty("is_shared_train") boolean isSharedTrain;
+
+    /**
+     * @see <a href="https://help.twitch.tv/s/article/hype-train-guide?language=en_US#special">Official Help Article</a>
+     */
+    public enum Type {
+
+        /**
+         * After reaching Level 5 of the Treasure Train, a 35% discount will be unlocked on purchases of 5 or more Tier 1 single-month gift subscriptions.
+         */
+        TREASURE,
+
+        /**
+         * Viewers will receive the Golden Kappa emote regardless of what level they contributed at,
+         * so long as the Hype Train reaches at least Level 1.
+         */
+        GOLDEN_KAPPA,
+
+        /**
+         * A regular hype train.
+         */
+        REGULAR
+
+    }
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEvent.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainEvent.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Data
 @Setter(AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Deprecated
 public class HypeTrainEvent {
     /**
      * The distinct ID of the event

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainMilestone.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainMilestone.java
@@ -1,0 +1,28 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class HypeTrainMilestone {
+
+    /**
+     * The level of the record Hype Train.
+     */
+    private int level;
+
+    /**
+     * Total points contributed to the record Hype Train.
+     */
+    private int total;
+
+    /**
+     * The time when the record was achieved.
+     */
+    private Instant achievedAt;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainStatus.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainStatus.java
@@ -1,0 +1,30 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class HypeTrainStatus {
+
+    /**
+     * An object describing the current Hype Train.
+     * Null if a Hype Train is not active.
+     */
+    private @Nullable HypeTrain current;
+
+    /**
+     * An object with information about the channel’s Hype Train records.
+     * Null if a Hype Train has not occurred.
+     */
+    private @Nullable HypeTrainMilestone allTimeHigh;
+
+    /**
+     * An object with information about the channel’s shared Hype Train records.
+     * Null if a Hype Train has not occurred.
+     */
+    private @Nullable HypeTrainMilestone sharedAllTimeHigh;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainStatusWrapper.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/HypeTrainStatusWrapper.java
@@ -1,0 +1,8 @@
+package com.github.twitch4j.helix.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class HypeTrainStatusWrapper extends ValueWrapper<HypeTrainStatus> {}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SharedChatParticipant.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/SharedChatParticipant.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.helix.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,6 +12,7 @@ public class SharedChatParticipant {
     /**
      * The User ID of the participant channel.
      */
+    @JsonAlias("broadcaster_user_id")
     private String broadcasterId;
 
 }

--- a/rest-helix/src/test/java/com/github/twitch4j/helix/domain/HypeTrainTest.java
+++ b/rest-helix/src/test/java/com/github/twitch4j/helix/domain/HypeTrainTest.java
@@ -1,0 +1,59 @@
+package com.github.twitch4j.helix.domain;
+
+import com.github.twitch4j.common.util.TypeConvert;
+import com.github.twitch4j.eventsub.domain.Contribution;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unittest")
+class HypeTrainTest {
+
+    @Test
+    void deserialize() {
+        HypeTrainStatus data = TypeConvert.jsonToObject(
+            "{\"current\":{\"id\":\"1b0AsbInCHZW2SQFQkCzqN07Ib2\",\"broadcaster_user_id\":\"1337\",\"broadcaster_user_login\":\"cool_user\",\"broadcaster_user_name\":\"Cool_User\",\"level\":2,\"total\":700,\"progress\":200,\"goal\":1000,\"top_contributions\":[{\"user_id\":\"123\",\"user_login\":\"pogchamp\",\"user_name\":\"PogChamp\",\"type\":\"bits\",\"total\":50},{\"user_id\":\"456\",\"user_login\":\"kappa\",\"user_name\":\"Kappa\",\"type\":\"subscription\",\"total\":45}],\"shared_train_participants\":[{\"broadcaster_user_id\":\"456\",\"broadcaster_user_login\":\"pogchamp\",\"broadcaster_user_name\":\"PogChamp\"},{\"broadcaster_user_id\":\"321\",\"broadcaster_user_login\":\"pogchamp\",\"broadcaster_user_name\":\"PogChamp\"}],\"started_at\":\"2020-07-15T17:16:03.17106713Z\",\"expires_at\":\"2020-07-15T17:16:11.17106713Z\",\"type\":\"golden_kappa\",\"is_shared_train\":true},\"all_time_high\":{\"level\":6,\"total\":2850,\"achieved_at\":\"2020-04-24T20:12:21.003802269Z\"},\"shared_all_time_high\":{\"level\":16,\"total\":23850,\"achieved_at\":\"2020-04-27T20:12:21.003802269Z\"}}",
+            HypeTrainStatus.class
+        );
+
+        HypeTrain train = data.getCurrent();
+        assertNotNull(train);
+        assertEquals("1b0AsbInCHZW2SQFQkCzqN07Ib2", train.getId());
+        assertEquals("1337", train.getBroadcasterUserId());
+        assertEquals("cool_user", train.getBroadcasterUserLogin());
+        assertEquals("Cool_User", train.getBroadcasterUserName());
+        assertEquals(2, train.getLevel());
+        assertEquals(700, train.getTotal());
+        assertEquals(200, train.getProgress());
+        assertEquals(1000, train.getGoal());
+        assertEquals(Instant.parse("2020-07-15T17:16:03.17106713Z"), train.getStartedAt());
+        assertEquals(Instant.parse("2020-07-15T17:16:11.17106713Z"), train.getExpiresAt());
+        assertEquals(HypeTrain.Type.GOLDEN_KAPPA, train.getType());
+        assertTrue(train.isSharedTrain());
+        assertNotNull(train.getTopContributions());
+        assertEquals(2, train.getTopContributions().size());
+        assertEquals("123", train.getTopContributions().get(0).getUserId());
+        assertEquals("pogchamp", train.getTopContributions().get(0).getUserLogin());
+        assertEquals(Contribution.Type.BITS, train.getTopContributions().get(0).getType());
+        assertEquals(50, train.getTopContributions().get(0).getTotal());
+        assertEquals(Contribution.Type.SUBSCRIPTION, train.getTopContributions().get(1).getType());
+        assertEquals(45, train.getTopContributions().get(1).getTotal());
+        assertNotNull(train.getSharedTrainParticipants());
+        assertEquals(2, train.getSharedTrainParticipants().size());
+        assertEquals("456", train.getSharedTrainParticipants().get(0).getBroadcasterId());
+
+        assertNotNull(data.getAllTimeHigh());
+        assertEquals(6, data.getAllTimeHigh().getLevel());
+        assertEquals(2850, data.getAllTimeHigh().getTotal());
+        assertEquals(Instant.parse("2020-04-24T20:12:21.003802269Z"), data.getAllTimeHigh().getAchievedAt());
+
+        assertNotNull(data.getSharedAllTimeHigh());
+        assertEquals(16, data.getSharedAllTimeHigh().getLevel());
+        assertEquals(23850, data.getSharedAllTimeHigh().getTotal());
+        assertEquals(Instant.parse("2020-04-27T20:12:21.003802269Z"), data.getSharedAllTimeHigh().getAchievedAt());
+    }
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#getHypeTrainStatus`
* Deprecate `TwitchHelix#getHypeTrainEvents`

### Additional Information
* `getHypeTrainStatus` open beta started on 2025‑07‑31
* `getHypeTrainStatus` was promoted to generally available on 2025‑08‑19
* `getHypeTrainEvents` will be decommissioned on 2025-12-04: https://discuss.dev.twitch.com/t/legacy-get-hype-train-events-api-and-eventsub-hype-train-v1-subscription-types-deprecation-and-withdrawal-timeline/64299
