### PR TITLE
fix(auth): allow scopes on dcf tokens for confidential CIDs

### DIFF
--- a/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java
+++ b/auth/src/main/java/com/github/twitch4j/auth/providers/TwitchIdentityProvider.java
@@ -63,6 +63,7 @@ public class TwitchIdentityProvider extends OAuth2IdentityProvider {
         this.baseUrl = baseUrl;
         this.tokenEndpointPostType = "QUERY";
         this.scopeSeparator = "+"; // Prevents a URISyntaxException when creating a URI from the authUrl
+        this.deviceFlowScopeParamName = "scopes"; // Twitch deviates from the RFC
     }
 
     /**


### PR DESCRIPTION
See https://github.com/PhilippHeuer/credential-manager/issues/131