### PR TITLE
fix(eventsub): populate gifId after official docs mistake

### DIFF
--- a/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Gif.java
+++ b/eventsub-common/src/main/java/com/github/twitch4j/eventsub/domain/chat/Gif.java
@@ -1,5 +1,6 @@
 package com.github.twitch4j.eventsub.domain.chat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,6 +12,7 @@ public class Gif {
     /**
      * An ID that uniquely identifies this GIF.
      */
+    @JsonProperty("id") // docs were incorrect https://discord.com/channels/504015559252377601/523675960797691915/1544919248881721435
     private String gifId;
 
     /**


### PR DESCRIPTION
### Prerequisites for Code Changes
* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Issues Fixed
* `Gif#getGifId` was always null in eventsub chat

### Changes Proposed
* Allow `id` in json to populate `gifId` in `com.github.twitch4j.eventsub.domain.chat.Gif`

### Additional Information
https://discord.com/channels/504015559252377601/523675960797691915/1544919248881721435

<img width="565" height="739" alt="image" src="https://github.com/user-attachments/assets/7665ef13-4309-4797-becf-6751f379e6fc" />
