### PR TITLE
feat: add gif parsing for chat events

### DIFF
--- a/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/events/AbstractChannelMessageEvent.java
@@ -4,6 +4,7 @@ import com.github.twitch4j.chat.events.channel.IRCMessageEvent;
 import com.github.twitch4j.chat.events.channel.MirrorableEvent;
 import com.github.twitch4j.chat.events.channel.ReplyableEvent;
 import com.github.twitch4j.chat.flag.AutoModFlag;
+import com.github.twitch4j.chat.util.GifChatTag;
 import com.github.twitch4j.common.annotation.Unofficial;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.events.domain.EventChannel;
@@ -86,6 +87,13 @@ public abstract class AbstractChannelMessageEvent extends AbstractChannelEvent i
      */
     public Optional<Boolean> isSourceOnly() {
         return messageEvent.getTagValue("source-only").map(Boolean::parseBoolean);
+    }
+
+    /**
+     * @return metadata pertaining to the gifs that were used in the message.
+     */
+    public Optional<List<GifChatTag>> getGifs() {
+        return messageEvent.getTagValue("gifs").map(GifChatTag::parseList);
     }
 
 }

--- a/chat/src/main/java/com/github/twitch4j/chat/util/GifChatTag.java
+++ b/chat/src/main/java/com/github/twitch4j/chat/util/GifChatTag.java
@@ -1,0 +1,53 @@
+package com.github.twitch4j.chat.util;
+
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Value
+public class GifChatTag {
+
+    int startPosition;
+    int endPosition;
+    String gifId;
+    String gifUrl;
+
+    public static GifChatTag of(String tagValue) {
+        if (tagValue == null || tagValue.isEmpty()) return null;
+
+        String[] parts = StringUtils.split(tagValue, '|');
+        if (parts.length < 3) return null;
+
+        int positionDelim = parts[0].indexOf('-');
+        if (positionDelim < 0) return null;
+
+        int startPosition;
+        int endPosition;
+        try {
+            startPosition = Integer.parseInt(parts[0].substring(0, positionDelim));
+            endPosition = Integer.parseInt(parts[0].substring(positionDelim + 1));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+        String gifId = parts[1];
+        String gifUrl = parts[2];
+        return new GifChatTag(startPosition, endPosition, gifId, gifUrl);
+    }
+
+    public static List<GifChatTag> parseList(String tagValue) {
+        if (tagValue == null || tagValue.isEmpty()) return null;
+
+        String[] parts = StringUtils.split(tagValue, ',');
+        List<GifChatTag> tags = new ArrayList<>(parts.length);
+
+        for (String part : parts) {
+            GifChatTag tag = GifChatTag.of(part);
+            if (tag != null) tags.add(tag);
+        }
+
+        return tags;
+    }
+
+}

--- a/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
+++ b/chat/src/test/java/com/github/twitch4j/chat/events/channel/IRCMessageEventTest.java
@@ -3,7 +3,7 @@ package com.github.twitch4j.chat.events.channel;
 import com.github.philippheuer.events4j.core.EventManager;
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.chat.events.IRCEventHandler;
-import com.github.twitch4j.common.annotation.Unofficial;
+import com.github.twitch4j.chat.util.GifChatTag;
 import com.github.twitch4j.common.enums.CommandPermission;
 import com.github.twitch4j.common.util.EventManagerUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -273,6 +273,24 @@ public class IRCMessageEventTest {
         assertFalse(e.getMessageEvent().getBadges().containsKey("moderator"));
         Map<String, String> sourceBadges = e.getSourceBadges().orElse(null);
         assertTrue(sourceBadges != null && sourceBadges.containsKey("moderator"));
+    }
+
+    @Test
+    @DisplayName("Test that a PRIVMSG containing gifs is parsed")
+    void parseGifMessage() {
+        IRCMessageEvent raw = parse("@badge-info=subscriber/30;badges=broadcaster/1,subscriber/0,ambassador/1;color=#033700;display-name=BarryCarlyon;emotes=;first-msg=0;flags=" +
+            ";gifs=0-33|joSNxeswxuc74Juo8X|https://media4.giphy.com/media/joSNxeswxuc74Juo8X/giphy.gif?cid=095d7a5dzizsiwgabonagkmigggv8v1spfai91ac3x0dsiy0&ep=v1_gifs_trending&rid=giphy.gif&ct=g" +
+            ";id=401abf17-7e99-45d6-9bdf-43934e839327;mod=0;returning-chatter=0;room-id=15185913;subscriber=1;tmi-sent-ts=1783632907018;turbo=0;user-id=15185913;user-type= " +
+            ":barrycarlyon!barrycarlyon@barrycarlyon.tmi.twitch.tv PRIVMSG #barrycarlyon :[Y A Y Yes GIF by Djemilah Birnie]");
+        assertNotNull(raw);
+
+        ChannelMessageEvent e = new ChannelMessageEvent(raw.getChannel(), raw, raw.getUser(), raw.getMessage().orElse(null));
+        assertNotNull(e);
+        assertEquals(
+            List.of(new GifChatTag(0, 33, "joSNxeswxuc74Juo8X", "https://media4.giphy.com/media/joSNxeswxuc74Juo8X/giphy.gif?cid=095d7a5dzizsiwgabonagkmigggv8v1spfai91ac3x0dsiy0&ep=v1_gifs_trending&rid=giphy.gif&ct=g")),
+            e.getGifs().orElse(null)
+        );
+        assertEquals("[Y A Y Yes GIF by Djemilah Birnie]", e.getMessage());
     }
 
 }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Fragment.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Fragment.java
@@ -44,11 +44,18 @@ public class Fragment {
     @Nullable
     private Mention mention;
 
+    /**
+     * Optional: Metadata pertaining to the GIF.
+     */
+    @Nullable
+    private Gif gif;
+
     public enum Type {
         TEXT,
         CHEERMOTE,
         EMOTE,
         MENTION,
+        GIF,
         @JsonEnumDefaultValue
         UNKNOWN
     }

--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Gif.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Gif.java
@@ -1,0 +1,23 @@
+package com.github.twitch4j.eventsub.domain.chat;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.PRIVATE)
+public class Gif {
+
+    /**
+     * An ID that uniquely identifies this GIF.
+     */
+    private String gifId;
+
+    /**
+     * The URL of the GIF asset.
+     * <p>
+     * Applications rendering the GIF must use the full URL provided; it must not be modified (according to Twitch).
+     */
+    private String url;
+
+}


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* `Fragment#getType` could yield `Fragment.Type.UNKNOWN` (eventsub)

### Changes Proposed
* Add `Fragment#getGif` (eventsub)
* Add `AbstractChannelMessageEvent#getGifs` (irc)

### Additional Information
2026-07-16 and 2026-07-17 changelog entries: https://dev.twitch.tv/docs/change-log/
