### PR TITLE
feat(eventsub): add custom powerups to ChannelBitsUseEvent

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/BitsType.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/BitsType.java
@@ -1,7 +1,6 @@
 package com.github.twitch4j.eventsub.domain;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
-import org.jetbrains.annotations.ApiStatus;
 
 public enum BitsType {
 
@@ -20,11 +19,20 @@ public enum BitsType {
     POWER_UP,
 
     /**
+     * Channel-specific power-ups.
+     *
+     * @see <a href="https://blog.twitch.tv/en/2026/05/19/new-ways-to-turn-your-community-s-participation-into-earnings/">Marketing Article</a>
+     * @see <a href="https://help.twitch.tv/s/article/power-ups">Official Help Article</a>
+     */
+    CUSTOM_POWER_UP,
+
+    /**
      * An experimental form of bits that triggers animations upon combo levels being reached.
      *
      * @see <a href="https://help.twitch.tv/s/article/combos?language=en_US">Twitch Help Article</a>
+     * @deprecated Twitch removed the combos experiment in late March 2026.
      */
-    @ApiStatus.Experimental
+    @Deprecated
     COMBO,
 
     /**

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/CustomPowerUp.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/CustomPowerUp.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.eventsub.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class CustomPowerUp {
+
+    /**
+     * The title of the custom Power-up.
+     */
+    private String title;
+
+    /**
+     * The ID of the custom Power-up.
+     */
+    private String rewardId;
+
+}

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelBitsUseEvent.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/events/ChannelBitsUseEvent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.twitch4j.common.enums.TwitchEnum;
 import com.github.twitch4j.common.util.TwitchEnumDeserializer;
 import com.github.twitch4j.eventsub.domain.BitsType;
+import com.github.twitch4j.eventsub.domain.CustomPowerUp;
 import com.github.twitch4j.eventsub.domain.PowerUp;
 import com.github.twitch4j.eventsub.domain.chat.Message;
 import lombok.AccessLevel;
@@ -45,5 +46,11 @@ public class ChannelBitsUseEvent extends EventSubUserChannelEvent {
      */
     @Nullable
     private PowerUp powerUp;
+
+    /**
+     * Optional: Data about a custom Power-up.
+     */
+    @Nullable
+    private CustomPowerUp customPowerUp;
 
 }


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed
* Add `ChannelBitsUseEvent#getCustomPowerUp`
* Add `BitsType.CUSTOM_POWER_UP`
* Deprecate `BitsType.COMBO`

### Additional Information
2026-04-02 changelog entry: https://dev.twitch.tv/docs/change-log/
