### PR TITLE
feat(eventsub): add isSourceOnly field to ChannelChatNotificationEvent

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatNotificationEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelChatNotificationEvent.java
@@ -106,6 +106,16 @@ public class ChannelChatNotificationEvent extends ChannelChatUserEvent {
     private List<Badge> sourceBadges;
 
     /**
+     * Whether the notification is only sent to the source channel.
+     * <p>
+     * Is null if the notification is not in a shared chat session.
+     */
+    @Nullable
+    @Accessors(fluent = true)
+    @JsonProperty("is_source_only")
+    private Boolean isSourceOnly;
+
+    /**
      * Information about the sub event.
      * Null if {@link #getNoticeType()} is not {@link NoticeType#SUB}.
      */


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ChannelChatNotificationEvent#isSourceOnly`

### Additional Information
2026-04-02 changelog entry: https://dev.twitch.tv/docs/change-log/
