### PR TITLE
feat(helix): add method to get eventsub subscriptions for a conduit id

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -950,6 +950,22 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets a list of EventSub subscriptions that the client in the access token created.
+     *
+     * @param authToken App access token
+     * @param conduitId Filter subscriptions by conduit ID.
+     * @param after     The cursor used to get the next page of results.
+     * @return {@link EventSubSubscriptionList}
+     */
+    @RequestLine("GET /eventsub/subscriptions?conduit_id={conduit_id}&after={after}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<EventSubSubscriptionList> getEventSubSubscriptionsByConduit(
+        @Param("token") String authToken,
+        @Param("conduit_id") String conduitId,
+        @Param("after") String after
+    );
+
+    /**
      * Get a list of your EventSub subscriptions.
      *
      * @param authToken Required: App Access Token.


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#getEventSubSubscriptionsByConduit`

### Additional Information
2026‑04‑17 changelog entry https://dev.twitch.tv/docs/change-log
