### PR TITLE
fix(helix): avoid serializing empty lists within ChannelInformation

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChannelInformation.java
@@ -26,7 +26,7 @@ import java.util.List;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ChannelInformation {
 
     /**
@@ -82,9 +82,8 @@ public class ChannelInformation {
      * A channel may specify a maximum of 10 tags.
      * Each tag is limited to a maximum of 25 characters and may not be an empty string or contain spaces or special characters.
      * Tags are case-insensitive. For readability, consider using camelCasing or PascalCasing.
-     * <p>
-     * For {@link com.github.twitch4j.helix.TwitchHelix#updateChannelInformation(String, String, ChannelInformation)},
-     * setting this to an empty list <a href="https://github.com/twitchdev/issues/issues/708">should</a> result in all tags being removed from the channel.
+     *
+     * @see <a href="https://github.com/twitchdev/issues/issues/708">TwitchDev Issue Report</a> if trying to clear the channel's tags
      */
     private List<String> tags;
 


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Related Issues
* https://redirect.github.com/twitchdev/issues/issues/708
* https://redirect.github.com/twitchdev/issues/issues/995
* https://redirect.github.com/twitchdev/issues/issues/1165 
* https://redirect.github.com/twitchdev/issues/issues/1166

### Changes Proposed
* Change `@JsonInclude` on `ChannelInformation` to `NON_EMPTY` instead of `NON_NULL`

### Additional Information
https://discord.com/channels/143001431388061696/268348117919858688/1502262350391279677

https://discord.com/channels/504015559252377601/523675960797691915/1502219774942380102
