### PR TITLE
feat(helix): add new pin message endpoints

### DIFF
--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -609,6 +609,9 @@ public interface TwitchHelix {
      * <p>
      * Only one mod-pinned message can be active per channel at a time.
      * If a mod-pinned message already exists, it is automatically replaced.
+     * <p>
+     * When using an app access token, the broadcaster must authorize the channel:bot scope to your client id
+     * and a moderator (or the broadcaster) must authorize the moderator:manage:chat_messages and user:bot scopes.
      *
      * @param authToken       User access token (scope: moderator:manage:chat_messages) or App access token (scopes: moderator:manage:chat_messages, user:bot, channel:bot).
      * @param broadcasterId   The ID of the broadcaster that owns the chat room.
@@ -621,6 +624,30 @@ public interface TwitchHelix {
     @RequestLine("PUT /chat/pins?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&message_id={message_id}&duration_seconds={duration_seconds}")
     @Headers("Authorization: Bearer {token}")
     HystrixCommand<Void> pinChatMessage(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("moderator_id") String moderatorId,
+        @Param("message_id") String messageId,
+        @Param("duration_seconds") @Nullable Integer durationSeconds
+    );
+
+    /**
+     * Updates the duration of an existing pinned chat message.
+     * <p>
+     * When using an app access token, the broadcaster must authorize the channel:bot scope to your client id
+     * and a moderator (or the broadcaster) must authorize the moderator:manage:chat_messages and user:bot scopes.
+     *
+     * @param authToken       User access token (scope: moderator:manage:chat_messages) or App access token (scopes: moderator:manage:chat_messages, user:bot, channel:bot).
+     * @param broadcasterId   The ID of the broadcaster that owns the chat room.
+     * @param moderatorId     The ID of the broadcaster or a user that has permission to moderate the broadcaster's chat room.
+     * @param messageId       The ID of the message to pin.
+     * @param durationSeconds Optional: The new number of seconds the message should remain pinned, starting from now. Minimum: 30. Maximum: 1800. If not specified, the message will be pinned until the stream ends.
+     * @return 204 No Content upon a successful call
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_MESSAGES_MANAGE
+     */
+    @RequestLine("PATCH /chat/pins?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&message_id={message_id}&duration_seconds={duration_seconds}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> updatePinnedChatMessage(
         @Param("token") String authToken,
         @Param("broadcaster_id") String broadcasterId,
         @Param("moderator_id") String moderatorId,

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -605,6 +605,27 @@ public interface TwitchHelix {
     );
 
     /**
+     * Gets the currently pinned message for the specified broadcaster's chat room, including message fragments.
+     * <p>
+     * Only one mod-pinned message can be active per channel at a time.
+     * <p>
+     * When using an app access token, the broadcaster must authorize the channel:bot scope to your client id
+     * and a moderator (or the broadcaster) must authorize the moderator:manage:chat_messages and user:bot scopes.
+     *
+     * @param authToken     User access token (scope: moderator:manage:chat_messages) or App access token (scopes: moderator:manage:chat_messages, user:bot, channel:bot).
+     * @param broadcasterId The ID of the broadcaster that owns the chat room.
+     * @param moderatorId   The ID of the broadcaster or a user that has permission to moderate the broadcaster's chat room.
+     * @return {@link PinnedMessage}
+     */
+    @RequestLine("GET /chat/pins?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<ValueWrapper<PinnedMessage>> getPinnedChatMessage(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("moderator_id") String moderatorId
+    );
+
+    /**
      * Pins a chat message to the top of the specified broadcaster’s chat room.
      * <p>
      * Only one mod-pinned message can be active per channel at a time.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -656,6 +656,28 @@ public interface TwitchHelix {
     );
 
     /**
+     * Unpins a pinned chat message from the specified broadcaster's chat room.
+     * <p>
+     * When using an app access token, the broadcaster must authorize the channel:bot scope to your client id and a
+     * moderator (or the broadcaster) must authorize the moderator:manage:chat_messages and user:bot scopes to the client id.
+     *
+     * @param authToken       User access token (scope: moderator:manage:chat_messages) or App access token (scopes: moderator:manage:chat_messages, user:bot, channel:bot).
+     * @param broadcasterId   The ID of the broadcaster that owns the chat room.
+     * @param moderatorId     The ID of the broadcaster or a user that has permission to moderate the broadcaster's chat room.
+     * @param messageId       The ID of the message to unpin.
+     * @return 204 No Content upon a successful call
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_MESSAGES_MANAGE
+     */
+    @RequestLine("DELETE /chat/pins?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&message_id={message_id}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> unpinChatMessage(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("moderator_id") String moderatorId,
+        @Param("message_id") String messageId
+    );
+
+    /**
      * Sends a Shoutout to the specified broadcaster.
      * <p>
      * Rate Limits: The broadcaster may send a Shoutout once every 2 minutes.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -605,6 +605,30 @@ public interface TwitchHelix {
     );
 
     /**
+     * Pins a chat message to the top of the specified broadcaster’s chat room.
+     * <p>
+     * Only one mod-pinned message can be active per channel at a time.
+     * If a mod-pinned message already exists, it is automatically replaced.
+     *
+     * @param authToken       User access token (scope: moderator:manage:chat_messages) or App access token (scopes: moderator:manage:chat_messages, user:bot, channel:bot).
+     * @param broadcasterId   The ID of the broadcaster that owns the chat room.
+     * @param moderatorId     The ID of the broadcaster or a user that has permission to moderate the broadcaster's chat room.
+     * @param messageId       The ID of the message to pin.
+     * @param durationSeconds Optional: The number of seconds the message should be pinned for. Minimum: 30. Maximum: 1800. If not specified, the message will be pinned until the stream ends.
+     * @return 204 No Content upon a successful call
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_MESSAGES_MANAGE
+     */
+    @RequestLine("PUT /chat/pins?broadcaster_id={broadcaster_id}&moderator_id={moderator_id}&message_id={message_id}&duration_seconds={duration_seconds}")
+    @Headers("Authorization: Bearer {token}")
+    HystrixCommand<Void> pinChatMessage(
+        @Param("token") String authToken,
+        @Param("broadcaster_id") String broadcasterId,
+        @Param("moderator_id") String moderatorId,
+        @Param("message_id") String messageId,
+        @Param("duration_seconds") @Nullable Integer durationSeconds
+    );
+
+    /**
      * Sends a Shoutout to the specified broadcaster.
      * <p>
      * Rate Limits: The broadcaster may send a Shoutout once every 2 minutes.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatMessage.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatMessage.java
@@ -68,13 +68,25 @@ public class ChatMessage {
     Boolean forSourceOnly;
 
     /**
+     * If true, the message will be sent and immediately pinned. Default: false.
+     * <p>
+     * Cannot be combined with reply_parent_message_id or for_source_only.
+     * <p>
+     * When pin is true, additionally requires the moderator:manage:chat_messages scope and the sender must be the broadcaster or a moderator.
+     * <p>
+     * Messages pinned via this endpoint are always pinned for 20 minutes. If the pin fails, the message is not sent.
+     */
+    @Nullable
+    Boolean pin;
+
+    /**
      * Legacy Constructor
      *
      * @param broadcasterId        The ID of the broadcaster whose chat room the message will be sent to.
      * @param senderId             The ID of the user sending the message.
      * @param message              The message to send.
      * @param replyParentMessageId The ID of the chat message being replied to, if any.
-     * @deprecated in favor of {@link ChatMessage#ChatMessage(String, String, String, String, Boolean)} or {@link ChatMessage#builder()}
+     * @deprecated in favor of {@link ChatMessage#ChatMessage(String, String, String, String, Boolean, Boolean)} or {@link ChatMessage#builder()}
      */
     @Deprecated
     public ChatMessage(@NotNull String broadcasterId, @NotNull String senderId, @NotNull String message, @Nullable String replyParentMessageId) {
@@ -82,6 +94,25 @@ public class ChatMessage {
         this.senderId = senderId;
         this.message = message;
         this.replyParentMessageId = replyParentMessageId;
+    }
+
+    /**
+     * Legacy Constructor
+     *
+     * @param broadcasterId        The ID of the broadcaster whose chat room the message will be sent to.
+     * @param senderId             The ID of the user sending the message.
+     * @param message              The message to send.
+     * @param replyParentMessageId The ID of the chat message being replied to, if any.
+     * @param forSourceOnly        Whether the chat message is sent only to the source channel during a shared chat session.
+     * @deprecated in favor of {@link ChatMessage#ChatMessage(String, String, String, String, Boolean, Boolean)} or {@link ChatMessage#builder()}
+     */
+    @Deprecated
+    public ChatMessage(@NotNull String broadcasterId, @NotNull String senderId, @NotNull String message, @Nullable String replyParentMessageId, @Nullable Boolean forSourceOnly) {
+        this.broadcasterId = broadcasterId;
+        this.senderId = senderId;
+        this.message = message;
+        this.replyParentMessageId = replyParentMessageId;
+        this.forSourceOnly = forSourceOnly;
     }
 
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/PinnedMessage.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/PinnedMessage.java
@@ -1,0 +1,83 @@
+package com.github.twitch4j.helix.domain;
+
+import com.github.twitch4j.eventsub.domain.chat.Message;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+
+@Data
+@With
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@AllArgsConstructor(onConstructor_ = { @ApiStatus.Internal })
+public class PinnedMessage {
+
+    /**
+     * The ID of the pinned chat message.
+     */
+    private String messageId;
+
+    /**
+     * The ID of the broadcaster.
+     */
+    private String broadcasterId;
+
+    /**
+     * The ID of the user who sent the pinned message.
+     */
+    private String senderUserId;
+
+    /**
+     * The login of the user who sent the pinned message.
+     */
+    private String senderUserLogin;
+
+    /**
+     * The display name of the user who sent the pinned message.
+     */
+    private String senderUserName;
+
+    /**
+     * The ID of the user who pinned the message.
+     */
+    private String pinnedByUserId;
+
+    /**
+     * The login of the user who pinned the message.
+     */
+    private String pinnedByUserLogin;
+
+    /**
+     * The display name of the user who pinned the message.
+     */
+    private String pinnedByUserName;
+
+    /**
+     * The pinned message content.
+     */
+    private Message message;
+
+    /**
+     * Timestamp of when the message was pinned.
+     */
+    private Instant startsAt;
+
+    /**
+     * The expiry timestamp. Null if pinned until stream ends.
+     */
+    @Nullable
+    private Instant endsAt;
+
+    /**
+     * Timestamp of the last update to this pinned message.
+     */
+    private Instant updatedAt;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#getPinnedChatMessage`
* Add `TwitchHelix#pinChatMessage`
* Add `TwitchHelix#updatePinnedChatMessage`
* Add `TwitchHelix#unpinChatMessage`
* Add `pin` optional parameter to `ChatMessage` for `TwitchHelix#sendChatMessage`

### Additional Information
2026‑05‑15: added as open beta
2026‑05‑29: promoted to GA
https://dev.twitch.tv/docs/change-log/
