### PR TITLE
feat(helix): add forSourceOnly option to sendChatAnnouncement

### DIFF
--- a/common/src/main/java/com/github/twitch4j/common/enums/AnnouncementColor.java
+++ b/common/src/main/java/com/github/twitch4j/common/enums/AnnouncementColor.java
@@ -1,6 +1,7 @@
 package com.github.twitch4j.common.enums;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.twitch4j.util.EnumUtil;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -19,6 +20,7 @@ public enum AnnouncementColor {
     private static final Map<String, AnnouncementColor> MAPPINGS = EnumUtil.buildMapping(AnnouncementColor.values());
 
     @Override
+    @JsonValue
     public String toString() {
         return this.name().toLowerCase();
     }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/TwitchHelix.java
@@ -405,12 +405,29 @@ public interface TwitchHelix {
      * Sends an announcement to the broadcaster’s chat room.
      * <p>
      * Rate Limits: One announcement may be sent every 2 seconds.
+     * <p>
+     * Note: When sending announcements during a Shared Chat session, behaviors differ depending on your authentication token type:
+     * <ul>
+     *     <li>
+     *         When using an App Access Token, announcements will only be sent to the source channel
+     *         (defined by the broadcaster_id parameter) by default.
+     *         Announcements can be sent to all channels by using the for_source_only parameter and setting it to false.
+     *     </li>
+     *     <li>
+     *         When using a User Access Token, announcements will be sent to all channels in the shared chat session,
+     *         including the source channel. This behavior cannot be changed with this token type.
+     *     </li>
+     * </ul>
      *
-     * @param authToken     User access token (scope: moderator:manage:announcements) of the broadcaster or a moderator.
+     * @param authToken     Either: (1) a user access token (from a moderator of the channel) that includes the
+     *                      moderator:manage:announcements scope OR (2) an app access token where the application,
+     *                      through prior authorizations has (a) the moderator:manage:announcements and user:bot scopes
+     *                      for the user represented by the moderator_id in the query parameter, AND
+     *                      (b) the channel:bot scope for the user represented by the broadcaster_id query parameter.
      * @param broadcasterId The ID of the broadcaster that owns the chat room to send the announcement to.
-     * @param moderatorId   The ID of a user who has permission to moderate the broadcaster’s chat room. This ID must match the user ID in the OAuth token, which can be a moderator or the broadcaster.
-     * @param message       The announcement to make in the broadcaster’s chat room. Announcements are limited to a maximum of 500 characters.
-     * @param color         The color used to highlight the announcement.
+     * @param moderatorId   The ID of a user who has permission to moderate the broadcaster’s chat room,
+     *                      or the broadcaster’s ID if they're sending the announcement.
+     * @param input         The customized announcement payload.
      * @return 204 No Content upon a successful call
      * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_ANNOUNCEMENTS_MANAGE
      */
@@ -419,14 +436,38 @@ public interface TwitchHelix {
         "Authorization: Bearer {token}",
         "Content-Type: application/json"
     })
-    @Body("%7B\"message\":\"{message}\",\"color\":\"{color}\"%7D")
     HystrixCommand<Void> sendChatAnnouncement(
+        @Param("token") String authToken,
+        @NotNull @Param("broadcaster_id") String broadcasterId,
+        @NotNull @Param("moderator_id") String moderatorId,
+        @NotNull ChatAnnouncementInput input
+    );
+
+    /**
+     * Sends an announcement to the broadcaster’s chat room.
+     * <p>
+     * Rate Limits: One announcement may be sent every 2 seconds.
+     *
+     * @param authToken     User access token (scope: moderator:manage:announcements) of the broadcaster or a moderator.
+     * @param broadcasterId The ID of the broadcaster that owns the chat room to send the announcement to.
+     * @param moderatorId   The ID of a user who has permission to moderate the broadcaster’s chat room. This ID must match the user ID in the OAuth token, which can be a moderator or the broadcaster.
+     * @param message       The announcement to make in the broadcaster’s chat room. Announcements are limited to a maximum of 500 characters.
+     * @param color         The color used to highlight the announcement.
+     * @return 204 No Content upon a successful call
+     * @see com.github.twitch4j.auth.domain.TwitchScopes#HELIX_CHAT_ANNOUNCEMENTS_MANAGE
+     * @deprecated in favor of {@link #sendChatAnnouncement(String, String, String, ChatAnnouncementInput)}
+     */
+    @Deprecated
+    default HystrixCommand<Void> sendChatAnnouncement(
         @Param("token") String authToken,
         @NotNull @Param("broadcaster_id") String broadcasterId,
         @NotNull @Param("moderator_id") String moderatorId,
         @NotNull @Param(value = "message", expander = JsonStringExpander.class) String message,
         @NotNull @Param("color") com.github.twitch4j.common.enums.AnnouncementColor color
-    );
+    ) {
+        ChatAnnouncementInput input = ChatAnnouncementInput.builder().message(message).color(color).build();
+        return sendChatAnnouncement(authToken, broadcasterId, moderatorId, input);
+    }
 
     /**
      * Sends an announcement to the broadcaster’s chat room.
@@ -876,6 +917,8 @@ public interface TwitchHelix {
 
     /**
      * Updates shard(s) for a conduit.
+     * <p>
+     * You can update up to 100 shards in a single request.
      * <p>
      * NOTE: Shard IDs are indexed starting at 0,
      * so a conduit with a {@code shard_count} of 5 will have shards with IDs 0 through 4.

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatAnnouncementInput.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatAnnouncementInput.java
@@ -58,4 +58,13 @@ public class ChatAnnouncementInput {
     @Nullable
     private Boolean forSourceOnly;
 
+    /**
+     * Simple constructor that uses defaults for optional parameters.
+     *
+     * @param message the announcement to make in the broadcaster's room.
+     */
+    public ChatAnnouncementInput(@NotNull String message) {
+        this.message = message;
+    }
+
 }

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatAnnouncementInput.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/ChatAnnouncementInput.java
@@ -1,0 +1,61 @@
+package com.github.twitch4j.helix.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.twitch4j.common.enums.AnnouncementColor;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@With
+@Data
+@Setter(AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Jacksonized
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ChatAnnouncementInput {
+
+    /**
+     * The announcement to make in the broadcaster’s chat room.
+     * <p>
+     * Announcements are limited to a maximum of 500 characters;
+     * announcements longer than 500 characters are truncated.
+     */
+    @NotNull
+    private String message;
+
+    /**
+     * The color used to highlight the announcement.
+     * <p>
+     * If color is set to primary or is not set, the channel’s accent color is used to highlight the announcement.
+     *
+     * @see <a href="https://www.twitch.tv/settings/profile">Profile Accent Color under profile settings, Channel and Videos, and Brand</a>
+     */
+    @Nullable
+    @Builder.Default
+    private AnnouncementColor color = AnnouncementColor.PRIMARY;
+
+    /**
+     * Determines if the chat announcement is sent only to the source channel
+     * (defined by broadcaster_id) during a shared chat session.
+     * <p>
+     * This has no effect if the announcement is not sent during a shared chat session.
+     * <p>
+     * The default value when using an App Access Token is true.
+     * If you prefer to send an announcement to all channels in a shared chat session, set this parameter to false.
+     * <p>
+     * NOTE: This parameter can only be set when utilizing an App Access Token.
+     * It cannot be specified when a User Access Token is used, and will instead result in an HTTP 400 error.
+     */
+    @Nullable
+    private Boolean forSourceOnly;
+
+}

--- a/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Team.java
+++ b/rest-helix/src/main/java/com/github/twitch4j/helix/domain/Team.java
@@ -19,6 +19,7 @@ public class Team {
     /**
      * Users in the specified Team.
      */
+    @Nullable
     private List<TeamUser> users;
 
     /**

--- a/twitch4j/src/main/java/com/github/twitch4j/internal/ChatCommandRegistry.java
+++ b/twitch4j/src/main/java/com/github/twitch4j/internal/ChatCommandRegistry.java
@@ -9,6 +9,7 @@ import com.github.twitch4j.helix.TwitchHelix;
 import com.github.twitch4j.helix.domain.BanUserInput;
 import com.github.twitch4j.helix.domain.ChannelVip;
 import com.github.twitch4j.helix.domain.ChannelVipList;
+import com.github.twitch4j.helix.domain.ChatAnnouncementInput;
 import com.github.twitch4j.helix.domain.ChatSettings;
 import com.github.twitch4j.helix.domain.Highlight;
 import com.github.twitch4j.helix.domain.Moderator;
@@ -64,7 +65,8 @@ enum ChatCommandRegistry {
 
         BiConsumer<ChatCommandHelixForwarder.CommandArguments, AnnouncementColor> announceHandler = (args, color) -> {
             if (args.getRestOfMessage() == null || args.getRestOfMessage().isEmpty()) return;
-            args.getHelix().sendChatAnnouncement(args.getToken().getAccessToken(), args.getChannelId(), args.getToken().getUserId(), args.getRestOfMessage(), color).execute();
+            ChatAnnouncementInput input = ChatAnnouncementInput.builder().message(args.getRestOfMessage()).color(color).build();
+            args.getHelix().sendChatAnnouncement(args.getToken().getAccessToken(), args.getChannelId(), args.getToken().getUserId(), input).execute();
         };
         m.put("announce", args -> announceHandler.accept(args, AnnouncementColor.PRIMARY));
         m.put("announceblue", args -> announceHandler.accept(args, AnnouncementColor.BLUE));


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed
* Add `TwitchHelix#sendChatAnnouncement` with optional `color` (previously required) & `for_source_only` (new shared chat feature) args

### Additional Information
2026‑04‑02 changelog entry https://dev.twitch.tv/docs/change-log/
